### PR TITLE
fix(search): contain invalid benchmark responses

### DIFF
--- a/src/benchmarks/search/browsecomp/benchmark.test.ts
+++ b/src/benchmarks/search/browsecomp/benchmark.test.ts
@@ -258,14 +258,15 @@ describe("makeBrowseCompSolver", () => {
       lane: makeLane(),
       retry: { maxRetries: 0 },
     });
-    await expect(
-      runPromise(
-        solver(initialTaskState(SAMPLE)).pipe(
-          provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
-        )
+    const state = await runPromise(
+      solver(initialTaskState(SAMPLE)).pipe(
+        provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
       )
-    ).rejects.toThrow("search response had no answer text");
+    );
+    const score = await runPromise(browseCompScorer(state, SAMPLE.target));
     expect(sent).toHaveLength(1);
+    expect(state.output?.completion).toBe("");
+    expect(score.value).toBe(ScoreValue.Incorrect);
   });
 });
 describe("browseCompRunLevelScores", () => {

--- a/src/benchmarks/search/core/solver.test.ts
+++ b/src/benchmarks/search/core/solver.test.ts
@@ -414,6 +414,7 @@ describe("searchSolver", () => {
         return effectSucceed(
           fixtureResult({
             text: "   ",
+            generationTimeMs: 5,
             usage: {
               inputTokens: 10,
               outputTokens: 0,
@@ -435,7 +436,8 @@ describe("searchSolver", () => {
     );
     expect(attempts).toBe(3);
     expect(state.output?.completion).toBe("");
-    expect(state.output?.usage?.totalCost).toBe(0.01);
+    expect(state.output?.usage?.totalCost).toBe(0.03);
+    expect(state.output?.generationTimeMs).toBe(15);
   });
   it("keeps exhausted incomplete responses on the failure path", async () => {
     let attempts = 0;
@@ -446,6 +448,35 @@ describe("searchSolver", () => {
           fixtureResult({ status: "incomplete", text: "partial" })
         );
       },
+    };
+    const solver = searchSolver(service, {
+      model: "m",
+      instructions: "i",
+      lane: LANE,
+      retry: { maxRetries: 2, baseDelayMs: 1 },
+    });
+    const exit = await runSolverExit(
+      solver(initialTaskState({ id: "s", input: "q", target: { text: "t" } }))
+    );
+    expect(attempts).toBe(3);
+    expect(isFailure(exit)).toBe(true);
+  });
+  it("does not recover a later provider error that matches the blank message", async () => {
+    let attempts = 0;
+    const service: ResponsesService = {
+      send: () =>
+        suspend(() => {
+          attempts += 1;
+          return attempts === 1
+            ? effectSucceed(fixtureResult({ text: "" }))
+            : effectFail(
+                new ResponsesError({
+                  message: "search response had no answer text",
+                  status: 503,
+                  retryable: true,
+                })
+              );
+        }),
     };
     const solver = searchSolver(service, {
       model: "m",

--- a/src/benchmarks/search/core/solver.test.ts
+++ b/src/benchmarks/search/core/solver.test.ts
@@ -406,6 +406,37 @@ describe("searchSolver", () => {
     expect(attempts).toBe(3);
     expect(state.output?.completion).toBe("Exact Answer: 42");
   });
+  it("returns the last completed blank response after retries are exhausted", async () => {
+    let attempts = 0;
+    const service: ResponsesService = {
+      send: () => {
+        attempts += 1;
+        return effectSucceed(
+          fixtureResult({
+            text: "   ",
+            usage: {
+              inputTokens: 10,
+              outputTokens: 0,
+              totalTokens: 10,
+              cost: 0.01,
+            },
+          })
+        );
+      },
+    };
+    const solver = searchSolver(service, {
+      model: "m",
+      instructions: "i",
+      lane: LANE,
+      retry: { maxRetries: 2, baseDelayMs: 1 },
+    });
+    const state = await runSolver(
+      solver(initialTaskState({ id: "s", input: "q", target: { text: "t" } }))
+    );
+    expect(attempts).toBe(3);
+    expect(state.output?.completion).toBe("");
+    expect(state.output?.usage?.totalCost).toBe(0.01);
+  });
   it("aborts and retries an attempt that stalls mid-stream", async () => {
     let attempts = 0;
     let aborts = 0;

--- a/src/benchmarks/search/core/solver.test.ts
+++ b/src/benchmarks/search/core/solver.test.ts
@@ -437,6 +437,28 @@ describe("searchSolver", () => {
     expect(state.output?.completion).toBe("");
     expect(state.output?.usage?.totalCost).toBe(0.01);
   });
+  it("keeps exhausted incomplete responses on the failure path", async () => {
+    let attempts = 0;
+    const service: ResponsesService = {
+      send: () => {
+        attempts += 1;
+        return effectSucceed(
+          fixtureResult({ status: "incomplete", text: "partial" })
+        );
+      },
+    };
+    const solver = searchSolver(service, {
+      model: "m",
+      instructions: "i",
+      lane: LANE,
+      retry: { maxRetries: 2, baseDelayMs: 1 },
+    });
+    const exit = await runSolverExit(
+      solver(initialTaskState({ id: "s", input: "q", target: { text: "t" } }))
+    );
+    expect(attempts).toBe(3);
+    expect(isFailure(exit)).toBe(true);
+  });
   it("aborts and retries an attempt that stalls mid-stream", async () => {
     let attempts = 0;
     let aborts = 0;

--- a/src/benchmarks/search/core/solver.ts
+++ b/src/benchmarks/search/core/solver.ts
@@ -1,6 +1,7 @@
 import type { ResponsesRequest, StreamEvents } from "@openrouter/sdk/models";
 import type { Effect } from "effect/Effect";
 import {
+  catchTag,
   fail,
   flatMap,
   gen,
@@ -37,6 +38,8 @@ import { makeSearchProgressTracker } from "./progress";
 import { buildSearchRequestBody } from "./request";
 
 export const DEFAULT_SEARCH_TIMEOUT_MS = 420000;
+
+const EMPTY_SEARCH_RESPONSE_MESSAGE = "search response had no answer text";
 
 export interface SearchSolverOptions {
   readonly model: string;
@@ -154,6 +157,7 @@ function sendWithRetry({
   readonly retryConfig?: RetryConfig;
   readonly timeoutMs: number;
 }): Effect<ResponsesResult, ModelError> {
+  let lastBlankResult: ResponsesResult | undefined;
   return suspend(() => responses.send(body, options())).pipe(
     mapError(toModelError),
     timeoutFail({
@@ -174,16 +178,23 @@ function sendWithRetry({
         );
       }
       if (result.text.trim() === "") {
+        lastBlankResult = result;
         return fail(
           new ModelError({
             status: 503,
-            message: "search response had no answer text",
+            message: EMPTY_SEARCH_RESPONSE_MESSAGE,
           })
         );
       }
       return succeed(result);
     }),
-    retry(rateLimitRetrySchedule(retryConfig ?? {}))
+    retry(rateLimitRetrySchedule(retryConfig ?? {})),
+    catchTag("ModelError", (error) =>
+      error.message === EMPTY_SEARCH_RESPONSE_MESSAGE &&
+      lastBlankResult !== undefined
+        ? succeed(lastBlankResult)
+        : fail(error)
+    )
   );
 }
 

--- a/src/benchmarks/search/core/solver.ts
+++ b/src/benchmarks/search/core/solver.ts
@@ -5,6 +5,7 @@ import {
   fail,
   flatMap,
   gen,
+  map,
   mapError,
   retry,
   succeed,
@@ -36,6 +37,7 @@ import { rateLimitRetrySchedule } from "../../../runtime/retry";
 import type { SearchLaneConfig } from "./config";
 import { makeSearchProgressTracker } from "./progress";
 import { buildSearchRequestBody } from "./request";
+import { mergeModelUsages } from "./usage";
 
 export const DEFAULT_SEARCH_TIMEOUT_MS = 420000;
 
@@ -119,7 +121,7 @@ export function searchSolver(
           versionOverride: opts.versionOverride,
         }),
       });
-      const result = yield* sendWithRetry({
+      const { result, attemptResults } = yield* sendWithRetry({
         responses,
         body,
         options: () => ({
@@ -139,6 +141,7 @@ export function searchSolver(
         state,
         request: body,
         result,
+        attemptResults,
         text: result.text.trim(),
       });
     });
@@ -156,8 +159,16 @@ function sendWithRetry({
   readonly options: () => ResponsesSendOptions;
   readonly retryConfig?: RetryConfig;
   readonly timeoutMs: number;
-}): Effect<ResponsesResult, ModelError> {
+}): Effect<
+  {
+    readonly result: ResponsesResult;
+    readonly attemptResults: readonly ResponsesResult[];
+  },
+  ModelError
+> {
+  const blankResults: ResponsesResult[] = [];
   let lastBlankResult: ResponsesResult | undefined;
+  let lastBlankError: ModelError | undefined;
   return suspend(() => responses.send(body, options())).pipe(
     mapError(toModelError),
     timeoutFail({
@@ -178,23 +189,27 @@ function sendWithRetry({
         );
       }
       if (result.text.trim() === "") {
+        blankResults.push(result);
         lastBlankResult = result;
-        return fail(
-          new ModelError({
-            status: 503,
-            message: EMPTY_SEARCH_RESPONSE_MESSAGE,
-          })
-        );
+        lastBlankError = new ModelError({
+          status: 503,
+          message: EMPTY_SEARCH_RESPONSE_MESSAGE,
+        });
+        return fail(lastBlankError);
       }
       return succeed(result);
     }),
     retry(rateLimitRetrySchedule(retryConfig ?? {})),
     catchTag("ModelError", (error) =>
-      error.message === EMPTY_SEARCH_RESPONSE_MESSAGE &&
-      lastBlankResult !== undefined
+      error === lastBlankError && lastBlankResult !== undefined
         ? succeed(lastBlankResult)
         : fail(error)
-    )
+    ),
+    map((result) => ({
+      result,
+      attemptResults:
+        result.text.trim() === "" ? blankResults : [...blankResults, result],
+    }))
   );
 }
 
@@ -216,18 +231,26 @@ function completedState({
   state,
   request,
   result,
+  attemptResults,
   text,
 }: {
   readonly state: TaskState;
   readonly request: ResponsesRequest;
   readonly result: ResponsesResult;
+  readonly attemptResults: readonly ResponsesResult[];
   readonly text: string;
 }): TaskState {
   const citations = extractCitations(result.output).map(({ url, title }) => ({
     url,
     title,
   }));
-  const usage = usageFromResponses(result.usage);
+  const usage = mergeModelUsages(
+    attemptResults.map((attempt) => usageFromResponses(attempt.usage))
+  );
+  const generationTimeMs = attemptResults.reduce(
+    (total, attempt) => total + attempt.generationTimeMs,
+    0
+  );
   const metadata: SearchSolverMetadata = {
     citations,
     responseStatus: result.status,
@@ -254,8 +277,8 @@ function completedState({
       completion: text,
       message: { role: MessageRole.Assistant, content: text },
       ...(usage !== undefined && { usage }),
-      ...(result.generationTimeMs > 0 && {
-        generationTimeMs: result.generationTimeMs,
+      ...(generationTimeMs > 0 && {
+        generationTimeMs,
       }),
     },
     completed: true,

--- a/src/benchmarks/search/dsqa/benchmark.test.ts
+++ b/src/benchmarks/search/dsqa/benchmark.test.ts
@@ -200,6 +200,7 @@ describe("DSQA benchmark", () => {
     );
     const score = await runPromise(dsqaScorer(state, SAMPLE.target));
     expect(calls).toBe(2);
+    expect(state.output?.usage?.totalCost).toBeCloseTo(0.021, 5);
     expect(score.value).toBe(ScoreValue.Incorrect);
     expect(score.trajectory).toEqual({
       kind: "judge_runs",
@@ -224,6 +225,25 @@ describe("DSQA benchmark", () => {
         },
       ],
     });
+    const metrics = aggregateScores([{ sampleId: SAMPLE.id, epoch: 0, score }]);
+    const run: RunResult = {
+      metrics,
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        reasoningTokens: 0,
+        totalCost: 0,
+        generationTimeMs: 0,
+      },
+      sampleScores: [{ sampleId: SAMPLE.id, epoch: 0, score }],
+    };
+    expect(metrics).toMatchObject({
+      accuracy: 0,
+      totalQuestions: 1,
+      skippedQuestions: 0,
+    });
+    expect(dsqaPrimaryScore(run)).toEqual({ value: 0, weight: 1 });
   });
 });
 

--- a/src/benchmarks/search/dsqa/benchmark.test.ts
+++ b/src/benchmarks/search/dsqa/benchmark.test.ts
@@ -140,7 +140,7 @@ describe("DSQA benchmark", () => {
     const dsqaResult = await runPromise(dsqaScorer(state, SAMPLE.target));
     expect(dsqaResult.value).toBe(ScoreValue.Correct);
   });
-  it("skips judging an empty generated answer", async () => {
+  it("scores a persistent completed blank answer as incorrect after retries", async () => {
     let calls = 0;
     const service: ResponsesService = {
       send: () => {
@@ -152,16 +152,67 @@ describe("DSQA benchmark", () => {
       model: "m",
       instructions: "research it",
       lane: makeLane(),
+      retry: { maxRetries: 2, baseDelayMs: 1 },
+    });
+    const state = await runPromise(
+      solver(initialTaskState(SAMPLE)).pipe(
+        provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
+      )
+    );
+    const score = await runPromise(dsqaScorer(state, SAMPLE.target));
+    expect(calls).toBe(3);
+    expect(state.output?.completion).toBe("");
+    expect(score.value).toBe(ScoreValue.Incorrect);
+    expect(score.explanation).toBe("no verdict");
+  });
+  it("scores an unreadable judge verdict as incorrect with parse evidence", async () => {
+    let calls = 0;
+    const service: ResponsesService = {
+      send: (body) => {
+        calls += 1;
+        const isJudge = body.model === "google/gemini-2.5-flash";
+        return succeed(
+          fixtureResult(isJudge ? "not valid JSON" : "Belgium and France", isJudge)
+        );
+      },
+    };
+    const solver = makeDsqaSolver(service, {
+      model: "m",
+      instructions: "research it",
+      lane: makeLane(),
       retry: { maxRetries: 0 },
     });
-    await expect(
-      runPromise(
-        solver(initialTaskState(SAMPLE)).pipe(
-          provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
-        )
+    const state = await runPromise(
+      solver(initialTaskState(SAMPLE)).pipe(
+        provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
       )
-    ).rejects.toThrow("search response had no answer text");
-    expect(calls).toBe(1);
+    );
+    const score = await runPromise(dsqaScorer(state, SAMPLE.target));
+    expect(calls).toBe(2);
+    expect(score.value).toBe(ScoreValue.Incorrect);
+    expect(score.trajectory).toEqual({
+      kind: "judge_runs",
+      runs: [
+        {
+          kind: "dsqa_grade",
+          verdict: {
+            explanation: "Judge verdict could not be parsed.",
+            correctness_details: {},
+            excessive_answers: [],
+          },
+          error: expect.stringContaining("judge verdict parse failed"),
+          metrics: {
+            precision: 0,
+            recall: 0,
+            f1_score: 0,
+            fully_correct: 0,
+            fully_incorrect: 1,
+            partially_correct: 0,
+            correct_with_extraneous_answers: 0,
+          },
+        },
+      ],
+    });
   });
 });
 

--- a/src/benchmarks/search/dsqa/benchmark.test.ts
+++ b/src/benchmarks/search/dsqa/benchmark.test.ts
@@ -10,6 +10,7 @@ import {
 import type { Sample, TaskState } from "../../../harness/core";
 import { initialTaskState, ScoreValue } from "../../../harness/core";
 import type { SampleScore } from "../../../harness/metric";
+import { aggregateScores } from "../../../harness/metric";
 import type { RunResult } from "../../../harness/run";
 import { assertRight } from "../../../internal/testing";
 import { parseSchema } from "../../../internal/zod";
@@ -164,6 +165,13 @@ describe("DSQA benchmark", () => {
     expect(state.output?.completion).toBe("");
     expect(score.value).toBe(ScoreValue.Incorrect);
     expect(score.explanation).toBe("no verdict");
+    expect(
+      aggregateScores([{ sampleId: SAMPLE.id, epoch: 0, score }])
+    ).toMatchObject({
+      accuracy: 0,
+      totalQuestions: 1,
+      skippedQuestions: 0,
+    });
   });
   it("scores an unreadable judge verdict as incorrect with parse evidence", async () => {
     let calls = 0;
@@ -172,7 +180,10 @@ describe("DSQA benchmark", () => {
         calls += 1;
         const isJudge = body.model === "google/gemini-2.5-flash";
         return succeed(
-          fixtureResult(isJudge ? "not valid JSON" : "Belgium and France", isJudge)
+          fixtureResult(
+            isJudge ? "not valid JSON" : "Belgium and France",
+            isJudge
+          )
         );
       },
     };

--- a/src/benchmarks/search/dsqa/benchmark.ts
+++ b/src/benchmarks/search/dsqa/benchmark.ts
@@ -24,6 +24,7 @@ import { DSQA_JUDGE_CONFIG, DsqaVerdictSchema, dsqaJudgeSpec } from "./grader";
 export const DSQA_BENCHMARK_ID = DSQA_META.id;
 
 const VERDICT_METADATA_KEY = "verdict" as const;
+const VERDICT_ERROR_METADATA_KEY = "verdict_error" as const;
 
 export const DSQA_METRIC_NAMES = [
   "precision",
@@ -61,11 +62,15 @@ const DsqaTrajectoryGradeSchema = z.object({
   kind: z.literal("dsqa_grade"),
   verdict: DsqaVerdictSchema,
   metrics: DsqaMetricsSchema,
+  error: z.string().optional(),
 });
 
 type DsqaTrajectoryGrade = z.infer<typeof DsqaTrajectoryGradeSchema>;
 
-export function calculateDsqaGrade(verdict: DsqaVerdict): DsqaTrajectoryGrade {
+export function calculateDsqaGrade(
+  verdict: DsqaVerdict,
+  error?: string
+): DsqaTrajectoryGrade {
   const details = Object.values(verdict.correctness_details);
   const truePositives = details.filter(Boolean).length;
   const falseNegatives = details.length - truePositives;
@@ -93,6 +98,7 @@ export function calculateDsqaGrade(verdict: DsqaVerdict): DsqaTrajectoryGrade {
   return {
     kind: "dsqa_grade",
     verdict,
+    ...(error !== undefined && { error }),
     metrics: {
       precision,
       recall,
@@ -143,6 +149,9 @@ function judgeStage(
           metadata: {
             ...state.sample.metadata,
             [VERDICT_METADATA_KEY]: judged.verdict,
+            ...(judged.parseError !== undefined && {
+              [VERDICT_ERROR_METADATA_KEY]: judged.parseError,
+            }),
           },
         },
       };
@@ -179,7 +188,11 @@ export function dsqaScorer(
     });
   }
   const verdict: DsqaVerdict = parsed.right;
-  const grade = calculateDsqaGrade(verdict);
+  const verdictError = state.sample.metadata?.[VERDICT_ERROR_METADATA_KEY];
+  const grade = calculateDsqaGrade(
+    verdict,
+    typeof verdictError === "string" ? verdictError : undefined
+  );
   return succeed({
     value:
       grade.metrics.fully_correct === 1

--- a/src/benchmarks/search/dsqa/grader.test.ts
+++ b/src/benchmarks/search/dsqa/grader.test.ts
@@ -71,5 +71,10 @@ describe("DSQA grader", () => {
     });
     expect(spec.schemaName).toBe("dsqa_judge");
     expect(spec.jsonSchema).toBeUndefined();
+    expect(spec.parseFailureFallback).toEqual({
+      explanation: "Judge verdict could not be parsed.",
+      correctness_details: {},
+      excessive_answers: [],
+    });
   });
 });

--- a/src/benchmarks/search/dsqa/grader.ts
+++ b/src/benchmarks/search/dsqa/grader.ts
@@ -80,6 +80,12 @@ export const DsqaVerdictSchema = z.object({
 
 export type DsqaVerdict = z.infer<typeof DsqaVerdictSchema>;
 
+const DSQA_PARSE_FAILURE_VERDICT: DsqaVerdict = {
+  explanation: "Judge verdict could not be parsed.",
+  correctness_details: {},
+  excessive_answers: [],
+};
+
 const RawDsqaVerdictSchema = z.object({
   "Answer Correctness": z.object({
     Explanation: z.string(),
@@ -137,5 +143,6 @@ export function dsqaJudgeSpec(fields: {
     userInput: renderDsqaGraderPrompt(fields),
     schemaName: DSQA_JUDGE_PROMPT_ID,
     parseVerdict: parseDsqaVerdict,
+    parseFailureFallback: DSQA_PARSE_FAILURE_VERDICT,
   };
 }

--- a/src/benchmarks/search/hle/benchmark.test.ts
+++ b/src/benchmarks/search/hle/benchmark.test.ts
@@ -241,14 +241,15 @@ describe("makeHleSolver", () => {
       lane: makeLane(),
       retry: { maxRetries: 0 },
     });
-    await expect(
-      runPromise(
-        solver(initialTaskState(SAMPLE)).pipe(
-          provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
-        )
+    const state = await runPromise(
+      solver(initialTaskState(SAMPLE)).pipe(
+        provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
       )
-    ).rejects.toThrow("search response had no answer text");
+    );
+    const score = await runPromise(hleScorer(state, SAMPLE.target));
     expect(calls).toBe(1);
+    expect(state.output?.completion).toBe("");
+    expect(score.value).toBe(ScoreValue.Incorrect);
   });
 });
 

--- a/src/benchmarks/search/widesearch/benchmark.test.ts
+++ b/src/benchmarks/search/widesearch/benchmark.test.ts
@@ -109,19 +109,24 @@ describe("makeWideSearchSolver", () => {
         return succeed(fixtureResult("", 0.02));
       },
     };
-    await expect(
-      runPromise(
-        makeWideSearchSolver(service, {
-          model: "m",
-          instructions: "research it",
-          lane: lane(),
-          retry: { maxRetries: 0 },
-        })(initialTaskState(SAMPLE)).pipe(
-          provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
-        )
+    const state = await runPromise(
+      makeWideSearchSolver(service, {
+        model: "m",
+        instructions: "research it",
+        lane: lane(),
+        retry: { maxRetries: 0 },
+      })(initialTaskState(SAMPLE)).pipe(
+        provide(mergeAll(noopProgressLayer, noopCheckpointLayer))
       )
-    ).rejects.toThrow("search response had no answer text");
+    );
+    const score = await runPromise(wideSearchScorer(state, SAMPLE.target));
     expect(sent).toHaveLength(1);
+    expect(state.output?.completion).toBe("");
+    expect(score.value).toBe(ScoreValue.Incorrect);
+    expect(score.trajectory).toMatchObject({
+      kind: "judge_runs",
+      runs: [{ metrics: { f1_by_item: 0 } }],
+    });
   });
   it("retries a transient cell-judge failure without repeating generation", async () => {
     let generationCalls = 0;


### PR DESCRIPTION
## Invalid responses cross the wrong failure boundaries

Two search-benchmark outcomes currently inherit generic infrastructure-error behavior:

- A completed response with blank text becomes a retryable `503`. After retries, the harness records it as `Skipped`, removing the question from accuracy and primary-score denominators.
- DeepSearchQA intentionally uses the official free-form judge contract. One malformed verdict becomes a status-less `ModelError`, which is systemic and fails the harness invocation instead of only that sample.

In the internal Temporal worker, the first path can persist a completed aggregate over only the model's nonblank answers. The second path retries the affected chunk activity and can leave a partial run after retry exhaustion.

## TL;DR

Keep bounded retries for completed blank responses, but after exhaustion return the final completed response to normal scoring so all four search suites count it as incorrect. Keep DSQA on the official unstructured judge request, but use the existing parse-fallback contract to emit a zero-credit sample with parse evidence instead of failing the chunk.

## What changed?

### Completed blank responses remain benchmark outcomes

- Retry blank completed responses with the existing schedule.
- Recover only the exact synthetic blank error after the retry budget; later provider or incomplete-response errors remain failures.
- Preserve usage and generation time from every completed blank attempt plus any eventual valid response.
- Let BrowseComp, HLE, DSQA, and WideSearch skip unnecessary judge calls and score exhausted blanks as `Incorrect`.

### DSQA parse failures fail closed per sample

- Keep `jsonSchema` absent, preserving the official Kaggle/paper grader request.
- Supply a DSQA-specific fallback verdict through `parseFailureFallback`.
- Produce precision/recall/F1 `0`, `fully_incorrect: 1`, and primary-score weight `1`.
- Attach the parser error to the existing `judge_runs` trajectory so Parquet and Mission Control retain diagnostic evidence.
- Preserve judge usage/cost on the fallback path.

## Why?

`Skipped` is appropriate for exhausted provider capacity or incomplete transport results, but not for a response that completed and supplied no answer. Likewise, judge-format nondeterminism should not invalidate unrelated samples in the same worker chunk. Both changes keep failure policy at the narrow benchmark-specific boundary instead of weakening global `ModelError` classification.

## Compatibility and sequencing

No exported package path, benchmark config, Temporal payload, or OpenAPI schema changes. Successful DSQA trajectories are unchanged; failed parses add only an optional `error` field.

After merge:

1. Update the pinned benchmark-harness commit in `search-benchmarks`.
2. Re-sync the vendored subtree in `openrouter-web#33074`.
3. Deploy `gcp-bench-worker` only after that updated subtree lands.

## Validation

No paid inference calls were made.

- `bun test`: 1,178 passed.
- `bun run typecheck`: 291 files, zero diagnostics.
- `bun run format:check`: passed.
- `bun run check`: passed with nine pre-existing warnings outside this diff.
- `bun run build`: passed.
- GitHub validate and CodeQL checks: passed.
- Independent defect-first re-review after the final fix: no findings.

Downstream validation used an exact subtree sync of commit `f66108a` into the `openrouter-web#33074` head:

- Subtree integrity: expected and actual tree `35300b5de53e0796cc70e2d2016c1678d2bec4fd`.
- Vendored harness: 104 focused tests passed; typecheck passed.
- Temporal: chunk aggregation tests and typecheck passed.
- `gcp-bench-worker`: typecheck, worker build, and workflow bundle build passed.
- `search-bench-runner`: 29 tests and typecheck passed.
- Trajectory viewer: 7 tests and typecheck passed.
- DSQA run-spec dry run: parsed 10 tasks with the expected $2.50 budget; confirmed no API calls.

## Reviewer focus

- Recovery uses synthetic-error object identity, so a provider error with matching text cannot recover a stale blank response.
- Completed-attempt usage is accumulated without changing incomplete/provider error handling.
- DSQA fallback remains in the macro-F1 denominator and preserves the official unstructured request.
- The optional trajectory error serializes through existing generic Parquet and Mission Control paths.