### PR TITLE
ECO-2854: promote no-typeof-undefined; document Effect-misfiring lint rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@
 ## Code
 
 - Preserve the repository's strict TypeScript and Effect patterns.
+- Do not re-enable the following ultracite lint rules in `oxlint.config.ts`; they are disabled because they misfire on Effect (they are not type-aware and match `.then`/`.catch`/callbacks/constructors by syntax alone, flagging Effect's `Schedule`/`Effect.async`/`Effect.runPromise`/`TaggedError` combinators and pushing code toward worse error handling instead of `catchAll`/`catchTag`):
+  - `promise/prefer-await-to-then`
+  - `promise/prefer-await-to-callbacks`
+  - `promise/no-nesting`
+  - `unicorn/throw-new-error` (fires on `TaggedError("Name")<{...}>()` factory calls)
 - Validate external model, provider, dataset, and filesystem data at runtime.
 - Keep tests colocated as `*.test.ts` and add regression coverage for behavior changes.
 - Treat solver, scorer, prompt, and dataset changes as benchmark behavior changes.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -80,12 +80,11 @@ export default defineConfig({
     "unicorn/prefer-regexp-test": "off",
     "unicorn/prefer-string-slice": "off",
     "unicorn/prefer-structured-clone": "off",
+    "unicorn/throw-new-error": "off",
     "unicorn/no-useless-collection-argument": "off",
     "unicorn/no-useless-spread": "off",
     "unicorn/no-useless-switch-case": "off",
-    "unicorn/no-typeof-undefined": "off",
     "unicorn/no-unreadable-array-destructuring": "off",
-    "unicorn/throw-new-error": "off",
 
     "eslint/no-new-func": "warn",
     "eslint/require-yield": "warn",

--- a/src/internal/log.ts
+++ b/src/internal/log.ts
@@ -157,7 +157,7 @@ function sanitizeLogValue(
   ) {
     return value;
   }
-  if (typeof value === "undefined") {
+  if (value === undefined) {
     return undefined;
   }
   if (typeof value === "symbol" || typeof value === "function") {


### PR DESCRIPTION
Linear: [ECO-2854](https://linear.app/openrouter/issue/ECO-2854/chorebench-harness-promote-no-typeof-undefined-and-prefer-number)

## Summary

Promote one mechanical, correctness-oriented ultracite lint rule from `off` back to `error`, and document the Effect-misfiring rules so future agents don't re-enable them.

## Promoted to error (1 rule)

| Rule | Fix |
|---|---|
| `unicorn/no-typeof-undefined` | `typeof value === "undefined"` → `value === undefined` in `src/internal/log.ts` (`value` is a declared parameter, so the direct comparison is safe and equivalent) |

## Documented in AGENTS.md: Effect-misfiring rules to keep off

Auditing surfaced a **4th Effect false positive**: `unicorn/throw-new-error` fires on Effect's `TaggedError("Name")<{...}>()` curried class factory — it treats the factory call as "throw without `new`", but `TaggedError` is a class factory, not an error constructor. There are 12 such sites; none are real `throw X()` calls.

AGENTS.md now documents the four ultracite rules that must stay `off` because they're type-unaware and match by syntax alone, misfiring on Effect combinators and pushing code toward worse error handling (`await/try-catch`) instead of Effect's `catchAll`/`catchTag` pipeline:
- `promise/prefer-await-to-then`
- `promise/prefer-await-to-callbacks`
- `promise/no-nesting`
- `unicorn/throw-new-error`

## Reverted after review

`unicorn/prefer-number-properties` (global `isNaN` → `Number.isNaN` in a tau3-bench-banking tool handler) was initially included but reverted per review (Devin). `Number.isNaN` does not coerce, so a non-numeric `amount` (model-produced JSON kwargs have no schema validation) slips past the NaN check and later throws at `parsedAmount.toFixed()`, crashing the run instead of returning the friendly "Invalid amount" error. The coercion behavior of global `isNaN` is load-bearing in that benchmark fixture, so the rule stays off there.

Also restored an accidentally-deleted override (`unicorn/no-useless-collection-argument`) that was collateral damage from the earlier config edit.

## Why not more

The remaining `off` overrides are either deliberate style preferences the team chose to disable (`sort-keys`, `func-style`, `no-plusplus`, `no-bitwise`, `complexity`, etc.) or rules whose violations live in benchmark-fixture code mirroring reference APIs where refactoring risks altering benchmark scoring behavior (e.g. `unicorn/prefer-single-call` on banking tool response builders, `unicorn/prefer-number-properties` as above).

## Validation

`bun run format:check`, `bun run check`, `bun run typecheck`, `bun test` (1173 pass), and `bun run build` all pass.
