### PR TITLE
feat(search): expose benchmark provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "./benchmarks/registry": "./src/benchmarks/registry.ts",
     "./benchmarks/deep-swe/schema": "./src/benchmarks/deep-swe/schema.ts",
     "./benchmarks/search/core/config": "./src/benchmarks/search/core/config.ts",
+    "./benchmarks/search/provenance": "./src/benchmarks/search/provenance.ts",
     "./benchmarks/swe-atlas/schema": "./src/benchmarks/swe-atlas/schema.ts",
     "./benchmarks/terminal-bench/schema": "./src/benchmarks/terminal-bench/schema.ts",
     "./core": "./src/harness/core.ts",

--- a/src/benchmarks/search/dsqa/dataset.ts
+++ b/src/benchmarks/search/dsqa/dataset.ts
@@ -30,8 +30,9 @@ import { isRecord } from "../../../internal/guards";
 import { parseSchema, z } from "../../../internal/zod";
 import type { RetryConfig } from "../../../runtime/retry";
 
-export const DSQA_DATASET_URL =
-  "https://huggingface.co/datasets/google/deepsearchqa/resolve/b2623f8653065c2672de6d941fc5434cd652376c/DSQA-full.csv";
+export const DSQA_DATASET_REVISION = "b2623f8653065c2672de6d941fc5434cd652376c";
+
+export const DSQA_DATASET_URL = `https://huggingface.co/datasets/google/deepsearchqa/resolve/${DSQA_DATASET_REVISION}/DSQA-full.csv`;
 
 export const DSQA_DATASET_SHA256 =
   "25d48dcf7efa872e5467032e8b8eedf38d301f59a252d0da95cda584baa78396";

--- a/src/benchmarks/search/dsqa/grader.ts
+++ b/src/benchmarks/search/dsqa/grader.ts
@@ -6,7 +6,9 @@ export const DSQA_JUDGE_CONFIG = {
   judgeModel: "google/gemini-2.5-flash",
 } as const satisfies JudgeConfig;
 
-const DSQA_GRADER_PROMPT = `Evaluate whether the AI response answers the DeepSearchQA question correctly.
+export const DSQA_JUDGE_PROMPT_ID = "dsqa_judge";
+
+export const DSQA_GRADER_PROMPT = `Evaluate whether the AI response answers the DeepSearchQA question correctly.
 
 Prompt type: {prompt_type}
 Question: {question}
