### PR TITLE
docs: remove DeepSearchQA README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,3 @@ OPENROUTER_API_KEY=... bun run bench -- --benchmark gpqa_diamond --model openai/
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) before proposing changes. Report security issues privately as described in [SECURITY.md](SECURITY.md).
-
-## DeepSearchQA
-
-DeepSearchQA uses the official 900-row [Google DeepSearchQA dataset](https://huggingface.co/datasets/google/deepsearchqa), `google/gemini-2.5-flash`, and the grading prompt from the [official starter notebook](https://www.kaggle.com/code/andrewmingwang/deepsearchqa-starter-code). The primary score is macro per-question `f1_score`; macro precision and recall are reported alongside the paper's four categorical rates. Generic `accuracy` remains the strict Fully Correct rate and is not the primary DSQA score.
-
-The answer type is provided only to the judge, not to the model under test. Exact dataset and judge-prompt hashes are available from `@openrouter/bench-harness/benchmarks/search/provenance`. See the [paper](https://arxiv.org/abs/2601.20975) for the evaluation methodology.


### PR DESCRIPTION
## Outdated README detail

The root README currently includes implementation-specific DeepSearchQA dataset and grading details. Remove that section so the README remains focused on repository setup and contribution guidance.

## TL;DR

Removes the DeepSearchQA section from `README.md`; benchmark code and behavior are unchanged.

## How To Test

- `bun run format:check`
- `bun run check`
- `bun run typecheck`
- `bun test` (1,173 passing)
- `bun run build`

All commands pass. Lint reports existing warnings only.