### PR TITLE
feat(search): persist effective request policy

### DIFF
--- a/src/benchmarks/benchmark-config.ts
+++ b/src/benchmarks/benchmark-config.ts
@@ -225,6 +225,9 @@ export const SearchBenchmarkOptionsSchema = z.object({
   lane: SearchLaneConfigSchema.default(
     () => ({ webSearch: "server-tool", engine: "auto" }) as const
   ),
+  providerOrder: z.array(z.string()).optional(),
+  providerOnly: z.array(z.string()).optional(),
+  allowFallbacks: z.boolean().optional(),
 });
 
 export const BrowseCompBenchmarkConfigSchema = z.object({

--- a/src/benchmarks/search/browsecomp/benchmark.ts
+++ b/src/benchmarks/search/browsecomp/benchmark.ts
@@ -43,6 +43,7 @@ export const BROWSECOMP_BENCHMARK: Benchmark = {
     makeSearchBenchmarkLayer(input, {
       benchmarkId: BROWSECOMP_BENCHMARK_ID,
       instructions: DEEP_RESEARCH_INSTRUCTIONS,
+      temperature: BROWSECOMP_TEMPERATURE,
       makeDatasetLayer: makeBrowseCompDatasetLayer,
       makeSolver: makeBrowseCompSolver,
       scorer: browseCompScorer,

--- a/src/benchmarks/search/core/benchmark.test.ts
+++ b/src/benchmarks/search/core/benchmark.test.ts
@@ -21,11 +21,15 @@ describe("searchSolverOptionsFromConfig", () => {
       costQualityTradeoff: 4,
       timeoutMs: 456,
       sort: ProviderSort.Latency,
+      providerOrder: ["openai", "azure"],
+      providerOnly: ["openai", "azure"],
+      allowFallbacks: false,
       cloudflareVersion: "worker-version",
     } as const;
     const options = searchSolverOptionsFromConfig({
       config,
       instructions: "instructions",
+      temperature: 0,
       retry: {
         maxRetries: 2,
         baseDelayMs: 3,
@@ -43,6 +47,9 @@ describe("searchSolverOptionsFromConfig", () => {
       timeoutMs: 456,
       endpointId: "endpoint",
       sort: "latency",
+      providerOrder: ["openai", "azure"],
+      providerOnly: ["openai", "azure"],
+      allowFallbacks: false,
       versionOverride: "worker-version",
       retry: { maxRetries: 2, baseDelayMs: 3 },
     });
@@ -50,7 +57,7 @@ describe("searchSolverOptionsFromConfig", () => {
       buildSearchRequestBody({ ...options, problem: "Q?" }).temperature
     ).toBe(0.2);
   });
-  it("omits temperature when the config omits an override", () => {
+  it("uses the benchmark-declared temperature when the config omits an override", () => {
     const config = {
       benchmarkId: "search_hle",
       model: "model",
@@ -59,12 +66,13 @@ describe("searchSolverOptionsFromConfig", () => {
     const options = searchSolverOptionsFromConfig({
       config,
       instructions: "instructions",
+      temperature: 0,
       maxOutputTokens: 999,
     });
     expect(options.maxOutputTokens).toBe(999);
-    expect(options.temperature).toBeUndefined();
+    expect(options.temperature).toBe(0);
     expect(
       buildSearchRequestBody({ ...options, problem: "Q?" }).temperature
-    ).toBeUndefined();
+    ).toBe(0);
   });
 });

--- a/src/benchmarks/search/core/benchmark.ts
+++ b/src/benchmarks/search/core/benchmark.ts
@@ -24,6 +24,7 @@ export const DEFAULT_SEARCH_MAX_OUTPUT_TOKENS = 128000;
 interface SearchBenchmarkLayerDefinition {
   readonly benchmarkId: string;
   readonly instructions: string;
+  readonly temperature: number;
   readonly makeDatasetLayer: (retry?: RetryConfig) => Layer<Dataset>;
   readonly makeSolver: (
     responses: ResponsesService,
@@ -36,11 +37,13 @@ interface SearchBenchmarkLayerDefinition {
 export function searchSolverOptionsFromConfig({
   config,
   instructions,
+  temperature,
   retry,
   maxOutputTokens = DEFAULT_SEARCH_MAX_OUTPUT_TOKENS,
 }: {
   readonly config: SearchBenchmarkConfig;
   readonly instructions: string;
+  readonly temperature: number;
   readonly retry?: RetryConfig;
   readonly maxOutputTokens?: number;
 }): SearchSolverOptions {
@@ -49,15 +52,22 @@ export function searchSolverOptionsFromConfig({
     instructions,
     lane: config.lane,
     maxOutputTokens: config.maxTokens ?? maxOutputTokens,
-    ...(config.temperature !== undefined && {
-      temperature: config.temperature,
-    }),
+    temperature: config.temperature ?? temperature,
     ...(config.timeoutMs !== undefined && { timeoutMs: config.timeoutMs }),
     ...(config.reasoningEffort !== undefined && {
       reasoningEffort: config.reasoningEffort,
     }),
     ...(config.endpointId !== undefined && { endpointId: config.endpointId }),
     ...(config.sort !== undefined && { sort: config.sort }),
+    ...(config.providerOrder !== undefined && {
+      providerOrder: config.providerOrder,
+    }),
+    ...(config.providerOnly !== undefined && {
+      providerOnly: config.providerOnly,
+    }),
+    ...(config.allowFallbacks !== undefined && {
+      allowFallbacks: config.allowFallbacks,
+    }),
     ...(config.cloudflareVersion !== undefined && {
       versionOverride: config.cloudflareVersion,
     }),
@@ -90,6 +100,7 @@ export function makeSearchBenchmarkLayer(
   const options = searchSolverOptionsFromConfig({
     config,
     instructions: definition.instructions,
+    temperature: definition.temperature,
     retry: input.modelRetry,
     maxOutputTokens: definition.maxOutputTokens,
   });

--- a/src/benchmarks/search/core/request.test.ts
+++ b/src/benchmarks/search/core/request.test.ts
@@ -172,6 +172,27 @@ describe("buildSearchRequestBody", () => {
     expect(body.temperature).toBe(0);
     expect(body.reasoning).toEqual({ effort: "high" });
   });
+  it("serializes deterministic provider routing through the SDK", () => {
+    const body = buildSearchRequestBody({
+      ...BASE,
+      lane: lane({}),
+      providerOrder: ["openai", "azure"],
+      providerOnly: ["openai", "azure"],
+      allowFallbacks: false,
+    });
+    expect(body.provider).toEqual({
+      order: ["openai", "azure"],
+      only: ["openai", "azure"],
+      allowFallbacks: false,
+    });
+    expect(JSON.parse(responsesRequestToJSON(body))).toMatchObject({
+      provider: {
+        order: ["openai", "azure"],
+        only: ["openai", "azure"],
+        allow_fallbacks: false,
+      },
+    });
+  });
   it("threads search-context and character caps into tool parameters", () => {
     const body = buildSearchRequestBody({
       ...BASE,

--- a/src/benchmarks/search/core/request.ts
+++ b/src/benchmarks/search/core/request.ts
@@ -1,5 +1,6 @@
 import type {
   AutoRouterPlugin,
+  ProviderPreferences,
   ResponsesRequest,
   WebFetchServerTool,
   WebFetchServerToolConfig,
@@ -27,6 +28,9 @@ export interface SearchRequestOptions {
   readonly temperature?: number;
   readonly reasoningEffort?: ReasoningEffort;
   readonly sort?: ProviderSort;
+  readonly providerOrder?: readonly string[];
+  readonly providerOnly?: readonly string[];
+  readonly allowFallbacks?: boolean;
   readonly costQualityTradeoff?: number;
   readonly costTier?: CostTier;
 }
@@ -125,7 +129,24 @@ export function buildSearchRequestBody(
       ...(opts.reasoningEffort !== undefined && {
         reasoning: { effort: opts.reasoningEffort },
       }),
-      ...(opts.sort !== undefined && { provider: { sort: opts.sort } }),
+      provider:
+        opts.sort !== undefined ||
+        opts.providerOrder !== undefined ||
+        opts.providerOnly !== undefined ||
+        opts.allowFallbacks !== undefined
+          ? (definedValues({
+              sort: opts.sort,
+              order:
+                opts.providerOrder === undefined
+                  ? undefined
+                  : [...opts.providerOrder],
+              only:
+                opts.providerOnly === undefined
+                  ? undefined
+                  : [...opts.providerOnly],
+              allowFallbacks: opts.allowFallbacks,
+            }) satisfies ProviderPreferences)
+          : undefined,
     }),
   };
   if (lane.webSearch === "plugin") {

--- a/src/benchmarks/search/core/solver.test.ts
+++ b/src/benchmarks/search/core/solver.test.ts
@@ -236,7 +236,7 @@ describe("searchSolver", () => {
       }),
       { model: "m", instructions: "i", lane: LANE }
     );
-    await runSolver(
+    const state = await runSolver(
       solver(initialTaskState({ id: "s", input: "q", target: { text: "t" } }))
     );
     expect(sent?.maxToolCalls).toBe(3);
@@ -249,6 +249,7 @@ describe("searchSolver", () => {
         },
       },
     ]);
+    expect(state.requestBody).toEqual(sent);
   });
   it("trims whitespace from the answer", async () => {
     const solver = searchSolver(

--- a/src/benchmarks/search/core/solver.ts
+++ b/src/benchmarks/search/core/solver.ts
@@ -43,6 +43,9 @@ export interface SearchSolverOptions {
   readonly reasoningEffort?: ReasoningEffort;
   readonly endpointId?: string;
   readonly sort?: ProviderSort;
+  readonly providerOrder?: readonly string[];
+  readonly providerOnly?: readonly string[];
+  readonly allowFallbacks?: boolean;
   readonly versionOverride?: string;
   readonly costQualityTradeoff?: number;
   readonly costTier?: CostTier;
@@ -85,6 +88,15 @@ export function searchSolver(
           reasoningEffort: opts.reasoningEffort,
         }),
         ...(sendSort && { sort: opts.sort }),
+        ...(opts.providerOrder !== undefined && {
+          providerOrder: opts.providerOrder,
+        }),
+        ...(opts.providerOnly !== undefined && {
+          providerOnly: opts.providerOnly,
+        }),
+        ...(opts.allowFallbacks !== undefined && {
+          allowFallbacks: opts.allowFallbacks,
+        }),
         ...(opts.costQualityTradeoff !== undefined && {
           costQualityTradeoff: opts.costQualityTradeoff,
         }),
@@ -191,6 +203,7 @@ function completedState({
         : []),
     ],
     responseItems: responseItemsForCall(request, result),
+    requestBody: { ...request },
     output: {
       completion: text,
       message: { role: MessageRole.Assistant, content: text },

--- a/src/benchmarks/search/dsqa/benchmark.ts
+++ b/src/benchmarks/search/dsqa/benchmark.ts
@@ -117,6 +117,7 @@ export const DSQA_BENCHMARK: Benchmark = {
     makeSearchBenchmarkLayer(input, {
       benchmarkId: DSQA_BENCHMARK_ID,
       instructions: DEEP_RESEARCH_INSTRUCTIONS,
+      temperature: 0,
       makeDatasetLayer: makeDsqaDatasetLayer,
       makeSolver: makeDsqaSolver,
       scorer: dsqaScorer,

--- a/src/benchmarks/search/hle/benchmark.ts
+++ b/src/benchmarks/search/hle/benchmark.ts
@@ -43,6 +43,7 @@ export const HLE_BENCHMARK: Benchmark = {
     makeSearchBenchmarkLayer(input, {
       benchmarkId: HLE_BENCHMARK_ID,
       instructions: DEEP_RESEARCH_INSTRUCTIONS,
+      temperature: HLE_TEMPERATURE,
       makeDatasetLayer: makeHleDatasetLayer,
       makeSolver: makeHleSolver,
       scorer: hleScorer,

--- a/src/benchmarks/search/widesearch/benchmark.ts
+++ b/src/benchmarks/search/widesearch/benchmark.ts
@@ -190,6 +190,7 @@ export const WIDESEARCH_BENCHMARK: Benchmark = {
     makeSearchBenchmarkLayer(input, {
       benchmarkId: WIDESEARCH_BENCHMARK_ID,
       instructions: WIDESEARCH_INSTRUCTIONS,
+      temperature: WIDESEARCH_TEMPERATURE,
       makeDatasetLayer: makeWideSearchDatasetLayer,
       makeSolver: makeWideSearchSolver,
       scorer: wideSearchScorer,

--- a/src/harness/core.ts
+++ b/src/harness/core.ts
@@ -142,6 +142,7 @@ export interface TaskState {
   readonly sample: Sample;
   readonly messages: readonly ChatMessage[];
   readonly responseItems?: readonly ResponseItem[];
+  readonly requestBody?: Readonly<Record<string, unknown>>;
   readonly output?: ModelOutput;
   readonly completed: boolean;
   readonly epoch?: number;

--- a/src/harness/metric.ts
+++ b/src/harness/metric.ts
@@ -7,6 +7,7 @@ export interface SampleScore {
   readonly score: Score;
   readonly messages?: readonly ChatMessage[];
   readonly responseItems?: readonly ResponseItem[];
+  readonly requestBody?: Readonly<Record<string, unknown>>;
   readonly generationIds?: readonly string[];
   readonly metadata?: Readonly<Record<string, unknown>>;
   readonly input?: string;

--- a/src/harness/run.test.ts
+++ b/src/harness/run.test.ts
@@ -232,6 +232,33 @@ describe("runBenchmark", () => {
     );
     expect(result.sampleScores[0]?.responseItems).toEqual(responseItems);
   });
+  it("carries the request body from TaskState into per-sample scores", async () => {
+    const requestBody = {
+      model: "model",
+      provider: { order: ["openai"], allowFallbacks: false },
+    } as const;
+    const solver: SolverService = (state) =>
+      effectSucceed({
+        ...state,
+        requestBody,
+        output: {
+          completion: "Answer: B",
+          message: { role: MessageRole.Assistant, content: "Answer: B" },
+        },
+        completed: true,
+      });
+    const layers = mergeAll(
+      fakeDatasetLayer(SAMPLES.slice(0, 1)),
+      layerSucceed(Solver, Solver.of(solver)),
+      layerSucceed(Scorer, Scorer.of(mcqScorer)),
+      noopProgressLayer,
+      noopCheckpointLayer
+    );
+    const result = await runPromise(
+      runBenchmark({ epochs: 1, maxConcurrency: 1 }).pipe(provide(layers))
+    );
+    expect(result.sampleScores[0]?.requestBody).toEqual(requestBody);
+  });
   it("respects a sample range (chunk slice)", async () => {
     const model = fakeModel(() => "Answer: B");
     const solver = generate(model.service, { temperature: 0 });

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -190,6 +190,9 @@ function evaluateOne(
         ...(state.responseItems !== undefined && {
           responseItems: state.responseItems,
         }),
+        ...(state.requestBody !== undefined && {
+          requestBody: state.requestBody,
+        }),
         ...(state.sample.metadata && { metadata: state.sample.metadata }),
         input: sample.input,
         target: sample.target.text,

--- a/src/results/parquet-schema.ts
+++ b/src/results/parquet-schema.ts
@@ -39,6 +39,7 @@ export const BenchmarkResultRowSchema = z.object({
   explanation: z.string().nullable(),
   scorer_trajectory: z.string().nullish(),
   response_items: z.string().nullish(),
+  request_body: z.string().nullish(),
   generation_ids: z.string().nullish(),
   messages: z.string().nullable(),
   metadata: z.string().nullable(),

--- a/src/results/parquet.test.ts
+++ b/src/results/parquet.test.ts
@@ -235,8 +235,43 @@ describe("runResultToParquet", () => {
   it("writes null response_items and generation_ids when the solver recorded none", () => {
     for (const row of rows) {
       expect(row.response_items).toBeNull();
+      expect(row.request_body).toBeNull();
       expect(row.generation_ids).toBeNull();
     }
+  });
+  it("round-trips the effective request body as JSON", async () => {
+    const requestBody = {
+      model: "openai/gpt-5.4-nano",
+      maxOutputTokens: 128000,
+      provider: {
+        order: ["openai", "azure"],
+        only: ["openai", "azure"],
+        allowFallbacks: false,
+      },
+      tools: [
+        {
+          type: "openrouter:web_search",
+          parameters: { excludedDomains: ["example.com"] },
+        },
+      ],
+    };
+    const bufferWithRequest = runResultToParquet({
+      result: {
+        metrics: METRICS,
+        usage: USAGE,
+        sampleScores: [
+          {
+            sampleId: "s0",
+            epoch: 0,
+            score: { value: ScoreValue.Correct, answer: "B", explanation: "" },
+            requestBody,
+          },
+        ],
+      },
+      meta: META,
+    });
+    const requestRows = await readRows(bufferWithRequest);
+    expect(JSON.parse(requestRows[0]!.request_body!)).toEqual(requestBody);
   });
   it("serializes generation ids as a JSON column", async () => {
     const bufferWithIds = runResultToParquet({
@@ -644,6 +679,7 @@ describe("BenchmarkResultRowSchema", () => {
     expect(parsed.right.benchmark_config).toBeUndefined();
     expect(parsed.right.scorer_trajectory).toBeUndefined();
     expect(parsed.right.response_items).toBeUndefined();
+    expect(parsed.right.request_body).toBeUndefined();
     expect(parsed.right.generation_ids).toBeUndefined();
   });
   it("parses a row with response_items present", () => {

--- a/src/results/parquet.ts
+++ b/src/results/parquet.ts
@@ -95,6 +95,7 @@ const COLUMN_SPECS = [
   { name: "explanation", type: "STRING", nullable: true },
   { name: "scorer_trajectory", type: "JSON", nullable: true },
   { name: "response_items", type: "JSON", nullable: true },
+  { name: "request_body", type: "JSON", nullable: true },
   { name: "generation_ids", type: "JSON", nullable: true },
   { name: "messages", type: "JSON", nullable: true },
   { name: "metadata", type: "JSON", nullable: true },
@@ -243,6 +244,9 @@ function cellValue(name: ColumnName, ctx: RowContext, s: SampleScore): unknown {
       return s.responseItems !== undefined && s.responseItems.length > 0
         ? JSON.stringify(s.responseItems)
         : null;
+    }
+    case "request_body": {
+      return s.requestBody !== undefined ? JSON.stringify(s.requestBody) : null;
     }
     case "generation_ids": {
       return s.generationIds !== undefined && s.generationIds.length > 0


### PR DESCRIPTION
## Stored results could not prove the effective search request

Search benchmarks omitted their declared zero temperature unless a run explicitly overrode it. They also lacked provider order, allowlist, and fallback controls, while parquet results did not retain the effective request body. A stored run therefore could not prove its search budget, routing policy, blocklist, or temperature.

## What changed

- Use each search benchmark's declared temperature when no override is supplied.
- Add search-only `providerOrder`, `providerOnly`, and `allowFallbacks` configuration.
- Serialize those controls into the Responses provider policy.
- Retain the effective SDK request in task state and sample scores.
- Add optional nullable `request_body` JSON persistence.
- Keep older parquet rows readable without changing the format version.

## Validation

- Full package test suite: 1,151 passed.
- Typecheck: 289 files, no errors or warnings.
- Oxlint passed with only pre-existing warnings.
- No paid benchmark run was started.

## Reviewer focus

The persisted object is the effective SDK request before wire-format key conversion. Failed attempts that never complete remain represented by their error rather than a request body.