@@ -73,7 +75,7 @@ export function dsqaJudgeSpec(fields: {
 }): JudgeCallSpec<DsqaVerdict> {
   return {
     userInput: renderDsqaGraderPrompt(fields),
-    schemaName: "dsqa_judge",
+    schemaName: DSQA_JUDGE_PROMPT_ID,
     jsonSchema: DSQA_VERDICT_JSON_SCHEMA,
     parseVerdict: parseDsqaVerdict,
   };

--- a/src/benchmarks/search/grading/answer-equivalence.ts
+++ b/src/benchmarks/search/grading/answer-equivalence.ts
@@ -7,6 +7,8 @@ export const ANSWER_EQUIVALENCE_JUDGE_CONFIG = {
   temperature: 0,
 } as const satisfies JudgeConfig;
 
+export const ANSWER_EQUIVALENCE_JUDGE_PROMPT_ID = "answer_equivalence_judge";
+
 export const ANSWER_EQUIVALENCE_GRADER_PROMPT = `Judge whether the following [response] to [question] is correct or not based on the precise and unambiguous [correct_answer] below.
 
 [question]: {question}
@@ -94,7 +96,7 @@ export function answerEquivalenceJudgeSpec(fields: {
 }): JudgeCallSpec<AnswerEquivalenceVerdict> {
   return {
     userInput: renderAnswerEquivalenceGraderPrompt(fields),
-    schemaName: "answer_equivalence_judge",
+    schemaName: ANSWER_EQUIVALENCE_JUDGE_PROMPT_ID,
     jsonSchema: VERDICT_JSON_SCHEMA,
     parseVerdict: parseAnswerEquivalenceVerdict,
   };

--- a/src/benchmarks/search/provenance.test.ts
+++ b/src/benchmarks/search/provenance.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  getSearchBenchmarkProvenance,
+  searchBenchmarkProvenanceIds,
+} from "@openrouter/bench-harness/benchmarks/search/provenance";
+
+describe("search benchmark provenance", () => {
+  it("exposes pinned BrowseComp provenance without raw prompts", () => {
+    expect(getSearchBenchmarkProvenance("search_browsecomp")).toEqual({
+      benchmarkId: "search_browsecomp",
+      dataset: {
+        source:
+          "https://openaipublic.blob.core.windows.net/simple-evals/browse_comp_test_set.csv",
+        revision: null,
+        sha256:
+          "7b24471cd5b3eb2a46830a14802b5c029ea62f488ff75a0f88af7923d1454abf",
+        rowCount: 1266,
+      },
+      generationPrompt: {
+        sha256:
+          "2250aa21b4a98647dbcfed62a30261eb914016c81cb33e7694c15859205de78f",
+      },
+      judges: [
+        {
+          model: "openai/gpt-4.1",
+          prompt: {
+            id: "answer_equivalence_judge",
+            sha256:
+              "0f0023ee579b8c134f1834ed8952778b9e01460e31d47c242ee3629da9d44835",
+          },
+        },
+      ],
+      gradingReferenceDate: null,
+    });
+  });
+
+  it("exposes pinned DSQA provenance", () => {
+    expect(getSearchBenchmarkProvenance("search_dsqa")).toEqual({
+      benchmarkId: "search_dsqa",
+      dataset: {
+        source:
+          "https://huggingface.co/datasets/google/deepsearchqa/resolve/b2623f8653065c2672de6d941fc5434cd652376c/DSQA-full.csv",
+        revision: "b2623f8653065c2672de6d941fc5434cd652376c",
+        sha256:
+          "25d48dcf7efa872e5467032e8b8eedf38d301f59a252d0da95cda584baa78396",
+        rowCount: 900,
+      },
+      generationPrompt: {
+        sha256:
+          "2250aa21b4a98647dbcfed62a30261eb914016c81cb33e7694c15859205de78f",
+      },
+      judges: [
+        {
+          model: "google/gemini-2.5-flash",
+          prompt: {
+            id: "dsqa_judge",
+            sha256:
+              "7b9279e2d8dba2547eb6e1c00dcd7498150df3fdd3cace6b8e817ea67ae07f9c",
+          },
+        },
+      ],
+      gradingReferenceDate: null,
+    });
+  });
+
+  it("exposes both WideSearch judge prompts and its grading date", () => {
+    expect(getSearchBenchmarkProvenance("search_widesearch")).toEqual({
+      benchmarkId: "search_widesearch",
+      dataset: {
+        source:
+          "https://huggingface.co/datasets/ByteDance-Seed/WideSearch/resolve/6531a7e5b497d44c8912407e0cb3dc95bd98cc09/widesearch.jsonl",
+        revision: "6531a7e5b497d44c8912407e0cb3dc95bd98cc09",
+        sha256:
+          "bba28ec51dce28fa617f82617d88fcd6bdd4cd4d7f0a4d70db07d7fa8a90bdf4",
+        rowCount: 200,
+      },
+      generationPrompt: {
+        sha256:
+          "14061a8a9476ecd7f5b5a4ca3de70248bd9a46f6ff963992a813538382ef23e8",
+      },
+      judges: [
+        {
+          model: "openai/gpt-4.1",
+          prompt: {
+            id: "widesearch_alignment",
+            sha256:
+              "5e2a997c046b43b300cfcca9b3576821d0c46341f65c8f1648e11bccc86b7e84",
+          },
+        },
+        {
+          model: "openai/gpt-4.1",
+          prompt: {
+            id: "widesearch_cell_judge",
+            sha256:
+              "75d44852d07dff3924c269a4d2838c6a5a85820d8a8b709d65b293fc1525b2a2",
+          },
+        },
+      ],
+      gradingReferenceDate: "2026-07-18",
+    });
+  });
+
+  it("lists only the supported search benchmarks and rejects unknown ids", () => {
+    expect(searchBenchmarkProvenanceIds()).toEqual([
+      "search_browsecomp",
+      "search_dsqa",
+      "search_widesearch",
+    ]);
+    expect(getSearchBenchmarkProvenance("search_hle")).toBeUndefined();
+  });
+});

--- a/src/benchmarks/search/provenance.ts
+++ b/src/benchmarks/search/provenance.ts
@@ -1,0 +1,163 @@
+import { createHash } from "node:crypto";
+
+import {
+  BROWSECOMP_ROWS,
+  BROWSECOMP_SHA256,
+  BROWSECOMP_URL,
+} from "./browsecomp/dataset";
+import {
+  DEEP_RESEARCH_INSTRUCTIONS,
+  WIDESEARCH_INSTRUCTIONS,
+} from "./core/prompts";
+import {
+  DSQA_DATASET_REVISION,
+  DSQA_DATASET_ROWS,
+  DSQA_DATASET_SHA256,
+  DSQA_DATASET_URL,
+} from "./dsqa/dataset";
+import {
+  DSQA_GRADER_PROMPT,
+  DSQA_JUDGE_CONFIG,
+  DSQA_JUDGE_PROMPT_ID,
+} from "./dsqa/grader";
+import {
+  ANSWER_EQUIVALENCE_GRADER_PROMPT,
+  ANSWER_EQUIVALENCE_JUDGE_CONFIG,
+  ANSWER_EQUIVALENCE_JUDGE_PROMPT_ID,
+} from "./grading/answer-equivalence";
+import {
+  WIDESEARCH_DATASET_SHA256,
+  WIDESEARCH_DATASET_URL,
+  WIDESEARCH_REVISION,
+  WIDESEARCH_ROWS,
+} from "./widesearch/dataset";
+import { WIDESEARCH_GRADING_REFERENCE_DATE } from "./widesearch/grading";
+import {
+  ALIGNMENT_PROMPT,
+  CELL_JUDGE_PROMPT,
+  WIDESEARCH_ALIGNMENT_PROMPT_ID,
+  WIDESEARCH_CELL_JUDGE_PROMPT_ID,
+  WIDESEARCH_JUDGE_CONFIG,
+} from "./widesearch/judges";
+
+export type SearchBenchmarkProvenanceId =
+  | "search_browsecomp"
+  | "search_dsqa"
+  | "search_widesearch";
+
+export interface SearchBenchmarkProvenance {
+  readonly benchmarkId: SearchBenchmarkProvenanceId;
+  readonly dataset: {
+    readonly source: string;
+    readonly revision: string | null;
+    readonly sha256: string;
+    readonly rowCount: number;
+  };
+  readonly generationPrompt: {
+    readonly sha256: string;
+  };
+  readonly judges: readonly {
+    readonly model: string;
+    readonly prompt: {
+      readonly id: string;
+      readonly sha256: string;
+    };
+  }[];
+  readonly gradingReferenceDate: string | null;
+}
+
+const SEARCH_BENCHMARK_PROVENANCE = {
+  search_browsecomp: {
+    benchmarkId: "search_browsecomp",
+    dataset: {
+      source: BROWSECOMP_URL,
+      revision: null,
+      sha256: BROWSECOMP_SHA256,
+      rowCount: BROWSECOMP_ROWS,
+    },
+    generationPrompt: { sha256: sha256(DEEP_RESEARCH_INSTRUCTIONS) },
+    judges: [
+      {
+        model: ANSWER_EQUIVALENCE_JUDGE_CONFIG.judgeModel,
+        prompt: {
+          id: ANSWER_EQUIVALENCE_JUDGE_PROMPT_ID,
+          sha256: sha256(ANSWER_EQUIVALENCE_GRADER_PROMPT),
+        },
+      },
+    ],
+    gradingReferenceDate: null,
+  },
+  search_dsqa: {
+    benchmarkId: "search_dsqa",
+    dataset: {
+      source: DSQA_DATASET_URL,
+      revision: DSQA_DATASET_REVISION,
+      sha256: DSQA_DATASET_SHA256,
+      rowCount: DSQA_DATASET_ROWS,
+    },
+    generationPrompt: { sha256: sha256(DEEP_RESEARCH_INSTRUCTIONS) },
+    judges: [
+      {
+        model: DSQA_JUDGE_CONFIG.judgeModel,
+        prompt: {
+          id: DSQA_JUDGE_PROMPT_ID,
+          sha256: sha256(DSQA_GRADER_PROMPT),
+        },
+      },
+    ],
+    gradingReferenceDate: null,
+  },
+  search_widesearch: {
+    benchmarkId: "search_widesearch",
+    dataset: {
+      source: WIDESEARCH_DATASET_URL,
+      revision: WIDESEARCH_REVISION,
+      sha256: WIDESEARCH_DATASET_SHA256,
+      rowCount: WIDESEARCH_ROWS,
+    },
+    generationPrompt: { sha256: sha256(WIDESEARCH_INSTRUCTIONS) },
+    judges: [
+      {
+        model: WIDESEARCH_JUDGE_CONFIG.judgeModel,
+        prompt: {
+          id: WIDESEARCH_ALIGNMENT_PROMPT_ID,
+          sha256: sha256(ALIGNMENT_PROMPT),
+        },
+      },
+      {
+        model: WIDESEARCH_JUDGE_CONFIG.judgeModel,
+        prompt: {
+          id: WIDESEARCH_CELL_JUDGE_PROMPT_ID,
+          sha256: sha256(CELL_JUDGE_PROMPT),
+        },
+      },
+    ],
+    gradingReferenceDate: WIDESEARCH_GRADING_REFERENCE_DATE,
+  },
+} as const satisfies Readonly<
+  Record<SearchBenchmarkProvenanceId, SearchBenchmarkProvenance>
+>;
+
+export function getSearchBenchmarkProvenance(
+  id: string
+): SearchBenchmarkProvenance | undefined {
+  return isSearchBenchmarkProvenanceId(id)
+    ? SEARCH_BENCHMARK_PROVENANCE[id]
+    : undefined;
+}
+
+export function searchBenchmarkProvenanceIds(): readonly SearchBenchmarkProvenanceId[] {
+  return Object.keys(
+    SEARCH_BENCHMARK_PROVENANCE
+  ) as SearchBenchmarkProvenanceId[];
+}
+
+function isSearchBenchmarkProvenanceId(
+  id: string
+): id is SearchBenchmarkProvenanceId {
+  return Object.hasOwn(SEARCH_BENCHMARK_PROVENANCE, id);
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}

--- a/src/benchmarks/search/widesearch/grading.test.ts
+++ b/src/benchmarks/search/widesearch/grading.test.ts
@@ -82,6 +82,23 @@ describe("gradeWideSearch", () => {
       f1_by_item: 1,
     });
   });
+  it("uses the pinned grading date for partial-year normalization", async () => {
+    const service: ResponsesService = {
+      send: () => succeed(fixtureResult("{}")),
+    };
+    const result = await runPromise(
+      gradeWideSearch({
+        responses: service,
+        judgeConfig: WIDESEARCH_JUDGE_CONFIG,
+        expectedText: expected({
+          rows: [{ name: "A", value: "1984" }],
+          valuePreprocess: ["norm_date"],
+        }),
+        predictedAnswer: "| Name | Value |\n| --- | --- |\n| A | 1984-07-01 |",
+      })
+    );
+    expect(result.grade.metrics.success_rate).toBe(1);
+  });
   it("returns zero metrics without cell judging when no rows match", async () => {
     const sent: ResponsesRequest[] = [];
     const service: ResponsesService = {

--- a/src/benchmarks/search/widesearch/grading.ts
+++ b/src/benchmarks/search/widesearch/grading.ts
@@ -29,6 +29,8 @@ export const WIDESEARCH_METRIC_NAMES = [
   "f1_by_item",
 ] as const;
 
+export const WIDESEARCH_GRADING_REFERENCE_DATE = "2026-07-18";
+
 export type WideSearchMetricName = ValueOf<typeof WIDESEARCH_METRIC_NAMES>;
 
 export type WideSearchMetrics = Readonly<Record<WideSearchMetricName, number>>;
@@ -130,7 +132,7 @@ export function gradeWideSearch({
   judgeConfig,
   expectedText,
   predictedAnswer,
-  referenceNow = new Date(),
+  referenceNow = new Date(WIDESEARCH_GRADING_REFERENCE_DATE),
 }: GradeWideSearchOptions): Effect<WideSearchGradingResult, ModelError> {
   return gen(function* gradeWideSearchEffect() {
     const expected = parseWideSearchExpected(expectedText);

--- a/src/benchmarks/search/widesearch/judges.ts
+++ b/src/benchmarks/search/widesearch/judges.ts
@@ -8,6 +8,10 @@ export const WIDESEARCH_JUDGE_CONFIG = {
   timeoutMs: 180000,
 } as const satisfies JudgeConfig;
 
+export const WIDESEARCH_ALIGNMENT_PROMPT_ID = "widesearch_alignment";
+
+export const WIDESEARCH_CELL_JUDGE_PROMPT_ID = "widesearch_cell_judge";
+
 export const ALIGNMENT_PROMPT = `Your task is to align two vocabularies. The inputs are the vocabulary to be aligned and the reference vocabulary respectively. Note that you need to perform semantic alignment (not positional alignment). If two strings are exactly the same, they must correspond to each other. These two strings are supposed to represent the same entity, with differences only in the expression forms and formats.
 
 
@@ -110,7 +114,7 @@ export function alignmentJudgeSpec(
           ? JSON.stringify(observed)
           : JSON.stringify(reference)
     ),
-    schemaName: "widesearch_alignment",
+    schemaName: WIDESEARCH_ALIGNMENT_PROMPT_ID,
     jsonSchema: {
       type: "object",
       additionalProperties: false,
@@ -152,7 +156,7 @@ export function cellJudgeSpec(
       (placeholder) =>
         placeholder === "{criterion}" ? criterion : JSON.stringify(values)
     ),
-    schemaName: "widesearch_cell_judge",
+    schemaName: WIDESEARCH_CELL_JUDGE_PROMPT_ID,
     jsonSchema: {
       type: "object",
       additionalProperties: false,


### PR DESCRIPTION
## External runners could not identify an exact benchmark definition

Public benchmark metadata exposed IDs and execution defaults, but dataset pins, generation prompt identity, judge identity, and the WideSearch grading date remained scattered across internal modules. External campaign runners had to import implementation files or duplicate that assembly.

## What changed

- Add `@openrouter/bench-harness/benchmarks/search/provenance`.
- Expose dataset source, revision, SHA-256, and row count.
- Expose generation prompt SHA-256.
- Expose judge model plus stable prompt ID and SHA-256.
- Expose a fixed grading reference date where applicable.
- Limit the contract to BrowseComp, DSQA, and WideSearch.
- Use the fixed WideSearch grading date instead of the wall clock.

Raw prompts are not exported; hashes are derived from the exact UTF-8 templates used during execution.

## Validation

- Full package test suite: 1,153 passed.
- Typecheck: 291 files, no errors or warnings.
- Oxlint passed with only pre-existing warnings.
- No paid benchmark run was started.

## Reviewer focus

BrowseComp has no revision identifier, but exact bytes remain checksum-pinned. Judge model names identify configured routes, not immutable provider endpoint snapshots.