### PR TITLE
fix(search): preserve WideSearch judge verdicts

### DIFF
--- a/src/benchmarks/search/widesearch/grading.test.ts
+++ b/src/benchmarks/search/widesearch/grading.test.ts
@@ -225,6 +225,30 @@ describe("gradeWideSearch", () => {
       totalCost: 0.03,
     });
   });
+  it("uses the last duplicate judge entry and ignores unrelated entries", async () => {
+    const replies = [
+      '{"alignments":[{"origin":"Alpha","transform":"Other"},{"origin":"Other","transform":"A"},{"origin":"Alpha","transform":"A"}]}',
+      '{"scores":[{"index":0,"score":0},{"index":1,"score":1},{"index":0,"score":1}]}',
+    ];
+    const service: ResponsesService = {
+      send: () => succeed(fixtureResult(replies.shift()!)),
+    };
+    const result = await runPromise(
+      gradeWideSearch({
+        responses: service,
+        judgeConfig: WIDESEARCH_JUDGE_CONFIG,
+        expectedText: expected({
+          uniqueMetric: ["exact_match"],
+          valueMetric: ["llm_judge"],
+        }),
+        predictedAnswer: "| Name | Value |\n|---|---|\n| Alpha | 3 |",
+      })
+    );
+    expect(result.grade.metrics.success_rate).toBe(1);
+    expect(
+      result.grade.judgeRuns.every((run) => run["error"] === undefined)
+    ).toBeTrue();
+  });
   it("deduplicates unique keys created by value alignment", async () => {
     const sent: ResponsesRequest[] = [];
     const service: ResponsesService = {

--- a/src/benchmarks/search/widesearch/judges.test.ts
+++ b/src/benchmarks/search/widesearch/judges.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import { assertLeft, assertRight } from "../../../internal/testing";
 import { alignmentJudgeSpec, cellJudgeSpec } from "./judges";
 describe("WideSearch judge specs", () => {
-  it("accepts partial alignments and rejects unknown or duplicate origins", () => {
+  it("accepts partial, duplicate, and out-of-vocabulary alignments", () => {
     const spec = alignmentJudgeSpec(["Alpha", "Beta"], ["A", "B"]);
     const valid = spec.parseVerdict(
       '{"alignments":[{"origin":"Alpha","transform":"A"}]}'
@@ -14,22 +14,42 @@ describe("WideSearch judge specs", () => {
     const duplicate = spec.parseVerdict(
       '{"alignments":[{"origin":"Alpha","transform":"A"},{"origin":"Alpha","transform":"B"}]}'
     );
+    const unknownTransform = spec.parseVerdict(
+      '{"alignments":[{"origin":"Alpha","transform":"Other"}]}'
+    );
+    const malformed = spec.parseVerdict(
+      '{"alignments":[{"origin":"Alpha","transform":1}]}'
+    );
     assertRight(valid);
-    assertLeft(unexpected);
-    assertLeft(duplicate);
+    assertRight(unexpected);
+    assertRight(duplicate);
+    assertRight(unknownTransform);
+    assertLeft(malformed);
     expect(valid.right).toEqual([{ origin: "Alpha", transform: "A" }]);
+    expect(duplicate.right).toEqual([
+      { origin: "Alpha", transform: "A" },
+      { origin: "Alpha", transform: "B" },
+    ]);
   });
-  it("accepts missing cell scores and rejects out-of-range or duplicate indices", () => {
+  it("accepts missing, out-of-range, and duplicate cell indices", () => {
     const spec = cellJudgeSpec(["a", "b"], ["x", "y"], "criterion");
     const valid = spec.parseVerdict('{"scores":[{"index":0,"score":1}]}');
     const outOfRange = spec.parseVerdict('{"scores":[{"index":2,"score":1}]}');
     const duplicate = spec.parseVerdict(
       '{"scores":[{"index":0,"score":1},{"index":0,"score":0}]}'
     );
+    const malformed = spec.parseVerdict(
+      '{"scores":[{"index":0,"score":2}]}'
+    );
     assertRight(valid);
-    assertLeft(outOfRange);
-    assertLeft(duplicate);
+    assertRight(outOfRange);
+    assertRight(duplicate);
+    assertLeft(malformed);
     expect(valid.right).toEqual([{ index: 0, score: 1 }]);
+    expect(duplicate.right).toEqual([
+      { index: 0, score: 1 },
+      { index: 0, score: 0 },
+    ]);
   });
   it("uses fixed schemas for large verdict sets", () => {
     const observed = Array.from(

--- a/src/benchmarks/search/widesearch/judges.test.ts
+++ b/src/benchmarks/search/widesearch/judges.test.ts
@@ -38,9 +38,7 @@ describe("WideSearch judge specs", () => {
     const duplicate = spec.parseVerdict(
       '{"scores":[{"index":0,"score":1},{"index":0,"score":0}]}'
     );
-    const malformed = spec.parseVerdict(
-      '{"scores":[{"index":0,"score":2}]}'
-    );
+    const malformed = spec.parseVerdict('{"scores":[{"index":0,"score":2}]}');
     assertRight(valid);
     assertRight(outOfRange);
     assertRight(duplicate);

--- a/src/benchmarks/search/widesearch/judges.ts
+++ b/src/benchmarks/search/widesearch/judges.ts
@@ -134,7 +134,7 @@ export function alignmentJudgeSpec(
       },
       required: ["alignments"],
     },
-    parseVerdict: (text) => parseAlignmentVerdict(text, observed, reference),
+    parseVerdict: parseAlignmentVerdict,
     parseFailureFallback: EMPTY_ALIGNMENT_VERDICT,
   };
 }
@@ -176,61 +176,27 @@ export function cellJudgeSpec(
       },
       required: ["scores"],
     },
-    parseVerdict: (text) => parseCellVerdict(text, observed.length),
+    parseVerdict: parseCellVerdict,
     parseFailureFallback: EMPTY_CELL_JUDGE_VERDICT,
   };
 }
 
 function parseAlignmentVerdict(
-  text: string,
-  observed: readonly string[],
-  reference: readonly string[]
+  text: string
 ): Either.Either<AlignmentVerdict, string> {
   const parsed = parseJson(text, AlignmentVerdictSchema);
-  if (Either.isLeft(parsed)) {
-    return Either.left(parsed.left);
-  }
-  const origins = parsed.right.alignments.map((item) => item.origin);
-  const duplicate = origins.find(
-    (origin, index) => origins.indexOf(origin) !== index
-  );
-  if (duplicate !== undefined) {
-    return Either.left(`duplicate alignment origin: ${duplicate}`);
-  }
-  const unknown = origins.find((origin) => !observed.includes(origin));
-  if (unknown !== undefined) {
-    return Either.left(`unknown alignment origin: ${unknown}`);
-  }
-  const invalid = parsed.right.alignments.find(
-    (item) =>
-      item.transform !== item.origin && !reference.includes(item.transform)
-  );
-  return invalid === undefined
-    ? Either.right(parsed.right.alignments)
-    : Either.left(
-        `unknown alignment transform for ${invalid.origin}: ${invalid.transform}`
-      );
+  return Either.isLeft(parsed)
+    ? Either.left(parsed.left)
+    : Either.right(parsed.right.alignments);
 }
 
 function parseCellVerdict(
-  text: string,
-  itemCount: number
+  text: string
 ): Either.Either<CellJudgeVerdict, string> {
   const parsed = parseJson(text, CellJudgeVerdictSchema);
-  if (Either.isLeft(parsed)) {
-    return Either.left(parsed.left);
-  }
-  const indices = parsed.right.scores.map((item) => item.index);
-  const duplicate = indices.find(
-    (index, position) => indices.indexOf(index) !== position
-  );
-  if (duplicate !== undefined) {
-    return Either.left(`duplicate cell verdict index: ${duplicate}`);
-  }
-  const outOfRange = indices.find((index) => index >= itemCount);
-  return outOfRange === undefined
-    ? Either.right(parsed.right.scores)
-    : Either.left(`cell verdict index out of range: ${outOfRange}`);
+  return Either.isLeft(parsed)
+    ? Either.left(parsed.left)
+    : Either.right(parsed.right.scores);
 }
 
 function parseJson<T>(


### PR DESCRIPTION
## The discard-all failure

WideSearch reshapes the paper evaluator’s dictionary verdicts into arrays for strict structured output. The parser then rejects duplicate alignment origins, duplicate cell indices, unknown origins, unknown transforms, and out-of-range indices. Any one rejected entry replaces the entire completed verdict with an empty fallback, discarding otherwise usable mappings or scores.

The issue is visible across all three tracked engine ladders:

| Engine | Trajectories with any parse failure | Confirmed duplicate-representation failures |
| --- | ---: | ---: |
| Perplexity | 68 / 300 | 64 / 300 |
| Exa | 66 / 300 | 62 / 300 |
| Parallel | 72 / 300 | 63 / 300 |

The official evaluator parses dictionaries without these membership or uniqueness checks. Repeated keys are last-write-wins, unknown origins are inert, and cell score lookup ignores unrelated keys.

## TL;DR

Preserve structurally valid WideSearch verdict entries instead of converting semantic outliers into an empty verdict. Existing downstream `Object.fromEntries` and `Map` construction provide last-write-wins behavior, while unknown origins and unrelated cell indices remain inert. Structural JSON and schema validation still use the existing conservative fallback.

## What Changed?

- Removed whole-verdict rejection for duplicate or out-of-vocabulary alignment entries.
- Removed whole-verdict rejection for duplicate or out-of-range cell indices.
- Kept strict structured-output schemas and malformed-output fallback unchanged.
- Added parser and end-to-end regressions for last-write-wins behavior and inert unrelated entries.

## Why?

The old semantic checks introduced failure states that the paper evaluator’s object format cannot expose after parsing. Keeping structurally valid entries matches its dictionary behavior and prevents one repeated or unrelated entry from erasing the rest of a completed judge result.

This deliberately does not change the judge prompt, structured-output transport, date handling, post-alignment row deduplication, judge model alias, or epoch protocol.

## Validation

- `bun run format:check`
- `bun run check`
- `bun run typecheck`
- `bun test`: 1,174 passed
- `bun run build`

The regressions verify that malformed structure is still rejected, duplicate entries resolve to the last value downstream, unknown alignment origins do not affect known rows, and unrelated cell indices do not affect known cells.

## Reviewer Focus

Check that removing semantic validation preserves the official evaluator’s behavior without weakening structural validation. In particular, unknown transforms are intentionally retained because the upstream evaluator applies parsed dictionary entries without reference-membership validation.