### PR TITLE
fix(search): clamp output token budgets

### DIFF
--- a/src/benchmarks/search/core/benchmark.test.ts
+++ b/src/benchmarks/search/core/benchmark.test.ts
@@ -4,6 +4,12 @@ import { ProviderSort, WebSearchEngine } from "../../../internal/enums";
 import { searchSolverOptionsFromConfig } from "./benchmark";
 import { buildSearchRequestBody } from "./request";
 describe("searchSolverOptionsFromConfig", () => {
+  const baseConfig = {
+    benchmarkId: "search_hle",
+    model: "model",
+    lane: { webSearch: "server-tool", engine: "auto" },
+  } as const;
+
   it("projects every shared search inference option", () => {
     const config = {
       benchmarkId: "search_hle",
@@ -51,13 +57,8 @@ describe("searchSolverOptionsFromConfig", () => {
     ).toBe(0.2);
   });
   it("omits temperature when the config omits an override", () => {
-    const config = {
-      benchmarkId: "search_hle",
-      model: "model",
-      lane: { webSearch: "server-tool", engine: "auto" },
-    } as const;
     const options = searchSolverOptionsFromConfig({
-      config,
+      config: baseConfig,
       instructions: "instructions",
       maxOutputTokens: 999,
     });
@@ -66,5 +67,45 @@ describe("searchSolverOptionsFromConfig", () => {
     expect(
       buildSearchRequestBody({ ...options, problem: "Q?" }).temperature
     ).toBeUndefined();
+  });
+
+  it("clamps the default output tokens to the supplied ceiling", () => {
+    const options = searchSolverOptionsFromConfig({
+      config: baseConfig,
+      instructions: "instructions",
+      maxOutputTokensCeiling: 32768,
+    });
+
+    expect(options.maxOutputTokens).toBe(32768);
+  });
+
+  it("clamps configured output tokens to the supplied ceiling", () => {
+    const options = searchSolverOptionsFromConfig({
+      config: { ...baseConfig, maxTokens: 64000 },
+      instructions: "instructions",
+      maxOutputTokensCeiling: 16000,
+    });
+
+    expect(options.maxOutputTokens).toBe(16000);
+  });
+
+  it("preserves configured output tokens below the supplied ceiling", () => {
+    const options = searchSolverOptionsFromConfig({
+      config: { ...baseConfig, maxTokens: 8000 },
+      instructions: "instructions",
+      maxOutputTokensCeiling: 16000,
+    });
+
+    expect(options.maxOutputTokens).toBe(8000);
+  });
+
+  it("preserves output tokens when no ceiling is supplied", () => {
+    const options = searchSolverOptionsFromConfig({
+      config: baseConfig,
+      instructions: "instructions",
+      maxOutputTokens: 999,
+    });
+
+    expect(options.maxOutputTokens).toBe(999);
   });
 });

--- a/src/benchmarks/search/core/benchmark.ts
+++ b/src/benchmarks/search/core/benchmark.ts
@@ -38,17 +38,23 @@ export function searchSolverOptionsFromConfig({
   instructions,
   retry,
   maxOutputTokens = DEFAULT_SEARCH_MAX_OUTPUT_TOKENS,
+  maxOutputTokensCeiling,
 }: {
   readonly config: SearchBenchmarkConfig;
   readonly instructions: string;
   readonly retry?: RetryConfig;
   readonly maxOutputTokens?: number;
+  readonly maxOutputTokensCeiling?: number;
 }): SearchSolverOptions {
+  const requestedMaxOutputTokens = config.maxTokens ?? maxOutputTokens;
   return {
     model: config.model,
     instructions,
     lane: config.lane,
-    maxOutputTokens: config.maxTokens ?? maxOutputTokens,
+    maxOutputTokens:
+      maxOutputTokensCeiling === undefined
+        ? requestedMaxOutputTokens
+        : Math.min(requestedMaxOutputTokens, maxOutputTokensCeiling),
     ...(config.temperature !== undefined && {
       temperature: config.temperature,
     }),
@@ -92,6 +98,9 @@ export function makeSearchBenchmarkLayer(
     instructions: definition.instructions,
     retry: input.modelRetry,
     maxOutputTokens: definition.maxOutputTokens,
+    ...(input.maxOutputTokensCeiling !== undefined && {
+      maxOutputTokensCeiling: input.maxOutputTokensCeiling,
+    }),
   });
   const solverLayer = effect(Solver)(
     gen(function* () {

--- a/src/benchmarks/types.ts
+++ b/src/benchmarks/types.ts
@@ -17,6 +17,8 @@ export interface BenchmarkRunInput {
   readonly sessionId: string;
   readonly datasetRetry?: RetryConfig;
   readonly modelRetry?: RetryConfig;
+  /** Caller-resolved model output limit; absent preserves configured behavior. */
+  readonly maxOutputTokensCeiling?: number;
   readonly modelLayer?: Layer<Model, Error, HttpClient.HttpClient>;
   readonly responsesModelLayer?: Layer<
     ResponsesModel,

--- a/src/benchmarks/types.ts
+++ b/src/benchmarks/types.ts
@@ -17,7 +17,6 @@ export interface BenchmarkRunInput {
   readonly sessionId: string;
   readonly datasetRetry?: RetryConfig;
   readonly modelRetry?: RetryConfig;
-  /** Caller-resolved model output limit; absent preserves configured behavior. */
   readonly maxOutputTokensCeiling?: number;
   readonly modelLayer?: Layer<Model, Error, HttpClient.HttpClient>;
   readonly responsesModelLayer?: Layer<

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -46,7 +46,6 @@ export interface RunBenchmarkInput {
   readonly checkpointStore?: CheckpointStoreService;
   readonly abortSignal?: AbortSignal;
   readonly resultStore?: ResultStoreService;
-  /** @example `maxOutputTokensCeiling: endpoint.max_completion_tokens` */
   readonly maxOutputTokensCeiling?: number;
 }
 

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -46,7 +46,6 @@ export interface RunBenchmarkInput {
   readonly checkpointStore?: CheckpointStoreService;
   readonly abortSignal?: AbortSignal;
   readonly resultStore?: ResultStoreService;
-  /** Caller-resolved model output limit; absent preserves configured behavior. */
   readonly maxOutputTokensCeiling?: number;
 }
 

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -46,6 +46,7 @@ export interface RunBenchmarkInput {
   readonly checkpointStore?: CheckpointStoreService;
   readonly abortSignal?: AbortSignal;
   readonly resultStore?: ResultStoreService;
+  /** @example `maxOutputTokensCeiling: endpoint.max_completion_tokens` */
   readonly maxOutputTokensCeiling?: number;
 }
 

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -46,6 +46,8 @@ export interface RunBenchmarkInput {
   readonly checkpointStore?: CheckpointStoreService;
   readonly abortSignal?: AbortSignal;
   readonly resultStore?: ResultStoreService;
+  /** Caller-resolved model output limit; absent preserves configured behavior. */
+  readonly maxOutputTokensCeiling?: number;
 }
 
 export interface RunBenchmarkOutput {
@@ -72,6 +74,9 @@ export function runBenchmarkById(
       datasetRetry: input.datasetRetry,
     }),
     ...(maxRetries !== undefined && { modelRetry: { maxRetries } }),
+    ...(input.maxOutputTokensCeiling !== undefined && {
+      maxOutputTokensCeiling: input.maxOutputTokensCeiling,
+    }),
   });
   const progressLayer = layerSucceed(
     ProgressReporter,


### PR DESCRIPTION
## Search runs could request more output than an endpoint supports

Search benchmarks default to 128,000 output tokens and forwarded that value unchanged. Valid model endpoints can advertise lower completion ceilings, making the recorded request impossible before server-side routing applies its own clamp.

## What changed

- Add optional `maxOutputTokensCeiling` to the run input boundary.
- Thread the ceiling through `runBenchmarkById`.
- Clamp configured or default search output tokens before solver construction.
- Preserve current behavior when no ceiling is supplied.
- Cover default clamping, configured clamping, below-limit passthrough, and absent-ceiling behavior.

Metadata resolution intentionally remains outside the harness. External campaign runners can resolve provider or endpoint limits and pass only the numeric ceiling.

## Validation

- Full package test suite: 1,152 passed.
- Typecheck: 289 files, no errors or warnings.
- Oxlint passed with only pre-existing warnings.
- No paid benchmark run was started.

## Reviewer focus

The ceiling is transient execution context rather than persisted benchmark configuration, and only search benchmarks consume it.