### PR TITLE
fix(search): restore official DeepSearchQA grading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ OPENROUTER_API_KEY=... bun run bench -- --benchmark gpqa_diamond --model openai/
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) before proposing changes. Report security issues privately as described in [SECURITY.md](SECURITY.md).
+
+## DeepSearchQA
+
+DeepSearchQA uses the official 900-row [Google DeepSearchQA dataset](https://huggingface.co/datasets/google/deepsearchqa), `google/gemini-2.5-flash`, and the grading prompt from the [official starter notebook](https://www.kaggle.com/code/andrewmingwang/deepsearchqa-starter-code). The primary score is macro per-question `f1_score`; macro precision and recall are reported alongside the paper's four categorical rates. Generic `accuracy` remains the strict Fully Correct rate and is not the primary DSQA score.
+
+The answer type is provided only to the judge, not to the model under test. Exact dataset and judge-prompt hashes are available from `@openrouter/bench-harness/benchmarks/search/provenance`. See the [paper](https://arxiv.org/abs/2601.20975) for the evaluation methodology.

--- a/src/benchmarks/registry.test.ts
+++ b/src/benchmarks/registry.test.ts
@@ -72,6 +72,8 @@ describe("benchmark registry", () => {
     const benchmark = getBenchmark("search_dsqa");
     expect(benchmark?.id).toBe("search_dsqa");
     expect(benchmark?.defaultEpochs).toBe(1);
+    expect(typeof benchmark?.runLevelScores).toBe("function");
+    expect(typeof benchmark?.primaryScore).toBe("function");
     const config = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "search_dsqa",
       model: "openai/gpt-5.4-nano",

--- a/src/benchmarks/search/dsqa/benchmark.test.ts
+++ b/src/benchmarks/search/dsqa/benchmark.test.ts
@@ -9,6 +9,8 @@ import {
 } from "../../../../test/helpers/noop-progress-layer";
 import type { Sample, TaskState } from "../../../harness/core";
 import { initialTaskState, ScoreValue } from "../../../harness/core";
+import type { SampleScore } from "../../../harness/metric";
+import type { RunResult } from "../../../harness/run";
 import { assertRight } from "../../../internal/testing";
 import { parseSchema } from "../../../internal/zod";
 import type {
@@ -17,7 +19,13 @@ import type {
 } from "../../../providers/responses-client";
 import type { SearchLaneConfig } from "../core/config";
 import { SearchLaneConfigSchema } from "../core/config";
-import { dsqaScorer, makeDsqaSolver } from "./benchmark";
+import {
+  calculateDsqaGrade,
+  dsqaPrimaryScore,
+  dsqaRunLevelScores,
+  dsqaScorer,
+  makeDsqaSolver,
+} from "./benchmark";
 
 const SAMPLE: Sample = {
   id: "dsqa-0",
@@ -28,9 +36,19 @@ const SAMPLE: Sample = {
 
 const VERDICT = {
   explanation: "Both expected countries were found.",
-  all_expected_answers_found: true,
+  correctness_details: { Belgium: true, France: true },
   excessive_answers: [],
 };
+
+function rawVerdict(verdict = VERDICT): string {
+  return JSON.stringify({
+    "Answer Correctness": {
+      Explanation: verdict.explanation,
+      "Correctness Details": verdict.correctness_details,
+      "Excessive Answers": verdict.excessive_answers,
+    },
+  });
+}
 
 function makeLane(): SearchLaneConfig {
   const result = parseSchema(SearchLaneConfigSchema, { engine: "exa" });
@@ -79,7 +97,10 @@ describe("DSQA benchmark", () => {
   it("scores missing expected or excessive answers as incorrect", async () => {
     const missing = await runPromise(
       dsqaScorer(
-        stateWithVerdict({ ...VERDICT, all_expected_answers_found: false }),
+        stateWithVerdict({
+          ...VERDICT,
+          correctness_details: { Belgium: true, France: false },
+        }),
         SAMPLE.target
       )
     );
@@ -97,13 +118,9 @@ describe("DSQA benchmark", () => {
     const service: ResponsesService = {
       send: (body) => {
         calls += 1;
+        const isJudge = body.model === "google/gemini-2.5-flash";
         return succeed(
-          fixtureResult(
-            body.text === undefined
-              ? "Belgium and France"
-              : JSON.stringify(VERDICT),
-            body.text !== undefined
-          )
+          fixtureResult(isJudge ? rawVerdict() : "Belgium and France", isJudge)
         );
       },
     };
@@ -119,6 +136,7 @@ describe("DSQA benchmark", () => {
     );
     expect(calls).toBe(2);
     expect(state.output?.usage?.totalCost).toBeCloseTo(0.021, 5);
+    expect(state.sample.metadata?.["verdict"]).toEqual(VERDICT);
     expect((await runPromise(dsqaScorer(state, SAMPLE.target))).value).toBe(
       ScoreValue.Correct
     );
@@ -145,5 +163,96 @@ describe("DSQA benchmark", () => {
       )
     ).rejects.toThrow("search response had no answer text");
     expect(calls).toBe(1);
+  });
+});
+
+describe("DSQA metrics", () => {
+  it.each([
+    [{ A: true, B: true }, [], 1, 1, 1, 1],
+    [{ A: true, B: false }, [], 1, 0.5, 2 / 3, 0],
+    [{ A: true, B: true }, ["C"], 2 / 3, 1, 0.8, 0],
+    [{ A: true, B: false }, ["C"], 0.5, 0.5, 0.5, 0],
+    [{ A: false, B: false }, [], 0, 0, 0, 0],
+    [{}, [], 0, 0, 0, 0],
+  ] as const)(
+    "calculates paper metrics for %#",
+    (correctnessDetails, excessiveAnswers, precision, recall, f1, correct) => {
+      const grade = calculateDsqaGrade({
+        explanation: "grade",
+        correctness_details: correctnessDetails,
+        excessive_answers: excessiveAnswers,
+      });
+      expect(grade.metrics.precision).toBeCloseTo(precision);
+      expect(grade.metrics.recall).toBeCloseTo(recall);
+      expect(grade.metrics.f1_score).toBeCloseTo(f1);
+      expect(grade.metrics.fully_correct).toBe(correct);
+      expect(
+        Object.values(grade.metrics)
+          .slice(3)
+          .reduce((sum, value) => sum + value, 0)
+      ).toBe(1);
+    }
+  );
+
+  it("counts duplicate excessive answers as separate false positives", () => {
+    const grade = calculateDsqaGrade({
+      explanation: "grade",
+      correctness_details: { A: true },
+      excessive_answers: ["B", "B"],
+    });
+    expect(grade.metrics.precision).toBeCloseTo(1 / 3);
+    expect(grade.metrics.recall).toBe(1);
+    expect(grade.metrics.f1_score).toBeCloseTo(0.5);
+  });
+
+  it("macro-averages question metrics across epochs and uses F1 as primary", () => {
+    const score = (sampleId: string, epoch: number, f1Verdict: typeof VERDICT) =>
+      ({
+        sampleId,
+        epoch,
+        score: {
+          value: ScoreValue.Incorrect,
+          answer: null,
+          explanation: "",
+          trajectory: {
+            kind: "judge_runs",
+            runs: [calculateDsqaGrade(f1Verdict)],
+          },
+        },
+      }) satisfies SampleScore;
+    const sampleScores = [
+      score("a", 0, VERDICT),
+      score("a", 1, {
+        ...VERDICT,
+        correctness_details: { Belgium: true, France: false },
+      }),
+      score("b", 0, {
+        ...VERDICT,
+        correctness_details: { Belgium: false, France: false },
+      }),
+    ];
+    const run: RunResult = {
+      metrics: {
+        accuracy: 0,
+        totalQuestions: 2,
+        correctAnswers: 0,
+        skippedQuestions: 0,
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        reasoningTokens: 0,
+        totalCost: 0,
+        generationTimeMs: 0,
+      },
+      sampleScores,
+    };
+    expect(dsqaRunLevelScores(run)[0]?.metrics["f1_score"]?.value).toBeCloseTo(
+      5 / 12
+    );
+    expect(dsqaRunLevelScores(run)[0]?.metrics["samples_judged"]?.value).toBe(2);
+    expect(dsqaPrimaryScore(run)?.value).toBeCloseTo(5 / 12);
+    expect(dsqaPrimaryScore(run)?.weight).toBe(2);
   });
 });

--- a/src/benchmarks/search/dsqa/benchmark.test.ts
+++ b/src/benchmarks/search/dsqa/benchmark.test.ts
@@ -174,7 +174,14 @@ describe("DSQA metrics", () => {
     [{ A: true, B: false }, ["C"], 0.5, 0.5, 0.5, 0],
     [{ A: false, B: false }, [], 0, 0, 0, 0],
     [{}, [], 0, 0, 0, 0],
-  ] as const)(
+  ] satisfies [
+    Record<string, boolean>,
+    string[],
+    number,
+    number,
+    number,
+    number,
+  ][])(
     "calculates paper metrics for %#",
     (correctnessDetails, excessiveAnswers, precision, recall, f1, correct) => {
       const grade = calculateDsqaGrade({
@@ -206,7 +213,11 @@ describe("DSQA metrics", () => {
   });
 
   it("macro-averages question metrics across epochs and uses F1 as primary", () => {
-    const score = (sampleId: string, epoch: number, f1Verdict: typeof VERDICT) =>
+    const score = (
+      sampleId: string,
+      epoch: number,
+      f1Verdict: typeof VERDICT
+    ) =>
       ({
         sampleId,
         epoch,
@@ -251,7 +262,9 @@ describe("DSQA metrics", () => {
     expect(dsqaRunLevelScores(run)[0]?.metrics["f1_score"]?.value).toBeCloseTo(
       5 / 12
     );
-    expect(dsqaRunLevelScores(run)[0]?.metrics["samples_judged"]?.value).toBe(2);
+    expect(dsqaRunLevelScores(run)[0]?.metrics["samples_judged"]?.value).toBe(
+      2
+    );
     expect(dsqaPrimaryScore(run)?.value).toBeCloseTo(5 / 12);
     expect(dsqaPrimaryScore(run)?.weight).toBe(2);
   });

--- a/src/benchmarks/search/dsqa/benchmark.ts
+++ b/src/benchmarks/search/dsqa/benchmark.ts
@@ -65,9 +65,7 @@ const DsqaTrajectoryGradeSchema = z.object({
 
 type DsqaTrajectoryGrade = z.infer<typeof DsqaTrajectoryGradeSchema>;
 
-export function calculateDsqaGrade(
-  verdict: DsqaVerdict
-): DsqaTrajectoryGrade {
+export function calculateDsqaGrade(verdict: DsqaVerdict): DsqaTrajectoryGrade {
   const details = Object.values(verdict.correctness_details);
   const truePositives = details.filter(Boolean).length;
   const falseNegatives = details.length - truePositives;
@@ -214,13 +212,14 @@ function dsqaQuestionMetrics(result: RunResult): readonly DsqaMetrics[] {
       metricsBySample.set(sample.sampleId, [metrics]);
     }
   }
-  return [...metricsBySample.values()].map((metrics) =>
-    Object.fromEntries(
-      DSQA_METRIC_NAMES.map((name) => [
-        name,
-        metrics.reduce((sum, item) => sum + item[name], 0) / metrics.length,
-      ])
-    ) as DsqaMetrics
+  return [...metricsBySample.values()].map(
+    (metrics) =>
+      Object.fromEntries(
+        DSQA_METRIC_NAMES.map((name) => [
+          name,
+          metrics.reduce((sum, item) => sum + item[name], 0) / metrics.length,
+        ])
+      ) as DsqaMetrics
   );
 }
 

--- a/src/benchmarks/search/dsqa/benchmark.ts
+++ b/src/benchmarks/search/dsqa/benchmark.ts
@@ -3,14 +3,15 @@ import { fail, flatMap, gen, succeed } from "effect/Effect";
 
 import type { Score, Target, TaskState } from "../../../harness/core";
 import { ScoreValue, SolverError } from "../../../harness/core";
+import type { RunResult } from "../../../harness/run";
 import type { SolverService } from "../../../harness/solver";
 import { Either } from "../../../internal/either";
-import { parseSchema } from "../../../internal/zod";
+import { parseSchema, z } from "../../../internal/zod";
 import type { JudgeConfig } from "../../../judge/judge";
 import { judgeCall } from "../../../judge/judge";
 import type { ResponsesService } from "../../../providers/responses-client";
 import { DSQA_META } from "../../benchmark-meta";
-import type { Benchmark } from "../../types";
+import type { Benchmark, BenchmarkPrimaryScore } from "../../types";
 import { makeSearchBenchmarkLayer } from "../core/benchmark";
 import { DEEP_RESEARCH_INSTRUCTIONS } from "../core/prompts";
 import type { SearchSolverOptions } from "../core/solver";
@@ -23,6 +24,89 @@ import { DSQA_JUDGE_CONFIG, DsqaVerdictSchema, dsqaJudgeSpec } from "./grader";
 export const DSQA_BENCHMARK_ID = DSQA_META.id;
 
 const VERDICT_METADATA_KEY = "verdict" as const;
+
+export const DSQA_METRIC_NAMES = [
+  "precision",
+  "recall",
+  "f1_score",
+  "fully_correct",
+  "fully_incorrect",
+  "partially_correct",
+  "correct_with_extraneous_answers",
+] as const;
+
+const DsqaMetricsSchema = z.object({
+  precision: z.number().min(0).max(1),
+  recall: z.number().min(0).max(1),
+  f1_score: z.number().min(0).max(1),
+  fully_correct: z.number().min(0).max(1),
+  fully_incorrect: z.number().min(0).max(1),
+  partially_correct: z.number().min(0).max(1),
+  correct_with_extraneous_answers: z.number().min(0).max(1),
+});
+
+type DsqaMetrics = z.infer<typeof DsqaMetricsSchema>;
+
+const ZERO_DSQA_METRICS: DsqaMetrics = {
+  precision: 0,
+  recall: 0,
+  f1_score: 0,
+  fully_correct: 0,
+  fully_incorrect: 1,
+  partially_correct: 0,
+  correct_with_extraneous_answers: 0,
+};
+
+const DsqaTrajectoryGradeSchema = z.object({
+  kind: z.literal("dsqa_grade"),
+  verdict: DsqaVerdictSchema,
+  metrics: DsqaMetricsSchema,
+});
+
+type DsqaTrajectoryGrade = z.infer<typeof DsqaTrajectoryGradeSchema>;
+
+export function calculateDsqaGrade(
+  verdict: DsqaVerdict
+): DsqaTrajectoryGrade {
+  const details = Object.values(verdict.correctness_details);
+  const truePositives = details.filter(Boolean).length;
+  const falseNegatives = details.length - truePositives;
+  const falsePositives = verdict.excessive_answers.length;
+  const precisionDenominator = truePositives + falsePositives;
+  const recallDenominator = truePositives + falseNegatives;
+  const precision =
+    precisionDenominator === 0 ? 0 : truePositives / precisionDenominator;
+  const recall =
+    recallDenominator === 0 ? 0 : truePositives / recallDenominator;
+  const f1Score =
+    precision + recall === 0
+      ? 0
+      : (2 * precision * recall) / (precision + recall);
+  const allExpectedAnswersFound = details.every(Boolean);
+  const fullyCorrect =
+    details.length > 0 &&
+    allExpectedAnswersFound &&
+    verdict.excessive_answers.length === 0;
+  const fullyIncorrect = truePositives === 0;
+  const correctWithExtraneousAnswers =
+    details.length > 0 &&
+    allExpectedAnswersFound &&
+    verdict.excessive_answers.length > 0;
+  return {
+    kind: "dsqa_grade",
+    verdict,
+    metrics: {
+      precision,
+      recall,
+      f1_score: f1Score,
+      fully_correct: fullyCorrect ? 1 : 0,
+      fully_incorrect: fullyIncorrect ? 1 : 0,
+      partially_correct:
+        fullyCorrect || fullyIncorrect || correctWithExtraneousAnswers ? 0 : 1,
+      correct_with_extraneous_answers: correctWithExtraneousAnswers ? 1 : 0,
+    },
+  };
+}
 
 function judgeStage(
   responses: ResponsesService,
@@ -97,15 +181,89 @@ export function dsqaScorer(
     });
   }
   const verdict: DsqaVerdict = parsed.right;
-  const isCorrect =
-    verdict.all_expected_answers_found &&
-    verdict.excessive_answers.length === 0;
+  const grade = calculateDsqaGrade(verdict);
   return succeed({
-    value: isCorrect ? ScoreValue.Correct : ScoreValue.Incorrect,
+    value:
+      grade.metrics.fully_correct === 1
+        ? ScoreValue.Correct
+        : ScoreValue.Incorrect,
     answer: state.output?.completion ?? null,
     explanation: verdict.explanation,
-    trajectory: { kind: "judge_runs", runs: [verdict] } as const,
+    trajectory: { kind: "judge_runs", runs: [grade] } as const,
   });
+}
+
+function dsqaQuestionMetrics(result: RunResult): readonly DsqaMetrics[] {
+  const metricsBySample = new Map<string, DsqaMetrics[]>();
+  for (const sample of result.sampleScores) {
+    if (sample.score.value === ScoreValue.Skipped) {
+      continue;
+    }
+    const trajectory = sample.score.trajectory;
+    let metrics = ZERO_DSQA_METRICS;
+    if (trajectory?.kind === "judge_runs") {
+      const parsed = parseSchema(DsqaTrajectoryGradeSchema, trajectory.runs[0]);
+      if (Either.isRight(parsed)) {
+        metrics = parsed.right.metrics;
+      }
+    }
+    const existing = metricsBySample.get(sample.sampleId);
+    if (existing) {
+      existing.push(metrics);
+    } else {
+      metricsBySample.set(sample.sampleId, [metrics]);
+    }
+  }
+  return [...metricsBySample.values()].map((metrics) =>
+    Object.fromEntries(
+      DSQA_METRIC_NAMES.map((name) => [
+        name,
+        metrics.reduce((sum, item) => sum + item[name], 0) / metrics.length,
+      ])
+    ) as DsqaMetrics
+  );
+}
+
+export function dsqaRunLevelScores(result: RunResult): readonly {
+  name: string;
+  metrics: Readonly<Record<string, { value: number }>>;
+}[] {
+  const metrics = dsqaQuestionMetrics(result);
+  if (metrics.length === 0) {
+    return [];
+  }
+  return [
+    {
+      name: "dsqa",
+      metrics: {
+        ...Object.fromEntries(
+          DSQA_METRIC_NAMES.map((name) => [
+            name,
+            {
+              value:
+                metrics.reduce((sum, item) => sum + item[name], 0) /
+                metrics.length,
+            },
+          ])
+        ),
+        samples_judged: { value: metrics.length },
+      },
+    },
+  ];
+}
+
+export function dsqaPrimaryScore(
+  result: RunResult
+): BenchmarkPrimaryScore | undefined {
+  const metrics = dsqaQuestionMetrics(result);
+  if (metrics.length === 0) {
+    return undefined;
+  }
+  return {
+    value:
+      metrics.reduce((sum, item) => sum + item.f1_score, 0) / metrics.length,
+    weight: metrics.length,
+  };
 }
 
 export const DSQA_BENCHMARK: Benchmark = {
@@ -122,4 +280,6 @@ export const DSQA_BENCHMARK: Benchmark = {
       makeSolver: makeDsqaSolver,
       scorer: dsqaScorer,
     }),
+  runLevelScores: dsqaRunLevelScores,
+  primaryScore: dsqaPrimaryScore,
 };

--- a/src/benchmarks/search/dsqa/grader.test.ts
+++ b/src/benchmarks/search/dsqa/grader.test.ts
@@ -1,39 +1,68 @@
 import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
 
 import { assertLeft, assertRight } from "../../../internal/testing";
 import {
+  DSQA_GRADER_PROMPT,
+  DSQA_JUDGE_CONFIG,
   dsqaJudgeSpec,
   parseDsqaVerdict,
   renderDsqaGraderPrompt,
 } from "./grader";
 describe("DSQA grader", () => {
-  it("renders the benchmark inputs", () => {
+  it("pins the official prompt and judge", () => {
+    expect(createHash("sha256").update(DSQA_GRADER_PROMPT).digest("hex")).toBe(
+      "9bdd0b9198244de8a78bf256b5332805d00c140e85b713f0e1878b3e4aa605a0"
+    );
+    expect(DSQA_JUDGE_CONFIG.judgeModel).toBe("google/gemini-2.5-flash");
+  });
+  it("renders the benchmark inputs inside the official wrappers", () => {
     const prompt = renderDsqaGraderPrompt({
       question: "Name both countries.",
       promptType: "Set Answer",
       correctAnswer: "Belgium, France",
       response: "Belgium and France",
     });
-    expect(prompt).toContain("Prompt type: Set Answer");
-    expect(prompt).toContain("Correct answer: Belgium, France");
-    expect(prompt).toContain("AI response: Belgium and France");
+    expect(prompt).toContain("<prompt>\nName both countries.\n</prompt>");
+    expect(prompt).toContain("Prompt Type: Set Answer");
+    expect(prompt).toContain("<answer>\nBelgium, France\n</answer>");
+    expect(prompt).toContain("<response>\nBelgium and France\n</response>");
   });
-  it("validates a native verdict", () => {
+  it("parses the official nested verdict", () => {
     const result = parseDsqaVerdict(
       JSON.stringify({
-        explanation: "Both expected countries were found.",
-        all_expected_answers_found: true,
-        excessive_answers: [],
+        "Answer Correctness": {
+          Explanation: "Belgium was found but France was not.",
+          "Correctness Details": { Belgium: true, France: false },
+          "Excessive Answers": ["Italy"],
+        },
       })
     );
     assertRight(result);
-    expect(result.right.all_expected_answers_found).toBe(true);
+    expect(result.right).toEqual({
+      explanation: "Belgium was found but France was not.",
+      correctness_details: { Belgium: true, France: false },
+      excessive_answers: ["Italy"],
+    });
+  });
+  it("parses fenced output", () => {
+    const result = parseDsqaVerdict(`prefix "\`\`\`json
+{"Answer Correctness":{"Explanation":"ok","Correctness Details":{"A":true},"Excessive Answers":[]}}
+\`\`\`" suffix`);
+    assertRight(result);
+    expect(result.right.excessive_answers).toEqual([]);
   });
   it("rejects malformed verdicts", () => {
-    const result = parseDsqaVerdict('{"all_expected_answers_found":"yes"}');
-    assertLeft(result);
+    for (const text of [
+      "null",
+      '{"Answer Correctness":{"Explanation":"x","Correctness Details":{"A":"true"}}}',
+      '{"Answer Correctness":{"Explanation":"x","Correctness Details":[]}}',
+      '{"Answer Correctness":{"Explanation":"x","Correctness Details":{"A":true},"Excessive Answers":[1]}}',
+    ]) {
+      assertLeft(parseDsqaVerdict(text));
+    }
   });
-  it("uses a strict fixed verdict contract", () => {
+  it("uses the official unstructured verdict contract", () => {
     const spec = dsqaJudgeSpec({
       question: "Q",
       promptType: "Single Answer",
@@ -41,9 +70,6 @@ describe("DSQA grader", () => {
       response: "A",
     });
     expect(spec.schemaName).toBe("dsqa_judge");
-    expect(spec.jsonSchema).toMatchObject({
-      type: "object",
-      additionalProperties: false,
-    });
+    expect(spec.jsonSchema).toBeUndefined();
   });
 });

--- a/src/benchmarks/search/dsqa/grader.ts
+++ b/src/benchmarks/search/dsqa/grader.ts
@@ -8,33 +8,86 @@ export const DSQA_JUDGE_CONFIG = {
 
 export const DSQA_JUDGE_PROMPT_ID = "dsqa_judge";
 
-export const DSQA_GRADER_PROMPT = `Evaluate whether the AI response answers the DeepSearchQA question correctly.
+export const DSQA_GRADER_PROMPT_SOURCE =
+  "https://www.kaggle.com/code/andrewmingwang/deepsearchqa-starter-code?scriptVersionId=285323691";
 
-Prompt type: {prompt_type}
-Question: {question}
-Correct answer: {correct_answer}
-AI response: {response}
+export const DSQA_GRADER_PROMPT = `Your task is to evaluate whether a given "AI Response" for a specific "User Prompt" arrived at the correct answer.
 
-For a Single Answer, accept equivalent wording. For a Set Answer, require every expected item and reject additional unsupported answers.`;
+**Answer Correctness Task**
+
+*   **Purpose:** Assess whether the AI response provides the correct answer(s) based on the provided "Correct Answer" and "Prompt Type".
+*   **Process:**
+    *   Identify the "Prompt Type": "<prompt_type>".
+    *   Refer to the "Correct Answer": "<answer>".
+    *   Based on the "Prompt Type", determine if the "AI Response" contains the expected answer(s).
+        *   **'Single Answer'**: Check if the response provides the answer that addresses the user's question. It does not have to match the exact wording of the provided answer.
+        *   **'Set Answer'**: Check if the response includes *each* item from the provided ground truth answers. The order might not matter unless specified otherwise. The response might include more answers than the list. Determine the correctness *only* based on the list first and then check if the response includes answers not in the list.
+    *   **Explanation:** Provide a brief explanation justifying your assessment of answer correctness, referencing specific parts of the AI response and the correct answer.
+    *   **Correctness Details:** Provide a dictionary, one key for each expected answer part, and value is a boolean indicating whether each expected answer part was found.
+        *   For 'Set Answer', this will be a list of attributes, one for each item/part in the "Correct Answer". Each key will be a string indicating the expected answer part, and the value will be a boolean indicating whether that part was found in the response.
+    *   **Excessive Answers:** Provide a list of strings, each indicating an excessive answer part. If the response provides answers that are **not** in the "Correct Answer" list, add these answers as excessive answers. Return an empty list when there's no excessive answers in the response.
+
+
+**Output Format:**
+
+Your evaluation *must* be structured as a nested JSON dictionary with the following top-level keys: \`"Answer Correctness"\`. Please return NULL if any of "Prompt", "AI Response" or "Correct Answer" is empty.
+The value for \`"Answer Correctness"\` should be a dictionary containing \`"Explanation"\` (a string), \`"Correctness Details"\` (a dictionary where each key is the expected correct answer, and the value is a boolean indicating whether the response contains the correct answer), and \`"Excessive Answers"\` (a list of strings indicating the excessive answers).
+
+Make sure you return a valid JSON string. Pay special attention to quotes, commas and special characters in the JSON string. Make sure to escape all special characters and quotes in the JSON string.
+
+
+
+**Example (Partial):**
+
+"\`\`\`json
+{
+  "Answer Correctness": {
+    "Explanation": "The response correctly identified Belgium and France but also includes an excessive answer, Italy.",
+    "Correctness Details": {
+      "Belgium": true,
+      "France": true,
+    },
+    "Excessive Answers": [ "Italy" ]
+  }
+}
+\`\`\`"
+
+**Now, proceed with the evaluation using the provided User Prompt, AI Response, and Correct Answer.**
+
+User Prompt (Wrapped in <prompt> and </prompt>):
+<prompt>
+{prompt}
+</prompt>
+--------------------
+**  Correct Answer (Wrapped in <answer> and </answer>):
+Prompt Type: {prompt_type}
+<answer>
+{answer}
+</answer>
+--------------------
+AI assistant response (Wrapped in <response> and </response>):
+<response>
+{response}
+</response>
+
+--------------------
+Rating:`;
 
 export const DsqaVerdictSchema = z.object({
   explanation: z.string(),
-  all_expected_answers_found: z.boolean(),
+  correctness_details: z.record(z.string(), z.boolean()),
   excessive_answers: z.array(z.string()),
 });
 
 export type DsqaVerdict = z.infer<typeof DsqaVerdictSchema>;
 
-const DSQA_VERDICT_JSON_SCHEMA = {
-  type: "object",
-  additionalProperties: false,
-  properties: {
-    explanation: { type: "string" },
-    all_expected_answers_found: { type: "boolean" },
-    excessive_answers: { type: "array", items: { type: "string" } },
-  },
-  required: ["explanation", "all_expected_answers_found", "excessive_answers"],
-} as const;
+const RawDsqaVerdictSchema = z.object({
+  "Answer Correctness": z.object({
+    Explanation: z.string(),
+    "Correctness Details": z.record(z.string(), z.boolean()),
+    "Excessive Answers": z.array(z.string()),
+  }),
+});
 
 export function renderDsqaGraderPrompt(fields: {
   readonly question: string;
@@ -43,13 +96,13 @@ export function renderDsqaGraderPrompt(fields: {
   readonly response: string;
 }): string {
   const replacements: Readonly<Record<string, string>> = {
-    "{question}": fields.question,
+    "{prompt}": fields.question,
     "{prompt_type}": fields.promptType,
-    "{correct_answer}": fields.correctAnswer,
+    "{answer}": fields.correctAnswer,
     "{response}": fields.response,
   };
   return DSQA_GRADER_PROMPT.replaceAll(
-    /\{(?:question|prompt_type|correct_answer|response)\}/gu,
+    /\{(?:prompt|prompt_type|answer|response)\}/gu,
     (placeholder) => replacements[placeholder] ?? placeholder
   );
 }
@@ -57,14 +110,22 @@ export function renderDsqaGraderPrompt(fields: {
 export function parseDsqaVerdict(
   text: string
 ): Either.Either<DsqaVerdict, string> {
-  const json = Either.try(() => JSON.parse(text));
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/```json\s*([\s\S]*?)\s*```/u);
+  const json = Either.try(() => JSON.parse(fenced?.[1] ?? trimmed));
   if (Either.isLeft(json)) {
     return Either.left(`not valid JSON: ${text.slice(0, 200)}`);
   }
-  const parsed = parseSchema(DsqaVerdictSchema, json.right);
-  return Either.isLeft(parsed)
-    ? Either.left(parsed.left.message)
-    : Either.right(parsed.right);
+  const parsed = parseSchema(RawDsqaVerdictSchema, json.right);
+  if (Either.isLeft(parsed)) {
+    return Either.left(parsed.left.message);
+  }
+  const answerCorrectness = parsed.right["Answer Correctness"];
+  return Either.right({
+    explanation: answerCorrectness.Explanation,
+    correctness_details: answerCorrectness["Correctness Details"],
+    excessive_answers: answerCorrectness["Excessive Answers"],
+  });
 }
 
 export function dsqaJudgeSpec(fields: {
@@ -76,7 +137,6 @@ export function dsqaJudgeSpec(fields: {
   return {
     userInput: renderDsqaGraderPrompt(fields),
     schemaName: DSQA_JUDGE_PROMPT_ID,
-    jsonSchema: DSQA_VERDICT_JSON_SCHEMA,
     parseVerdict: parseDsqaVerdict,
   };
 }

--- a/src/benchmarks/search/dsqa/grader.ts
+++ b/src/benchmarks/search/dsqa/grader.ts
@@ -36,7 +36,6 @@ The value for \`"Answer Correctness"\` should be a dictionary containing \`"Expl
 Make sure you return a valid JSON string. Pay special attention to quotes, commas and special characters in the JSON string. Make sure to escape all special characters and quotes in the JSON string.
 
 
-
 **Example (Partial):**
 
 "\`\`\`json

--- a/src/benchmarks/search/grading/answer-equivalence.test.ts
+++ b/src/benchmarks/search/grading/answer-equivalence.test.ts
@@ -95,7 +95,7 @@ describe("answerEquivalenceJudgeSpec", () => {
     });
     expect(spec.schemaName).toBe("answer_equivalence_judge");
     expect(spec.userInput).toContain("[question]: Q?");
-    expect(spec.jsonSchema["required"]).toEqual([
+    expect(spec.jsonSchema?.["required"]).toEqual([
       "extracted_final_answer",
       "reasoning",
       "correct",

--- a/src/benchmarks/search/provenance.test.ts
+++ b/src/benchmarks/search/provenance.test.ts
@@ -56,7 +56,7 @@ describe("search benchmark provenance", () => {
           prompt: {
             id: "dsqa_judge",
             sha256:
-              "7b9279e2d8dba2547eb6e1c00dcd7498150df3fdd3cace6b8e817ea67ae07f9c",
+              "9bdd0b9198244de8a78bf256b5332805d00c140e85b713f0e1878b3e4aa605a0",
           },
         },
       ],

--- a/src/judge/judge.test.ts
+++ b/src/judge/judge.test.ts
@@ -81,10 +81,14 @@ describe("judgeCall", () => {
       },
     };
     const result = await runPromise(
-      judgeCall(service, { judgeModel: "openai/gpt-4.1" }, {
-        ...SPEC,
-        jsonSchema: undefined,
-      })
+      judgeCall(
+        service,
+        { judgeModel: "openai/gpt-4.1" },
+        {
+          ...SPEC,
+          jsonSchema: undefined,
+        }
+      )
     );
     expect(result.verdict).toEqual({ verdict: "yes" });
     expect(sentText).toBeUndefined();

--- a/src/judge/judge.test.ts
+++ b/src/judge/judge.test.ts
@@ -72,6 +72,23 @@ describe("judgeCall", () => {
       },
     });
   });
+  it("omits structured-output config for an unstructured judge spec", async () => {
+    let sentText: unknown = "unset";
+    const service: ResponsesService = {
+      send: (body) => {
+        sentText = body.text;
+        return succeed(fixtureResult('{"verdict":"yes"}'));
+      },
+    };
+    const result = await runPromise(
+      judgeCall(service, { judgeModel: "openai/gpt-4.1" }, {
+        ...SPEC,
+        jsonSchema: undefined,
+      })
+    );
+    expect(result.verdict).toEqual({ verdict: "yes" });
+    expect(sentText).toBeUndefined();
+  });
   it("fails with ModelError when the verdict does not parse, without retrying", async () => {
     let calls = 0;
     const service: ResponsesService = {

--- a/src/judge/judge.ts
+++ b/src/judge/judge.ts
@@ -32,7 +32,7 @@ export interface JudgeCallSpec<T> {
   readonly instructions?: string;
   readonly userInput: string;
   readonly schemaName: string;
-  readonly jsonSchema: Record<string, unknown>;
+  readonly jsonSchema?: Record<string, unknown>;
   readonly parseVerdict: (text: string) => Either.Either<T, string>;
   readonly parseFailureFallback?: T;
 }
@@ -48,18 +48,21 @@ export function judgeCall<T>(
   config: JudgeConfig,
   spec: JudgeCallSpec<T>
 ): Effect<JudgeResult<T>, ModelError> {
-  const text: TextExtendedConfig = {
-    format: {
-      type: "json_schema",
-      name: spec.schemaName,
-      strict: true,
-      schema: spec.jsonSchema,
-    },
-  };
+  const text: TextExtendedConfig | undefined =
+    spec.jsonSchema === undefined
+      ? undefined
+      : {
+          format: {
+            type: "json_schema",
+            name: spec.schemaName,
+            strict: true,
+            schema: spec.jsonSchema,
+          },
+        };
   const body: ResponsesRequest = {
     model: config.judgeModel,
     input: [{ role: "user" as const, content: spec.userInput }],
-    text,
+    ...(text !== undefined && { text }),
     ...(spec.instructions !== undefined && { instructions: spec.instructions }),
     ...(config.temperature !== undefined && {
       temperature: config.temperature,


### PR DESCRIPTION
## DSQA currently collapses item-level grading into binary accuracy

The current grader uses a compact noncanonical prompt and asks Gemini for one `all_expected_answers_found` boolean. That removes the per-answer decisions required by the DeepSearchQA paper, gives partial answers no continuous score, and makes strict Fully Correct accuracy the only headline result. The official dataset card warns that changing the judge prompt can produce statistically significant score differences.

## TL;DR

Restore the versioned Kaggle/paper prompt and nested correctness-detail verdict, call Gemini 2.5 Flash without a response schema as the official starter does, calculate per-question precision/recall/F1 plus all four categories, and use macro F1 as DSQA's primary score. Strict `accuracy` remains the Fully Correct rate.

## What Changed?

- Sends the official grader prompt to `google/gemini-2.5-flash` with no explicit temperature or structured-output override.
- Parses bare or `json`-fenced official verdicts and validates every detail value and excessive answer.
- Computes per-question precision, recall, F1, Fully Correct, Fully Incorrect, Partially Correct, and Correct with Extraneous Answers.
- Mean-reduces epochs per question, macro-averages across questions, and exposes macro `f1_score` through the existing primary-score hook.
- Keeps malformed non-skipped grades at zero and excludes skipped infrastructure failures, matching existing harness aggregation boundaries.
- Updates the exported judge-prompt provenance hash and documents the metric contract.
- Makes structured output optional in the shared judge helper; every existing judge that supplies a schema remains unchanged.

## Why?

The paper ranks systems by macro per-question F1. Preserving only the final strict predicate cannot distinguish a nearly complete answer from a fully wrong answer and cannot reproduce the published methodology. Dynamic correctness-detail keys also cannot be represented faithfully by the existing strict fixed schema, so DSQA follows the official free-form JSON call while retaining fail-closed parsing.

## Validation

Local validation passed:

- `bun run format:check`
- `bun run check` (pre-existing warning-level findings only)
- `bun run typecheck` (291 files, zero diagnostics)
- `bun test` (1,173 passed)
- `bun run build`

GitHub `validate`, CodeQL, and JavaScript/TypeScript analysis all pass. The mirrored search-benchmarks implementation also completed a paid 10-task DSQA run through the official free-form judge path with 10/10 valid verdicts and no skips or parse failures.

## Reviewer Focus

- Confirm the prompt text and hash match the pinned Kaggle starter.
- Confirm macro F1 is the mean of per-question F1 values, not pooled F1 or F1 of macro precision/recall.
- Confirm empty correctness-detail maps fail closed rather than becoming vacuously Fully Correct.
- Confirm omitting `text.format` is DSQA-only and leaves structured judges unchanged.