### PR TITLE
fix(search): retry invalid and stalled responses

### DIFF
--- a/src/benchmarks/search/browsecomp/benchmark.test.ts
+++ b/src/benchmarks/search/browsecomp/benchmark.test.ts
@@ -256,15 +256,16 @@ describe("makeBrowseCompSolver", () => {
       model: "m",
       instructions: "research it",
       lane: makeLane(),
+      retry: { maxRetries: 0 },
     });
-    const state = await runPromise(
-      solver(initialTaskState(SAMPLE)).pipe(
-        provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
+    await expect(
+      runPromise(
+        solver(initialTaskState(SAMPLE)).pipe(
+          provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
+        )
       )
-    );
+    ).rejects.toThrow("search response had no answer text");
     expect(sent).toHaveLength(1);
-    const score = await runPromise(browseCompScorer(state, SAMPLE.target));
-    expect(score.value).toBe(ScoreValue.Incorrect);
   });
 });
 describe("browseCompRunLevelScores", () => {

--- a/src/benchmarks/search/core/solver.test.ts
+++ b/src/benchmarks/search/core/solver.test.ts
@@ -9,6 +9,7 @@ import {
   runPromise,
   runPromiseExit,
   suspend,
+  tryPromise,
 } from "effect/Effect";
 import type { Exit } from "effect/Exit";
 import { isFailure } from "effect/Exit";
@@ -373,6 +374,89 @@ describe("searchSolver", () => {
       solver(initialTaskState({ id: "s", input: "q", target: { text: "t" } }))
     );
     expect(attempts).toBe(3);
+    expect(state.output?.completion).toBe("Exact Answer: 42");
+  });
+  it("retries non-completed and empty terminal responses", async () => {
+    let attempts = 0;
+    const service: ResponsesService = {
+      send: () =>
+        suspend(() => {
+          attempts += 1;
+          if (attempts === 1) {
+            return effectSucceed(
+              fixtureResult({ status: "incomplete", text: "partial" })
+            );
+          }
+          if (attempts === 2) {
+            return effectSucceed(fixtureResult({ text: "   " }));
+          }
+          return effectSucceed(fixtureResult({ text: "Exact Answer: 42" }));
+        }),
+    };
+    const solver = searchSolver(service, {
+      model: "m",
+      instructions: "i",
+      lane: LANE,
+      retry: { maxRetries: 3, baseDelayMs: 1 },
+    });
+    const state = await runSolver(
+      solver(initialTaskState({ id: "s", input: "q", target: { text: "t" } }))
+    );
+    expect(attempts).toBe(3);
+    expect(state.output?.completion).toBe("Exact Answer: 42");
+  });
+  it("aborts and retries an attempt that stalls mid-stream", async () => {
+    let attempts = 0;
+    let aborts = 0;
+    const service: ResponsesService = {
+      send: (_body, options) =>
+        tryPromise({
+          try: (signal) => {
+            attempts += 1;
+            if (attempts > 1) {
+              return Promise.resolve(
+                fixtureResult({ text: "Exact Answer: 42" })
+              );
+            }
+            options.onStreamEvent?.({
+              type: "response.output_item.added",
+              outputIndex: 0,
+              sequenceNumber: 1,
+              item: { type: "reasoning", id: "r-1", summary: [] },
+            });
+            const stalled = Promise.withResolvers<ResponsesResult>();
+            signal.addEventListener(
+              "abort",
+              () => {
+                aborts += 1;
+                stalled.reject(signal.reason);
+              },
+              { once: true }
+            );
+            return stalled.promise;
+          },
+          catch: (cause) =>
+            new ResponsesError({
+              message: String(cause),
+              retryable: true,
+            }),
+        }),
+    };
+    const solver = searchSolver(service, {
+      model: "m",
+      instructions: "i",
+      lane: LANE,
+      timeoutMs: 25,
+      retry: { maxRetries: 1, baseDelayMs: 1 },
+    });
+    const state = await runSolver(
+      solver({
+        ...initialTaskState({ id: "s", input: "q", target: { text: "t" } }),
+        epoch: 0,
+      })
+    );
+    expect(attempts).toBe(2);
+    expect(aborts).toBe(1);
     expect(state.output?.completion).toBe("Exact Answer: 42");
   });
   it("does not retry past maxRetries", async () => {

--- a/src/benchmarks/search/core/solver.ts
+++ b/src/benchmarks/search/core/solver.ts
@@ -1,14 +1,19 @@
 import type { ResponsesRequest, StreamEvents } from "@openrouter/sdk/models";
 import type { Effect } from "effect/Effect";
-import { gen, mapError, retry, suspend } from "effect/Effect";
+import {
+  fail,
+  flatMap,
+  gen,
+  mapError,
+  retry,
+  succeed,
+  suspend,
+  timeoutFail,
+} from "effect/Effect";
 
 import type { CostTier, ReasoningEffort } from "../../../harness/constants";
-import type {
-  ModelError,
-  ResponseItem,
-  TaskState,
-} from "../../../harness/core";
-import { MessageRole } from "../../../harness/core";
+import type { ResponseItem, TaskState } from "../../../harness/core";
+import { MessageRole, ModelError } from "../../../harness/core";
 import type { ProgressReporterService } from "../../../harness/progress";
 import { ProgressReporter } from "../../../harness/progress";
 import type { SolverService } from "../../../harness/solver";
@@ -113,6 +118,7 @@ export function searchSolver(
           }),
         }),
         retryConfig: opts.retry,
