### PR TITLE
ECO-2855: promote prefer-array-find (final safe lint promotion)

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -68,7 +68,6 @@ export default defineConfig({
     "unicorn/no-object-as-default-parameter": "off",
     "unicorn/no-array-reverse": "off",
     "unicorn/no-new-array": "off",
-    "unicorn/prefer-array-find": "off",
     "unicorn/prefer-array-some": "off",
     "unicorn/prefer-array-index-of": "off",
     "unicorn/prefer-code-point": "off",

--- a/src/benchmarks/mmmu-pro-vision.test.ts
+++ b/src/benchmarks/mmmu-pro-vision.test.ts
@@ -85,11 +85,9 @@ describe("mmmuProVisionRecordToSample", () => {
   });
   it("omits detail when imageDetail is not provided", () => {
     const sample = mmmuProVisionRecordToSample(VISION_RECORD, 0);
-    const imageParts = sample.contentParts!.filter(
-      (p) => p.type === "image_url"
-    );
+    const imagePart = sample.contentParts!.find((p) => p.type === "image_url");
     expect(
-      imageParts[0]!.type === "image_url" && imageParts[0]!.imageUrl.detail
+      imagePart!.type === "image_url" && imagePart!.imageUrl.detail
     ).toBeUndefined();
   });
 });


### PR DESCRIPTION
Linear: [ECO-2855](https://linear.app/openrouter/issue/ECO-2855/chorebench-harness-promote-prefer-array-find-final-safe-lint-promotion)

## Summary

Promote the last safely-promotable ultracite lint rule from `off` back to `error`.

## Promoted to error (1 rule)

| Rule | Fix |
|---|---|
| `unicorn/prefer-array-find` | `.filter(predicate)[0]` → `.find(predicate)` in `src/benchmarks/mmmu-pro-vision.test.ts` (equivalent: first match or `undefined`; clearer, avoids allocating the intermediate filtered array) |

## This is the last safe one — why the rest stay off

Auditing the remaining ~71 `off` overrides, none are safely promotable. They fall into three buckets:

### 1. Deliberate style preferences the team chose to disable
`sort-keys` (1951), `func-style` (533), `no-plusplus` (23), `no-bitwise` (hash functions in `scorers/mcq/shuffle.ts` + `browsecomp`), `complexity` (12), `numeric-separators-style` (52), `require-unicode-regexp` (71), `no-negated-condition`, `prefer-destructuring`, `func-names`, `no-use-before-define` (169), `no-non-null-assertion` (178), `consistent-type-imports` (6), `no-explicit-any` (25), etc.

### 2. Effect false positives (the type-unaware-by-syntax class, partially documented in AGENTS.md)
- `promise/prefer-await-to-then` (6), `promise/prefer-await-to-callbacks` (9), `promise/no-nesting` (1) — fire on Effect `Schedule`/`Effect.async`/`Effect.runPromise` combinators.
- `unicorn/throw-new-error` (8) — fires on `TaggedError("Name")<{...}>()` factory calls.
- `eslint/class-methods-use-this` (3) — fires on interface-implementing arrow properties like `NoopArtifactStore.get`/`put` that legitimately don't reference `this`; the rule's "make it static" suggestion would break the `ArtifactStore` interface contract.
- `eslint/no-loop-func` (2) — fires on closures over `const` block-scoped loop vars in `for...of`, which are safe (the rule targets legacy `var`-scoped loops).

### 3. Benchmark-fixture code where the lint "fix" changes load-bearing behavior
- `unicorn/prefer-number-properties` (1) — `Number.isNaN` loses coercion; a non-numeric model-produced `amount` slips past validation and crashes the run (reverted in PR #13 per review).
- `eslint/no-empty` (1) — intentional empty `catch {}` in a tau3 fixture; the repo's `no-comments` rule forbids the usual `// intentional` fix.
- `eslint/guard-for-in` (8), `unicorn/no-array-for-each` (3), `unicorn/prefer-single-call` (6) — in tau3/tau-bench handlers mirroring reference APIs where refactoring risks altering benchmark scoring behavior.

Plus the 6 `warn` rules (`no-new-func`, `require-yield`, `avoid-new`, `no-dynamic-delete`, `no-invalid-void-type`, `prefer-export-from`) remain intentional.

## Validation

`bun run format:check`, `bun run check`, `bun run typecheck`, `bun test` (1173 pass), and `bun run build` all pass.

<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->