+        timeoutMs: opts.timeoutMs ?? DEFAULT_SEARCH_TIMEOUT_MS,
       });
       return completedState({
         state,
@@ -128,14 +134,43 @@ function sendWithRetry({
   body,
   options,
   retryConfig,
+  timeoutMs,
 }: {
   readonly responses: ResponsesService;
   readonly body: ResponsesRequest;
   readonly options: () => ResponsesSendOptions;
   readonly retryConfig?: RetryConfig;
+  readonly timeoutMs: number;
 }): Effect<ResponsesResult, ModelError> {
   return suspend(() => responses.send(body, options())).pipe(
     mapError(toModelError),
+    timeoutFail({
+      duration: `${timeoutMs} millis`,
+      onTimeout: () =>
+        new ModelError({
+          status: 504,
+          message: `search response exceeded the ${timeoutMs}ms wall-clock deadline`,
+        }),
+    }),
+    flatMap((result) => {
+      if (result.status !== "completed") {
+        return fail(
+          new ModelError({
+            status: 503,
+            message: `search response ended with status ${result.status ?? "unknown"}`,
+          })
+        );
+      }
+      if (result.text.trim() === "") {
+        return fail(
+          new ModelError({
+            status: 503,
+            message: "search response had no answer text",
+          })
+        );
+      }
+      return succeed(result);
+    }),
     retry(rateLimitRetrySchedule(retryConfig ?? {}))
   );
 }

--- a/src/benchmarks/search/dsqa/benchmark.test.ts
+++ b/src/benchmarks/search/dsqa/benchmark.test.ts
@@ -135,12 +135,15 @@ describe("DSQA benchmark", () => {
       model: "m",
       instructions: "research it",
       lane: makeLane(),
+      retry: { maxRetries: 0 },
     });
-    await runPromise(
-      solver(initialTaskState(SAMPLE)).pipe(
-        provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
+    await expect(
+      runPromise(
+        solver(initialTaskState(SAMPLE)).pipe(
+          provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
+        )
       )
-    );
+    ).rejects.toThrow("search response had no answer text");
     expect(calls).toBe(1);
   });
 });

--- a/src/benchmarks/search/hle/benchmark.test.ts
+++ b/src/benchmarks/search/hle/benchmark.test.ts
@@ -239,16 +239,16 @@ describe("makeHleSolver", () => {
       model: "m",
       instructions: "research it",
       lane: makeLane(),
+      retry: { maxRetries: 0 },
     });
-    const state = await runPromise(
-      solver(initialTaskState(SAMPLE)).pipe(
-        provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
+    await expect(
+      runPromise(
+        solver(initialTaskState(SAMPLE)).pipe(
+          provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
+        )
       )
-    );
+    ).rejects.toThrow("search response had no answer text");
     expect(calls).toBe(1);
-    expect((await runPromise(hleScorer(state, SAMPLE.target))).value).toBe(
-      ScoreValue.Incorrect
-    );
   });
 });
 

--- a/src/benchmarks/search/widesearch/benchmark.test.ts
+++ b/src/benchmarks/search/widesearch/benchmark.test.ts
@@ -109,19 +109,19 @@ describe("makeWideSearchSolver", () => {
         return succeed(fixtureResult("", 0.02));
       },
     };
-    const state = await runPromise(
-      makeWideSearchSolver(service, {
-        model: "m",
-        instructions: "research it",
-        lane: lane(),
-      })(initialTaskState(SAMPLE)).pipe(
-        provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
+    await expect(
+      runPromise(
+        makeWideSearchSolver(service, {
+          model: "m",
+          instructions: "research it",
+          lane: lane(),
+          retry: { maxRetries: 0 },
+        })(initialTaskState(SAMPLE)).pipe(
+          provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
+        )
       )
-    );
+    ).rejects.toThrow("search response had no answer text");
     expect(sent).toHaveLength(1);
-    expect(
-      (await runPromise(wideSearchScorer(state, SAMPLE.target))).value
-    ).toBe(ScoreValue.Incorrect);
   });
   it("retries a transient cell-judge failure without repeating generation", async () => {
     let generationCalls = 0;


### PR DESCRIPTION
## Invalid search attempts were scored as answers

The search solver treated non-completed Responses results and whitespace-only output as successful task completions. Its configured timeout also did not bound the complete streamed response, so a stream that stalled after connecting could hold a benchmark task indefinitely.

## What changed

- Reject response statuses other than `completed` as retryable `503` model errors.
- Reject blank answer text as retryable `503` model errors.
- Bound the complete `responses.send` effect with the configured per-attempt deadline and classify expiry as retryable `504`.
- Keep cancellation propagation to the underlying request.
- Update benchmark fixtures to disable retries when they intentionally return empty output.

The suspected DSQA normalization issue is intentionally excluded: the pinned official dataset already contains four literal `None` answers and parses all 900 rows.

## Validation

- Full package test suite: 1,150 passed.
- Typecheck: 289 files, no errors or warnings.
- Oxlint passed with only pre-existing warnings.
- No paid benchmark run was started.

## Reviewer focus

The timeout is a total per-attempt wall-clock deadline, not an inactivity timer. It sits inside the existing retry schedule, so every retry receives a fresh deadline.