### PR TITLE
feat: unify Responses prompt caching

### DIFF
--- a/src/benchmarks/search/core/request.ts
+++ b/src/benchmarks/search/core/request.ts
@@ -1,5 +1,4 @@
 import type {
-  AutoRouterPlugin,
   ProviderPreferences,
   ResponsesRequest,
   WebFetchServerTool,
@@ -12,6 +11,7 @@ import type {
 import type { CostTier, ReasoningEffort } from "../../../harness/constants";
 import type { ProviderSort } from "../../../internal/enums";
 import { definedValues } from "../../../internal/guards";
+import { buildAutoRouterPlugin } from "../../../providers/auto-router-plugin";
 import { BENCHMARK_LEAK_EXCLUDED_DOMAINS } from "./blocklist";
 import type { SearchLaneConfig, WebFetchConfig } from "./config";
 
@@ -106,19 +106,10 @@ export function buildSearchRequestBody(
   opts: SearchRequestOptions
 ): ResponsesRequest {
   const { lane } = opts;
-  const autoRouterPlugin: readonly AutoRouterPlugin[] | undefined =
-    opts.model === "openrouter/auto" &&
-    (opts.costQualityTradeoff !== undefined || opts.costTier !== undefined)
-      ? [
-          {
-            id: "auto-router",
-            ...(opts.costQualityTradeoff !== undefined && {
-              costQualityTradeoff: opts.costQualityTradeoff,
-            }),
-            ...(opts.costTier !== undefined && { costTier: opts.costTier }),
-          },
-        ]
-      : undefined;
+  const autoRouterPlugin = buildAutoRouterPlugin(
+    opts.model === "openrouter/auto" ? opts.model : undefined,
+    opts
+  );
   const base: ResponsesRequest = {
     model: opts.model,
     instructions: opts.instructions,
@@ -150,7 +141,10 @@ export function buildSearchRequestBody(
     }),
   };
   if (lane.webSearch === "plugin") {
-    const webPlugins = [...(autoRouterPlugin ?? []), buildWebPlugin(lane)];
+    const webPlugins = [
+      ...(autoRouterPlugin === undefined ? [] : [autoRouterPlugin]),
+      buildWebPlugin(lane),
+    ];
     return { ...base, plugins: webPlugins };
   }
   return {
@@ -159,6 +153,6 @@ export function buildSearchRequestBody(
     ...(lane.maxAgentTurns !== undefined && {
       maxToolCalls: lane.maxAgentTurns,
     }),
-    ...(autoRouterPlugin !== undefined && { plugins: [...autoRouterPlugin] }),
+    ...(autoRouterPlugin !== undefined && { plugins: [autoRouterPlugin] }),
   };
 }

--- a/src/providers/auto-router-plugin.ts
+++ b/src/providers/auto-router-plugin.ts
@@ -1,0 +1,58 @@
+import type { GenerateConfig } from "../harness/model";
+
+interface AutoRouterPluginOptions {
+  readonly costTier?: GenerateConfig["costTier"];
+  readonly costQualityTradeoff?: number;
+  readonly pinModel?: boolean;
+}
+
+export interface AutoRouterPluginConfig {
+  readonly id: "auto-router" | "auto-beta-router";
+  readonly costTier?: GenerateConfig["costTier"];
+  readonly costQualityTradeoff?: number;
+  readonly pinModel?: boolean;
+}
+
+export function buildAutoRouterPlugin(
+  baseModel: string | undefined,
+  options: AutoRouterPluginOptions
+): AutoRouterPluginConfig | undefined {
+  let id: AutoRouterPluginConfig["id"] | undefined;
+  if (baseModel === "openrouter/auto") {
+    id = "auto-router";
+  } else if (baseModel === "openrouter/auto-beta") {
+    id = "auto-beta-router";
+  }
+  if (
+    id === undefined ||
+    (options.costTier === undefined &&
+      options.costQualityTradeoff === undefined &&
+      options.pinModel !== true)
+  ) {
+    return undefined;
+  }
+  return {
+    id,
+    ...(options.costTier !== undefined && { costTier: options.costTier }),
+    ...(options.costQualityTradeoff !== undefined && {
+      costQualityTradeoff: options.costQualityTradeoff,
+    }),
+    ...(options.pinModel === true && { pinModel: true }),
+  };
+}
+
+export function toWireAutoRouterPlugin(plugin: AutoRouterPluginConfig): {
+  readonly id: AutoRouterPluginConfig["id"];
+  readonly cost_tier?: GenerateConfig["costTier"];
+  readonly cost_quality_tradeoff?: number;
+  readonly pin_model?: boolean;
+} {
+  return {
+    id: plugin.id,
+    ...(plugin.costTier !== undefined && { cost_tier: plugin.costTier }),
+    ...(plugin.costQualityTradeoff !== undefined && {
+      cost_quality_tradeoff: plugin.costQualityTradeoff,
+    }),
+    ...(plugin.pinModel === true && { pin_model: true }),
+  };
+}

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -37,6 +37,10 @@ import { parseSchema, z } from "../internal/zod";
 import { recordGenerationId } from "../runtime/generation-ids";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule } from "../runtime/retry";
+import {
+  buildAutoRouterPlugin,
+  toWireAutoRouterPlugin,
+} from "./auto-router-plugin";
 import type { ModelErrorIdentifiers } from "./request-identifiers";
 import {
   appendModelErrorIdentifiers,
@@ -89,32 +93,6 @@ export function makeOpenRouterModelLayer(
   );
 }
 
-function buildAutoRouterPlugin(
-  baseModel: string,
-  genConfig: GenerateConfig
-):
-  | {
-      id: "auto-router" | "auto-beta-router";
-      cost_tier?: GenerateConfig["costTier"];
-      cost_quality_tradeoff?: number;
-      pin_model?: boolean;
-    }
-  | undefined {
-  const hasTier = genConfig.costTier !== undefined;
-  const hasCost = genConfig.costQualityTradeoff !== undefined;
-  const hasPin = genConfig.pinModel === true;
-  if (!hasTier && !hasCost && !hasPin) {
-    return undefined;
-  }
-  return {
-    id:
-      baseModel === "openrouter/auto-beta" ? "auto-beta-router" : "auto-router",
-    ...(hasTier && { cost_tier: genConfig.costTier }),
-    ...(hasCost && { cost_quality_tradeoff: genConfig.costQualityTradeoff }),
-    ...(hasPin && { pin_model: true }),
-  };
-}
-
 interface GenerateOpts {
   readonly model: string;
   readonly messages: readonly ChatMessage[];
@@ -151,11 +129,11 @@ export function generate(
   const hasTimeout =
     genConfig.timeoutMs !== undefined && genConfig.timeoutMs > 0;
   const baseModel = stripVariantSuffix(model);
-  const isAutoRouter =
-    baseModel === "openrouter/auto" || baseModel === "openrouter/auto-beta";
-  const autoRouterPlugin = isAutoRouter
-    ? buildAutoRouterPlugin(baseModel, genConfig)
-    : undefined;
+  const autoRouterPlugin = buildAutoRouterPlugin(baseModel, genConfig);
+  const wireAutoRouterPlugin =
+    autoRouterPlugin === undefined
+      ? undefined
+      : toWireAutoRouterPlugin(autoRouterPlugin);
   return gen(function* () {
     const startedAt = performance.now();
     const body = {
@@ -175,7 +153,9 @@ export function generate(
         reasoning_effort: genConfig.reasoningEffort,
       }),
       ...(sendSort && { provider: { sort: genConfig.sort } }),
-      ...(autoRouterPlugin !== undefined && { plugins: [autoRouterPlugin] }),
+      ...(wireAutoRouterPlugin !== undefined && {
+        plugins: [wireAutoRouterPlugin],
+      }),
       ...genConfig.extraBody,
     };
     const request = HttpClientRequest.post(

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -328,15 +328,15 @@ describe("consumeStream", () => {
   });
 });
 describe("makeResponsesLayer", () => {
-  it("records the generation id and applies prompt caching to every request", async () => {
+  it("records generation ids and applies default or explicit prompt caching", async () => {
     const originalFetch = globalThis.fetch;
     const stream = await readStreamFixture();
-    let capturedBody: unknown;
+    const capturedBodies: unknown[] = [];
     let capturedHeaders: Headers | undefined;
     globalThis.fetch = async (input, init) => {
       const request =
         input instanceof Request ? input : new Request(input, init);
-      capturedBody = await request.clone().json();
+      capturedBodies.push(await request.clone().json());
       capturedHeaders = request.headers;
       return new Response(stream, {
         status: 200,
@@ -353,6 +353,15 @@ describe("makeResponsesLayer", () => {
                 { model: "m", input: [] },
                 { timeoutMs: 1000 }
               );
+              yield* responses.send(
+                { model: "m", input: [] },
+                {
+                  timeoutMs: 1000,
+                  extraBody: {
+                    cache_control: { type: "ephemeral", ttl: "1h" },
+                  },
+                }
+              );
             })
           ),
           flatMap(() => getCollectedGenerationIds),
@@ -365,8 +374,12 @@ describe("makeResponsesLayer", () => {
         )
       );
       expect(ids).toEqual(["gen-1784161874-CXX4U5I6Ej7Z5hTnf0wU"]);
-      expect(capturedBody).toMatchObject({
+      expect(capturedBodies[0]).toMatchObject({
         cache_control: { type: "ephemeral" },
+        stream: true,
+      });
+      expect(capturedBodies[1]).toMatchObject({
+        cache_control: { type: "ephemeral", ttl: "1h" },
         stream: true,
       });
       expect(capturedHeaders?.get("http-referer")).toBe(

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -328,14 +328,21 @@ describe("consumeStream", () => {
   });
 });
 describe("makeResponsesLayer", () => {
-  it("records the generation id from a completed response", async () => {
+  it("records the generation id and applies prompt caching to every request", async () => {
     const originalFetch = globalThis.fetch;
     const stream = await readStreamFixture();
-    globalThis.fetch = async () =>
-      new Response(stream, {
+    let capturedBody: unknown;
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = async (input, init) => {
+      const request =
+        input instanceof Request ? input : new Request(input, init);
+      capturedBody = await request.clone().json();
+      capturedHeaders = request.headers;
+      return new Response(stream, {
         status: 200,
         headers: { "content-type": "text/event-stream" },
       });
+    };
     try {
       const ids = await runPromise(
         resetGenerationIds.pipe(
@@ -358,6 +365,16 @@ describe("makeResponsesLayer", () => {
         )
       );
       expect(ids).toEqual(["gen-1784161874-CXX4U5I6Ej7Z5hTnf0wU"]);
+      expect(capturedBody).toMatchObject({
+        cache_control: { type: "ephemeral" },
+        stream: true,
+      });
+      expect(capturedHeaders?.get("http-referer")).toBe(
+        "https://bench-harness.openrouter.ai/"
+      );
+      expect(capturedHeaders?.get("x-openrouter-title")).toBe(
+        "OpenRouter: Bench Harness"
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -417,4 +417,36 @@ describe("makeResponsesLayer", () => {
       globalThis.fetch = originalFetch;
     }
   });
+  it("classifies malformed SSE as a retryable response failure", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response("data: {not-json}\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    try {
+      const exit = await runPromiseExit(
+        gen(function* run() {
+          const responses = yield* Responses;
+          return yield* responses.send(
+            { model: "m", input: [] },
+            { timeoutMs: 1000 }
+          );
+        }).pipe(
+          provide(
+            makeResponsesLayer({
+              apiKey: "sk-test",
+              baseUrl: "https://example.test",
+            })
+          )
+        )
+      );
+      assertFailure(exit);
+      const error = getOrThrow(failureOption(exit.cause));
+      expect(error.status).toBe(500);
+      expect(error.retryable).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -4,7 +4,15 @@ import type {
   ResponsesRequest,
   StreamEvents,
 } from "@openrouter/sdk/models";
+import {
+  ConnectionError,
+  InvalidRequestError,
+  RequestAbortedError,
+  RequestTimeoutError,
+  UnexpectedClientError,
+} from "@openrouter/sdk/models/errors/httpclienterrors";
 import { OpenRouterError } from "@openrouter/sdk/models/errors/openroutererror";
+import { SDKValidationError } from "@openrouter/sdk/models/errors/sdkvalidationerror";
 import { Responses as ResponsesClient } from "@openrouter/sdk/sdk/responses";
 import { Tag } from "effect/Context";
 import { TaggedError } from "effect/Data";
@@ -18,6 +26,10 @@ import { ModelError } from "../harness/core";
 import { isRecord } from "../internal/guards";
 import { z } from "../internal/zod";
 import { recordGenerationId } from "../runtime/generation-ids";
+import {
+  BENCH_HARNESS_APP_REFERRER,
+  BENCH_HARNESS_APP_TITLE,
+} from "./openrouter-model";
 import type { ModelErrorIdentifiers } from "./request-identifiers";
 import {
   appendModelErrorIdentifiers,
@@ -40,9 +52,11 @@ export const ResponsesResultSchema = z.object({
 export type ResponsesResult = z.infer<typeof ResponsesResultSchema>;
 
 export interface ResponsesSendOptions {
-  readonly timeoutMs: number;
+  readonly timeoutMs?: number;
   readonly versionOverride?: string;
   readonly extraHeaders?: Readonly<Record<string, string>>;
+  readonly extraBody?: Readonly<Record<string, unknown>>;
+  readonly onResponseIdentifiers?: (identifiers: ModelErrorIdentifiers) => void;
   readonly onStreamEvent?: (event: StreamEvents) => void;
 }
 
@@ -59,6 +73,7 @@ export class ResponsesError extends TaggedError("ResponsesError")<
   {
     readonly message: string;
     readonly status?: number;
+    readonly retryAfterMs?: number;
     readonly retryable: boolean;
   } & ModelErrorIdentifiers
 > {}
@@ -68,6 +83,9 @@ export function toModelError(error: ResponsesError): ModelError {
   return new ModelError({
     message: error.message,
     ...(status !== undefined && { status }),
+    ...(error.retryAfterMs !== undefined && {
+      retryAfterMs: error.retryAfterMs,
+    }),
     ...pickModelErrorIdentifiers(error),
   });
 }
@@ -104,10 +122,10 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     let identifiers: ModelErrorIdentifiers = {};
     const httpClient = new HTTPClient({
       fetcher: async (input, init) => {
-        const response = await (init === undefined
-          ? fetch(input)
-          : fetch(input, init));
+        const request = await mergeExtraBody(input, init, options.extraBody);
+        const response = await fetch(request);
         identifiers = modelErrorIdentifiersFromFetchHeaders(response.headers);
+        options.onResponseIdentifiers?.(identifiers);
         return response;
       },
     });
@@ -120,6 +138,8 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
       }),
     });
     const headers: Record<string, string> = {
+      "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
+      "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
       ...options.extraHeaders,
       ...(options.versionOverride
         ? { [VERSION_OVERRIDE_HEADER]: `api="${options.versionOverride}"` }
@@ -131,8 +151,13 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     return tryPromise({
       try: async (signal) => {
         identifiers = {};
+        const requestBody = {
+          ...body,
+          cacheControl: body.cacheControl ?? { type: "ephemeral" },
+          stream: true,
+        } satisfies ResponsesRequest;
         const stream = await client.send(
-          { responsesRequest: { ...body, stream: true } },
+          { responsesRequest: requestBody },
           {
             fetchOptions: { signal },
             ...(options.timeoutMs !== undefined && {
@@ -170,6 +195,31 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
   return layerSucceed(Responses, Responses.of({ send }));
 }
 
+async function mergeExtraBody(
+  input: string | URL | Request,
+  init: RequestInit | undefined,
+  extraBody: Readonly<Record<string, unknown>> | undefined
+): Promise<Request> {
+  const request = input instanceof Request ? input : new Request(input, init);
+  if (extraBody === undefined) {
+    return request;
+  }
+  const parsed: unknown = JSON.parse(await request.clone().text());
+  if (!isRecord(parsed)) {
+    return request;
+  }
+  return new Request(request, {
+    method: "POST",
+    body: JSON.stringify({
+      ...parsed,
+      ...extraBody,
+      ...(parsed["cache_control"] !== undefined && {
+        cache_control: parsed["cache_control"],
+      }),
+    }),
+  });
+}
+
 function isAsyncIterable(value: unknown): value is AsyncIterable<StreamEvents> {
   return (
     typeof value === "object" &&
@@ -191,37 +241,42 @@ export async function consumeStream(
     for await (const event of stream) {
       onEvent?.(event);
       const eventRecord: unknown = event;
-      const eventResponse = isRecord(eventRecord)
-        ? eventRecord["response"]
+      const rawEvent =
+        isRecord(eventRecord) && isRecord(eventRecord["raw"])
+          ? eventRecord["raw"]
+          : eventRecord;
+      const eventResponse = isRecord(rawEvent)
+        ? rawEvent["response"]
         : undefined;
       if (isRecord(eventResponse) && typeof eventResponse["id"] === "string") {
         Object.assign(identifiers, { generationId: eventResponse["id"] });
+      }
+      const rawType = isRecord(rawEvent) ? rawEvent["type"] : undefined;
+      if (rawType === "response.failed") {
+        throw new ResponsesError({
+          message: appendModelErrorIdentifiers(
+            `OpenRouter stream error: ${extractResponseError(eventResponse)}`,
+            identifiers
+          ),
+          retryable: true,
+          ...identifiers,
+        });
+      }
+      if (rawType === "error") {
+        throw new ResponsesError({
+          message: appendModelErrorIdentifiers(
+            `OpenRouter stream error: ${isRecord(rawEvent) ? String(rawEvent["message"]) : String(rawEvent)}`,
+            identifiers
+          ),
+          retryable: true,
+          ...identifiers,
+        });
       }
       switch (event.type) {
         case "response.completed":
         case "response.incomplete": {
           finalResponse = event.response;
           break;
-        }
-        case "response.failed": {
-          throw new ResponsesError({
-            message: appendModelErrorIdentifiers(
-              `OpenRouter stream error: ${extractResponseError(event.response)}`,
-              identifiers
-            ),
-            retryable: true,
-            ...identifiers,
-          });
-        }
-        case "error": {
-          throw new ResponsesError({
-            message: appendModelErrorIdentifiers(
-              `OpenRouter stream error: ${event.message}`,
-              identifiers
-            ),
-            retryable: true,
-            ...identifiers,
-          });
         }
       }
     }
@@ -426,14 +481,47 @@ function toResponsesError(
       ...identifiers,
       ...modelErrorIdentifiersFromFetchHeaders(cause.headers),
     };
+    const retryAfterMs = parseRetryAfter(cause.headers.get("retry-after"));
     return new ResponsesError({
       message: appendModelErrorIdentifiers(
         `OpenRouter HTTP ${cause.statusCode}: ${cause.body}`,
         errorIdentifiers
       ),
       status: cause.statusCode,
+      ...(retryAfterMs !== undefined && { retryAfterMs }),
       retryable: cause.statusCode === 429 || cause.statusCode >= 500,
       ...errorIdentifiers,
+    });
+  }
+  if (
+    cause instanceof RequestAbortedError ||
+    cause instanceof RequestTimeoutError
+  ) {
+    return new ResponsesError({
+      message: appendModelErrorIdentifiers(cause.message, identifiers),
+      status: 408,
+      retryable: true,
+      ...identifiers,
+    });
+  }
+  if (
+    cause instanceof ConnectionError ||
+    cause instanceof UnexpectedClientError ||
+    cause instanceof SDKValidationError
+  ) {
+    return new ResponsesError({
+      message: appendModelErrorIdentifiers(cause.message, identifiers),
+      status: 500,
+      retryable: true,
+      ...identifiers,
+    });
+  }
+  if (cause instanceof InvalidRequestError) {
+    return new ResponsesError({
+      message: appendModelErrorIdentifiers(cause.message, identifiers),
+      status: 400,
+      retryable: false,
+      ...identifiers,
     });
   }
   if (cause instanceof TypeError) {
@@ -455,6 +543,7 @@ function toResponsesError(
         "Wall-clock timeout (request aborted)",
         identifiers
       ),
+      status: 408,
       retryable: true,
       ...identifiers,
     });
@@ -467,4 +556,12 @@ function toResponsesError(
     retryable: false,
     ...identifiers,
   });
+}
+
+function parseRetryAfter(value: string | null): number | undefined {
+  if (value === null) {
+    return undefined;
+  }
+  const seconds = Number(value);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1e3 : undefined;
 }

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -153,7 +153,10 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
         identifiers = {};
         const requestBody = {
           ...body,
-          cacheControl: body.cacheControl ?? { type: "ephemeral" },
+          ...(body.cacheControl === undefined &&
+            options.extraBody?.["cache_control"] === undefined && {
+              cacheControl: { type: "ephemeral" as const },
+            }),
           stream: true,
         } satisfies ResponsesRequest;
         const stream = await client.send(
@@ -204,7 +207,12 @@ async function mergeExtraBody(
   if (extraBody === undefined) {
     return request;
   }
-  const parsed: unknown = JSON.parse(await request.clone().text());
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await request.clone().text());
+  } catch {
+    return request;
+  }
   if (!isRecord(parsed)) {
     return request;
   }
@@ -213,11 +221,12 @@ async function mergeExtraBody(
     body: JSON.stringify({
       ...parsed,
       ...extraBody,
-      ...(parsed["cache_control"] !== undefined && {
-        cache_control: parsed["cache_control"],
-      }),
     }),
   });
+}
+
+export function unwrapStreamEvent(event: unknown): unknown {
+  return isRecord(event) && isRecord(event["raw"]) ? event["raw"] : event;
 }
 
 function isAsyncIterable(value: unknown): value is AsyncIterable<StreamEvents> {
@@ -240,11 +249,7 @@ export async function consumeStream(
   try {
     for await (const event of stream) {
       onEvent?.(event);
-      const eventRecord: unknown = event;
-      const rawEvent =
-        isRecord(eventRecord) && isRecord(eventRecord["raw"])
-          ? eventRecord["raw"]
-          : eventRecord;
+      const rawEvent = unwrapStreamEvent(event);
       const eventResponse = isRecord(rawEvent)
         ? rawEvent["response"]
         : undefined;
@@ -524,10 +529,7 @@ function toResponsesError(
       ...identifiers,
     });
   }
-  if (
-    cause instanceof SyntaxError ||
-    (cause instanceof Error && cause.name === "ZodError")
-  ) {
+  if (cause instanceof SyntaxError || cause instanceof z.ZodError) {
     return new ResponsesError({
       message: appendModelErrorIdentifiers(cause.message, identifiers),
       status: 500,

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -524,6 +524,17 @@ function toResponsesError(
       ...identifiers,
     });
   }
+  if (
+    cause instanceof SyntaxError ||
+    (cause instanceof Error && cause.name === "ZodError")
+  ) {
+    return new ResponsesError({
+      message: appendModelErrorIdentifiers(cause.message, identifiers),
+      status: 500,
+      retryable: true,
+      ...identifiers,
+    });
+  }
   if (cause instanceof TypeError) {
     return new ResponsesError({
       message: appendModelErrorIdentifiers(

--- a/src/providers/responses-model.test.ts
+++ b/src/providers/responses-model.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { readFile } from "node:fs/promises";
 
 import { FetchHttpClient } from "@effect/platform";
+import type { ResponsesRequest } from "@openrouter/sdk/models";
 import { failureOption } from "effect/Cause";
 import { flatMap, gen, provide, runPromiseExit, succeed } from "effect/Effect";
 import { provide as layerProvide } from "effect/Layer";
@@ -101,6 +102,42 @@ function readStreamFixture(): Promise<string> {
     "utf8"
   );
 }
+
+const FUNCTION_CALL_OUTPUT = {
+  type: "function_call",
+  id: "fc_1",
+  call_id: "call_1",
+  status: "completed",
+  name: "bash",
+  arguments: '{"command":"pwd"}',
+};
+
+function withFunctionCallOutput(stream: string): string {
+  return stream
+    .split("\n")
+    .map((line) => {
+      if (!line.startsWith("data: ") || line === "data: [DONE]") {
+        return line;
+      }
+      const event: unknown = JSON.parse(line.slice(6));
+      if (!isRecord(event) || event["type"] !== "response.completed") {
+        return line;
+      }
+      const response = event["response"];
+      if (!isRecord(response) || !Array.isArray(response["output"])) {
+        return line;
+      }
+      return `data: ${JSON.stringify({
+        ...event,
+        response: {
+          ...response,
+          output: [...response["output"], FUNCTION_CALL_OUTPUT],
+        },
+      })}`;
+    })
+    .join("\n");
+}
+
 describe("responses-model", () => {
   let restore: (() => void) | undefined;
   afterEach(() => {
@@ -109,7 +146,7 @@ describe("responses-model", () => {
   });
   it("builds a Responses request and parses output items, calls, text, and usage", async () => {
     const terminal = await readTerminalFixture();
-    const stream = await readStreamFixture();
+    const stream = withFunctionCallOutput(await readStreamFixture());
     const captured: {
       value: CapturedRequest | undefined;
     } = { value: undefined };
@@ -177,8 +214,13 @@ describe("responses-model", () => {
       provider: { sort: "price" },
       custom_field: "value",
     });
-    expect(exit.value.turn.outputItems).toEqual(terminal.output);
-    expect(exit.value.turn.functionCalls).toEqual([]);
+    expect(exit.value.turn.outputItems).toEqual([
+      ...terminal.output,
+      FUNCTION_CALL_OUTPUT,
+    ]);
+    expect(exit.value.turn.functionCalls).toEqual([
+      { callId: "call_1", name: "bash", arguments: '{"command":"pwd"}' },
+    ]);
     expect(exit.value.turn.text).toBe("4");
     expect(exit.value.turn.usage).toEqual(usageFromResponses(terminal.usage));
     expect(exit.value.generationIds).toEqual([
@@ -196,9 +238,11 @@ describe("responses-model", () => {
     expect(captured.value?.headers["x-session-id"]).toBe("session-1");
   });
   it("preserves legacy checkpoint items and maps SDK function calls", async () => {
+    let sentBody: ResponsesRequest | undefined;
     let sentOptions: ResponsesSendOptions | undefined;
     const responses: ResponsesService = {
-      send: (_body, options) => {
+      send: (body, options) => {
+        sentBody = body;
         sentOptions = options;
         return succeed({
           id: "resp-1",
@@ -215,6 +259,7 @@ describe("responses-model", () => {
               type: "openrouter:fusion",
               failedModels: [{ model: "model-a", statusCode: 503 }],
               failureReason: "all_panels_failed",
+              futureSdkField: "preserved",
               output: { statusCode: 200 },
             },
           ],
@@ -232,7 +277,12 @@ describe("responses-model", () => {
           model: "openai/gpt-5",
           input: [
             { type: "function_call_output", call_id: "call-0", output: "ok" },
-            { type: "reasoning", encrypted_content: "opaque" },
+            {
+              type: "reasoning",
+              id: "reasoning-1",
+              summary: [],
+              encrypted_content: "opaque",
+            },
           ],
           genConfig: {},
         },
@@ -240,17 +290,20 @@ describe("responses-model", () => {
       )
     );
     assertSuccess(exit);
-    expect(sentOptions?.extraBody?.["input"]).toEqual([
+    expect(sentBody?.input).toEqual([
       {
         type: "function_call_output",
-        call_id: "call-0",
+        callId: "call-0",
         output: "ok",
       },
       {
         type: "reasoning",
-        encrypted_content: "opaque",
+        id: "reasoning-1",
+        summary: [],
+        encryptedContent: "opaque",
       },
     ]);
+    expect(sentOptions?.extraBody).toBeUndefined();
     expect(exit.value.outputItems).toEqual([
       {
         type: "function_call",
@@ -262,6 +315,7 @@ describe("responses-model", () => {
         type: "openrouter:fusion",
         failed_models: [{ model: "model-a", status_code: 503 }],
         failure_reason: "all_panels_failed",
+        future_sdk_field: "preserved",
         output: { statusCode: 200 },
       },
     ]);

--- a/src/providers/responses-model.test.ts
+++ b/src/providers/responses-model.test.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 
 import { FetchHttpClient } from "@effect/platform";
 import { failureOption } from "effect/Cause";
-import { flatMap, gen, provide, runPromiseExit } from "effect/Effect";
+import { flatMap, gen, provide, runPromiseExit, succeed } from "effect/Effect";
 import { provide as layerProvide } from "effect/Layer";
 import { getOrThrow } from "effect/Option";
 
@@ -16,8 +16,16 @@ import {
   getCollectedGenerationIds,
   resetGenerationIds,
 } from "../runtime/generation-ids";
+import type {
+  ResponsesSendOptions,
+  ResponsesService,
+} from "./responses-client";
 import { usageFromResponses } from "./responses-client";
-import { ResponsesModel, makeResponsesModelLayer } from "./responses-model";
+import {
+  generate,
+  ResponsesModel,
+  makeResponsesModelLayer,
+} from "./responses-model";
 
 interface CapturedRequest {
   readonly url: string;
@@ -64,49 +72,6 @@ function installFetchStub(
   };
 }
 
-const OUTPUT = [
-  {
-    type: "reasoning",
-    encrypted_content: "opaque-encrypted",
-  },
-  {
-    type: "openrouter:advisor",
-    advice: "keep going",
-  },
-  {
-    type: "function_call",
-    id: "fc_1",
-    call_id: "call_1",
-    name: "bash",
-    arguments: '{"command":"pwd"}',
-  },
-  {
-    type: "message",
-    content: [
-      { type: "output_text", text: "hello " },
-      { type: "output_text", text: "world" },
-    ],
-  },
-];
-
-const RESPONSE = JSON.stringify({
-  id: "resp_1",
-  output: OUTPUT,
-  usage: {
-    input_tokens: 10,
-    output_tokens: 5,
-    total_tokens: 15,
-    output_tokens_details: { reasoning_tokens: 2 },
-    cost: 0.01,
-  },
-});
-
-const SSE_RESPONSE = [
-  `data: ${JSON.stringify({ type: "response.output_item.added", output_index: 0 })}`,
-  `data: ${JSON.stringify({ type: "response.completed", response: JSON.parse(RESPONSE) })}`,
-  "",
-].join("\n\n");
-
 const TerminalFixtureSchema = z.object({
   output: z.array(z.record(z.string(), z.unknown())),
   usage: z.record(z.string(), z.unknown()),
@@ -143,10 +108,12 @@ describe("responses-model", () => {
     restore = undefined;
   });
   it("builds a Responses request and parses output items, calls, text, and usage", async () => {
+    const terminal = await readTerminalFixture();
+    const stream = await readStreamFixture();
     const captured: {
       value: CapturedRequest | undefined;
     } = { value: undefined };
-    restore = installFetchStub(SSE_RESPONSE, 200, captured);
+    restore = installFetchStub(stream, 200, captured);
     const input = [
       { role: "user", content: "solve this" },
       { type: "function_call_output", call_id: "call_0", output: "ok" },
@@ -193,6 +160,7 @@ describe("responses-model", () => {
       input,
       stream: true,
       store: false,
+      cache_control: { type: "ephemeral" },
       include: ["reasoning.encrypted_content"],
       instructions: "Use bash.",
       tools: [
@@ -209,19 +177,13 @@ describe("responses-model", () => {
       provider: { sort: "price" },
       custom_field: "value",
     });
-    expect(exit.value.turn.outputItems).toEqual(OUTPUT);
-    expect(exit.value.turn.functionCalls).toEqual([
-      { callId: "call_1", name: "bash", arguments: '{"command":"pwd"}' },
+    expect(exit.value.turn.outputItems).toEqual(terminal.output);
+    expect(exit.value.turn.functionCalls).toEqual([]);
+    expect(exit.value.turn.text).toBe("4");
+    expect(exit.value.turn.usage).toEqual(usageFromResponses(terminal.usage));
+    expect(exit.value.generationIds).toEqual([
+      "gen-1784161874-CXX4U5I6Ej7Z5hTnf0wU",
     ]);
-    expect(exit.value.turn.text).toBe("hello world");
-    expect(exit.value.turn.usage).toEqual({
-      inputTokens: 10,
-      outputTokens: 5,
-      totalTokens: 15,
-      reasoningTokens: 2,
-      totalCost: 0.01,
-    });
-    expect(exit.value.generationIds).toEqual(["resp_1"]);
     expect(captured.value?.headers["http-referer"]).toBe(
       "https://bench-harness.openrouter.ai/"
     );
@@ -233,11 +195,77 @@ describe("responses-model", () => {
     ).toBe("ver-1");
     expect(captured.value?.headers["x-session-id"]).toBe("session-1");
   });
+  it("preserves legacy checkpoint items and maps SDK function calls", async () => {
+    let sentOptions: ResponsesSendOptions | undefined;
+    const responses: ResponsesService = {
+      send: (_body, options) => {
+        sentOptions = options;
+        return succeed({
+          id: "resp-1",
+          model: "openai/gpt-5",
+          status: "completed",
+          output: [
+            {
+              type: "function_call",
+              callId: "call-1",
+              name: "bash",
+              arguments: '{"command":"pwd"}',
+            },
+          ],
+          usage: null,
+          text: "",
+          generationId: "resp-1",
+          provider: "OpenAI",
+          generationTimeMs: 1,
+        });
+      },
+    };
+    const exit = await runPromiseExit(
+      generate(
+        {
+          model: "openai/gpt-5",
+          input: [
+            { type: "function_call_output", call_id: "call-0", output: "ok" },
+            { type: "reasoning", encrypted_content: "opaque" },
+          ],
+          genConfig: {},
+        },
+        responses
+      )
+    );
+    assertSuccess(exit);
+    expect(sentOptions?.extraBody?.["input"]).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call-0",
+        output: "ok",
+      },
+      {
+        type: "reasoning",
+        encrypted_content: "opaque",
+      },
+    ]);
+    expect(exit.value.outputItems).toEqual([
+      {
+        type: "function_call",
+        call_id: "call-1",
+        name: "bash",
+        arguments: '{"command":"pwd"}',
+      },
+    ]);
+    expect(exit.value.functionCalls).toEqual([
+      {
+        callId: "call-1",
+        name: "bash",
+        arguments: '{"command":"pwd"}',
+      },
+    ]);
+  });
   it("sends provider sort only when endpoint pinning is absent", async () => {
     const captured: {
       value: CapturedRequest | undefined;
     } = { value: undefined };
-    restore = installFetchStub(SSE_RESPONSE, 200, captured);
+    restore = installFetchStub(await readStreamFixture(), 200, captured);
     const layer = makeResponsesModelLayer({
       model: "openai/gpt-5",
       apiKey: "sk-test",
@@ -264,7 +292,7 @@ describe("responses-model", () => {
       const captured: {
         value: CapturedRequest | undefined;
       } = { value: undefined };
-      restore = installFetchStub(SSE_RESPONSE, 200, captured);
+      restore = installFetchStub(await readStreamFixture(), 200, captured);
       const layer = makeResponsesModelLayer({ model, apiKey: "sk-test" });
       const exit = await runPromiseExit(
         gen(function* run() {
@@ -282,7 +310,7 @@ describe("responses-model", () => {
     const captured: {
       value: CapturedRequest | undefined;
     } = { value: undefined };
-    restore = installFetchStub(SSE_RESPONSE, 200, captured);
+    restore = installFetchStub(await readStreamFixture(), 200, captured);
     const layer = makeResponsesModelLayer({
       model: "openrouter/auto",
       apiKey: "sk-test",
@@ -305,7 +333,7 @@ describe("responses-model", () => {
     const captured: {
       value: CapturedRequest | undefined;
     } = { value: undefined };
-    restore = installFetchStub(SSE_RESPONSE, 200, captured);
+    restore = installFetchStub(await readStreamFixture(), 200, captured);
     const layer = makeResponsesModelLayer({
       model: "openrouter/auto",
       apiKey: "sk-test",

--- a/src/providers/responses-model.test.ts
+++ b/src/providers/responses-model.test.ts
@@ -211,6 +211,12 @@ describe("responses-model", () => {
               name: "bash",
               arguments: '{"command":"pwd"}',
             },
+            {
+              type: "openrouter:fusion",
+              failedModels: [{ model: "model-a", statusCode: 503 }],
+              failureReason: "all_panels_failed",
+              output: { statusCode: 200 },
+            },
           ],
           usage: null,
           text: "",
@@ -251,6 +257,12 @@ describe("responses-model", () => {
         call_id: "call-1",
         name: "bash",
         arguments: '{"command":"pwd"}',
+      },
+      {
+        type: "openrouter:fusion",
+        failed_models: [{ model: "model-a", status_code: 503 }],
+        failure_reason: "all_panels_failed",
+        output: { statusCode: 200 },
       },
     ]);
     expect(exit.value.functionCalls).toEqual([

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -27,6 +27,7 @@ import { stripVariantSuffix } from "../harness/model";
 import { isRecord } from "../internal/guards";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule } from "../runtime/retry";
+import { buildAutoRouterPlugin } from "./auto-router-plugin";
 import type { ModelErrorIdentifiers } from "./request-identifiers";
 import { appendModelErrorIdentifiers } from "./request-identifiers";
 import type { ResponsesResult, ResponsesService } from "./responses-client";
@@ -124,34 +125,6 @@ export interface ResponsesGenerateOpts {
   readonly onStreamEvent?: (event: Record<string, unknown>) => void;
 }
 
-function buildAutoRouterPlugin(
-  baseModel: string,
-  genConfig: ResponsesGenerateConfig,
-  isAutoRouter: boolean
-):
-  | {
-      id: "auto-router" | "auto-beta-router";
-      costTier?: GenerateConfig["costTier"];
-      costQualityTradeoff?: number;
-    }
-  | undefined {
-  if (
-    !isAutoRouter ||
-    (genConfig.costTier === undefined &&
-      genConfig.costQualityTradeoff === undefined)
-  ) {
-    return undefined;
-  }
-  return {
-    id:
-      baseModel === "openrouter/auto-beta" ? "auto-beta-router" : "auto-router",
-    ...(genConfig.costTier !== undefined && { costTier: genConfig.costTier }),
-    ...(genConfig.costQualityTradeoff !== undefined && {
-      costQualityTradeoff: genConfig.costQualityTradeoff,
-    }),
-  };
-}
-
 export function generate(
   opts: ResponsesGenerateOpts,
   responses: ResponsesService
@@ -160,13 +133,7 @@ export function generate(
   const sendSort =
     genConfig.sort !== undefined && genConfig.endpointId === undefined;
   const baseModel = stripVariantSuffix(opts.model);
-  const isAutoRouter =
-    baseModel === "openrouter/auto" || baseModel === "openrouter/auto-beta";
-  const autoRouterPlugin = buildAutoRouterPlugin(
-    baseModel,
-    genConfig,
-    isAutoRouter
-  );
+  const autoRouterPlugin = buildAutoRouterPlugin(baseModel, genConfig);
   const body = {
     model: opts.model,
     input: toSdkInput(opts.input),

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -84,9 +84,10 @@ export class ResponsesModel extends Tag(
 export function makeResponsesModelLayer(
   config: ResponsesModelConfig
 ): Layer<ResponsesModel> {
+  const baseUrl = config.baseUrl ?? "https://openrouter.ai/api/v1";
   const responsesLayer = makeResponsesLayer({
     apiKey: config.apiKey,
-    ...(config.baseUrl !== undefined && { baseUrl: config.baseUrl }),
+    baseUrl,
     ...(config.sessionId !== undefined && { sessionId: config.sessionId }),
   });
   return effect(ResponsesModel)(
@@ -251,14 +252,41 @@ export function generate(
 function toLegacyOutputItem(
   item: Readonly<Record<string, unknown>>
 ): Record<string, unknown> {
-  const { callId, encryptedContent, ...legacyItem } = item;
-  return {
-    ...legacyItem,
-    ...(typeof callId === "string" && { call_id: callId }),
-    ...(typeof encryptedContent === "string" && {
-      encrypted_content: encryptedContent,
-    }),
-  };
+  return toWireRecord(item);
+}
+
+const WIRE_KEY_BY_SDK_KEY: Readonly<Record<string, string>> = {
+  callId: "call_id",
+  encryptedContent: "encrypted_content",
+  endIndex: "end_index",
+  failedModels: "failed_models",
+  failureReason: "failure_reason",
+  fileId: "file_id",
+  instanceName: "instance_name",
+  startIndex: "start_index",
+  statusCode: "status_code",
+  taskDescription: "task_description",
+  taskName: "task_name",
+};
+
+const RAW_PAYLOAD_KEYS = new Set(["arguments", "output"]);
+
+function toWireRecord(
+  record: Readonly<Record<string, unknown>>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      WIRE_KEY_BY_SDK_KEY[key] ?? key,
+      RAW_PAYLOAD_KEYS.has(key) ? value : toWireValue(value),
+    ])
+  );
+}
+
+function toWireValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(toWireValue);
+  }
+  return isRecord(value) ? toWireRecord(value) : value;
 }
 
 function toResponsesTurn(

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -1,4 +1,9 @@
-import type { ResponsesRequest, StreamEvents } from "@openrouter/sdk/models";
+import type {
+  InputsUnion,
+  ResponsesRequest,
+  StreamEvents,
+} from "@openrouter/sdk/models";
+import { camelCase, snakeCase } from "change-case";
 import { Tag } from "effect/Context";
 import { millis } from "effect/Duration";
 import type { Effect } from "effect/Effect";
@@ -30,6 +35,7 @@ import {
   makeResponsesLayer,
   Responses,
   toModelError,
+  unwrapStreamEvent,
   usageFromResponses,
 } from "./responses-client";
 
@@ -163,6 +169,7 @@ export function generate(
   );
   const body = {
     model: opts.model,
+    input: toSdkInput(opts.input),
     store: false,
     include: ["reasoning.encrypted_content"],
     ...(genConfig.instructions !== undefined && {
@@ -190,10 +197,7 @@ export function generate(
       "Cloudflare-Workers-Version-Overrides": genConfig.cloudflareVersion,
     }),
   };
-  const extraBody = {
-    input: [...opts.input],
-    ...genConfig.extraBody,
-  };
+  const extraBody = genConfig.extraBody;
   let identifiers: ModelErrorIdentifiers = {};
   const requestAttempt = suspend(() => {
     identifiers = {};
@@ -201,16 +205,12 @@ export function generate(
     return responses
       .send(body, {
         ...(Object.keys(extraHeaders).length > 0 && { extraHeaders }),
-        extraBody,
+        ...(extraBody !== undefined && { extraBody }),
         onResponseIdentifiers: (responseIdentifiers) => {
-          identifiers = responseIdentifiers;
+          identifiers = { ...identifiers, ...responseIdentifiers };
         },
         onStreamEvent: (event: StreamEvents) => {
-          const eventValue: unknown = event;
-          const rawEvent =
-            isRecord(eventValue) && isRecord(eventValue["raw"])
-              ? eventValue["raw"]
-              : eventValue;
+          const rawEvent = unwrapStreamEvent(event);
           if (isRecord(rawEvent)) {
             const response = rawEvent["response"];
             if (isRecord(response) && typeof response["id"] === "string") {
@@ -227,56 +227,55 @@ export function generate(
         )
       );
   });
-  const hasTimeout =
-    genConfig.timeoutMs !== undefined && genConfig.timeoutMs > 0;
-  const timedAttempt = hasTimeout
-    ? requestAttempt.pipe(
-        timeout(millis(genConfig.timeoutMs!)),
-        catchTag("TimeoutException", () =>
-          fail(
-            new ModelError({
-              status: 408,
-              message: appendModelErrorIdentifiers(
-                `Request timed out after ${genConfig.timeoutMs}ms`,
-                identifiers
-              ),
-              ...identifiers,
-            })
+  const timeoutMs = genConfig.timeoutMs;
+  const timedAttempt =
+    timeoutMs !== undefined && timeoutMs > 0
+      ? requestAttempt.pipe(
+          timeout(millis(timeoutMs)),
+          catchTag("TimeoutException", () =>
+            fail(
+              new ModelError({
+                status: 408,
+                message: appendModelErrorIdentifiers(
+                  `Request timed out after ${timeoutMs}ms`,
+                  identifiers
+                ),
+                ...identifiers,
+              })
+            )
           )
         )
-      )
-    : requestAttempt;
+      : requestAttempt;
   return timedAttempt.pipe(retry(rateLimitRetrySchedule(opts.retry ?? {})));
 }
 
-function toLegacyOutputItem(
-  item: Readonly<Record<string, unknown>>
-): Record<string, unknown> {
-  return toWireRecord(item);
+const RAW_PAYLOAD_KEYS = new Set(["arguments", "output"]);
+
+function toSdkInput(input: readonly ResponsesInputItem[]): InputsUnion {
+  return input.map(toSdkValue) as InputsUnion;
 }
 
-const WIRE_KEY_BY_SDK_KEY: Readonly<Record<string, string>> = {
-  callId: "call_id",
-  encryptedContent: "encrypted_content",
-  endIndex: "end_index",
-  failedModels: "failed_models",
-  failureReason: "failure_reason",
-  fileId: "file_id",
-  instanceName: "instance_name",
-  startIndex: "start_index",
-  statusCode: "status_code",
-  taskDescription: "task_description",
-  taskName: "task_name",
-};
-
-const RAW_PAYLOAD_KEYS = new Set(["arguments", "output"]);
+function toSdkValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(toSdkValue);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [
+      camelCase(key),
+      RAW_PAYLOAD_KEYS.has(key) ? nestedValue : toSdkValue(nestedValue),
+    ])
+  );
+}
 
 function toWireRecord(
   record: Readonly<Record<string, unknown>>
 ): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(record).map(([key, value]) => [
-      WIRE_KEY_BY_SDK_KEY[key] ?? key,
+      snakeCase(key),
       RAW_PAYLOAD_KEYS.has(key) ? value : toWireValue(value),
     ])
   );
@@ -293,10 +292,10 @@ function toResponsesTurn(
   result: ResponsesResult,
   generationTimeMs: number
 ): ResponsesTurn {
-  const outputItems = result.output.map(toLegacyOutputItem);
+  const outputItems = result.output.map(toWireRecord);
   const usage = usageFromResponses(result.usage);
   const functionCalls = outputItems.flatMap((item) => {
-    const callId = item["callId"] ?? item["call_id"];
+    const callId = item["call_id"];
     if (
       item["type"] !== "function_call" ||
       typeof callId !== "string" ||

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -1,44 +1,37 @@
-import { HttpClient, HttpClientRequest } from "@effect/platform";
-import type { HttpClientResponse as HttpClientResponseType } from "@effect/platform/HttpClientResponse";
+import type { ResponsesRequest, StreamEvents } from "@openrouter/sdk/models";
 import { Tag } from "effect/Context";
 import { millis } from "effect/Duration";
 import type { Effect } from "effect/Effect";
 import {
   catchTag,
   fail,
-  flatMap,
   gen,
+  map,
   mapError,
   retry,
-  succeed,
-  sync,
+  suspend,
   timeout,
 } from "effect/Effect";
 import type { Layer } from "effect/Layer";
-import { effect } from "effect/Layer";
-import { runForEach } from "effect/Stream";
+import { effect, provide } from "effect/Layer";
 
 import type { ModelUsage } from "../harness/core";
 import { ModelError } from "../harness/core";
 import type { GenerateConfig } from "../harness/model";
 import { stripVariantSuffix } from "../harness/model";
-import { Either } from "../internal/either";
 import { isRecord } from "../internal/guards";
-import { parseSchema, z } from "../internal/zod";
-import { recordGenerationId } from "../runtime/generation-ids";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule } from "../runtime/retry";
-import {
-  BENCH_HARNESS_APP_REFERRER,
-  BENCH_HARNESS_APP_TITLE,
-  normalizeBaseUrl,
-} from "./openrouter-model";
 import type { ModelErrorIdentifiers } from "./request-identifiers";
+import { appendModelErrorIdentifiers } from "./request-identifiers";
+import type { ResponsesResult, ResponsesService } from "./responses-client";
 import {
-  appendModelErrorIdentifiers,
-  modelErrorIdentifiersFromHeaders,
-} from "./request-identifiers";
-import { extractMessageText, usageFromResponses } from "./responses-client";
+  extractMessageText,
+  makeResponsesLayer,
+  Responses,
+  toModelError,
+  usageFromResponses,
+} from "./responses-client";
 
 export type ResponsesInputItem = Record<string, unknown>;
 
@@ -90,13 +83,15 @@ export class ResponsesModel extends Tag(
 
 export function makeResponsesModelLayer(
   config: ResponsesModelConfig
-): Layer<ResponsesModel, never, HttpClient.HttpClient> {
-  const baseUrl = normalizeBaseUrl(
-    config.baseUrl ?? "https://openrouter.ai/api/v1"
-  );
+): Layer<ResponsesModel> {
+  const responsesLayer = makeResponsesLayer({
+    apiKey: config.apiKey,
+    ...(config.baseUrl !== undefined && { baseUrl: config.baseUrl }),
+    ...(config.sessionId !== undefined && { sessionId: config.sessionId }),
+  });
   return effect(ResponsesModel)(
     gen(function* () {
-      const client = yield* HttpClient.HttpClient;
+      const responses = yield* Responses;
       return ResponsesModel.of({
         generate: (input, generateConfig, options) =>
           generate(
@@ -104,26 +99,20 @@ export function makeResponsesModelLayer(
               model: config.model,
               input,
               genConfig: generateConfig,
-              sessionId: config.sessionId,
-              apiKey: config.apiKey,
-              baseUrl,
               retry: config.retry,
               onStreamEvent: options?.onStreamEvent,
             },
-            client
+            responses
           ),
       });
     })
-  );
+  ).pipe(provide(responsesLayer));
 }
 
 export interface ResponsesGenerateOpts {
   readonly model: string;
   readonly input: readonly ResponsesInputItem[];
   readonly genConfig: ResponsesGenerateConfig;
-  readonly sessionId?: string;
-  readonly apiKey: string;
-  readonly baseUrl: string;
   readonly retry?: RetryConfig;
   readonly onStreamEvent?: (event: Record<string, unknown>) => void;
 }
@@ -135,8 +124,8 @@ function buildAutoRouterPlugin(
 ):
   | {
       id: "auto-router" | "auto-beta-router";
-      cost_tier?: GenerateConfig["costTier"];
-      cost_quality_tradeoff?: number;
+      costTier?: GenerateConfig["costTier"];
+      costQualityTradeoff?: number;
     }
   | undefined {
   if (
@@ -149,38 +138,20 @@ function buildAutoRouterPlugin(
   return {
     id:
       baseModel === "openrouter/auto-beta" ? "auto-beta-router" : "auto-router",
-    ...(genConfig.costTier !== undefined && { cost_tier: genConfig.costTier }),
+    ...(genConfig.costTier !== undefined && { costTier: genConfig.costTier }),
     ...(genConfig.costQualityTradeoff !== undefined && {
-      cost_quality_tradeoff: genConfig.costQualityTradeoff,
+      costQualityTradeoff: genConfig.costQualityTradeoff,
     }),
   };
 }
 
 export function generate(
   opts: ResponsesGenerateOpts,
-  client: HttpClient.HttpClient
+  responses: ResponsesService
 ): Effect<ResponsesTurn, ModelError> {
   const { genConfig } = opts;
-  const headers: Record<string, string> = {
-    Authorization: `Bearer ${opts.apiKey}`,
-    "Content-Type": "application/json",
-    "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
-    "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
-  };
-  if (genConfig.endpointId !== undefined) {
-    headers["X-OR-Endpoint-Id"] = genConfig.endpointId;
-  }
-  if (genConfig.cloudflareVersion !== undefined) {
-    headers["Cloudflare-Workers-Version-Overrides"] =
-      genConfig.cloudflareVersion;
-  }
-  if (opts.sessionId !== undefined) {
-    headers["x-session-id"] = opts.sessionId;
-  }
   const sendSort =
     genConfig.sort !== undefined && genConfig.endpointId === undefined;
-  const hasTimeout =
-    genConfig.timeoutMs !== undefined && genConfig.timeoutMs > 0;
   const baseModel = stripVariantSuffix(opts.model);
   const isAutoRouter =
     baseModel === "openrouter/auto" || baseModel === "openrouter/auto-beta";
@@ -189,260 +160,118 @@ export function generate(
     genConfig,
     isAutoRouter
   );
-  return gen(function* () {
+  const body = {
+    model: opts.model,
+    store: false,
+    include: ["reasoning.encrypted_content"],
+    ...(genConfig.instructions !== undefined && {
+      instructions: genConfig.instructions,
+    }),
+    ...(genConfig.tools !== undefined &&
+      genConfig.tools.length > 0 && { tools: [...genConfig.tools] }),
+    ...(genConfig.reasoningEffort !== undefined && {
+      reasoning: { effort: genConfig.reasoningEffort },
+    }),
+    ...(genConfig.temperature !== undefined && {
+      temperature: genConfig.temperature,
+    }),
+    ...(genConfig.maxTokens !== undefined && {
+      maxOutputTokens: genConfig.maxTokens,
+    }),
+    ...(sendSort && { provider: { sort: genConfig.sort } }),
+    ...(autoRouterPlugin !== undefined && { plugins: [autoRouterPlugin] }),
+  } satisfies ResponsesRequest;
+  const extraHeaders = {
+    ...(genConfig.endpointId !== undefined && {
+      "X-OR-Endpoint-Id": genConfig.endpointId,
+    }),
+    ...(genConfig.cloudflareVersion !== undefined && {
+      "Cloudflare-Workers-Version-Overrides": genConfig.cloudflareVersion,
+    }),
+  };
+  const extraBody = {
+    input: [...opts.input],
+    ...genConfig.extraBody,
+  };
+  let identifiers: ModelErrorIdentifiers = {};
+  const requestAttempt = suspend(() => {
+    identifiers = {};
     const startedAt = performance.now();
-    let identifiers: ModelErrorIdentifiers = {};
-    const body = {
-      model: opts.model,
-      input: [...opts.input],
-      stream: true,
-      store: false,
-      cache_control: { type: "ephemeral" },
-      include: ["reasoning.encrypted_content"],
-      ...(genConfig.instructions !== undefined && {
-        instructions: genConfig.instructions,
-      }),
-      ...(genConfig.tools !== undefined &&
-        genConfig.tools.length > 0 && { tools: [...genConfig.tools] }),
-      ...(genConfig.reasoningEffort !== undefined && {
-        reasoning: { effort: genConfig.reasoningEffort },
-      }),
-      ...(genConfig.temperature !== undefined && {
-        temperature: genConfig.temperature,
-      }),
-      ...(genConfig.maxTokens !== undefined && {
-        max_output_tokens: genConfig.maxTokens,
-      }),
-      ...(sendSort && { provider: { sort: genConfig.sort } }),
-      ...(autoRouterPlugin !== undefined && { plugins: [autoRouterPlugin] }),
-      ...genConfig.extraBody,
-    };
-    const request = HttpClientRequest.post(`${opts.baseUrl}/responses`).pipe(
-      HttpClientRequest.setHeaders(headers),
-      HttpClientRequest.bodyUnsafeJson(body)
-    );
-    const requestAttempt = gen(function* () {
-      identifiers = {};
-      const response = yield* client.execute(request);
-      identifiers = modelErrorIdentifiersFromHeaders(response.headers);
-      if (response.status < 200 || response.status >= 300) {
-        const text = yield* response.text;
-        return yield* fail(
-          new ModelError({
-            status: response.status,
-            message: appendModelErrorIdentifiers(
-              `OpenRouter HTTP ${response.status}: ${text}`,
-              identifiers
-            ),
-            ...identifiers,
-            ...(response.status === 429 && {
-              retryAfterMs: parseRetryAfter(
-                response.headers["retry-after"] ?? null
-              ),
-            }),
-          })
-        );
-      }
-      const terminalResponse = yield* consumeSse(
-        response,
-        identifiers,
-        opts.onStreamEvent
+    return responses
+      .send(body, {
+        ...(Object.keys(extraHeaders).length > 0 && { extraHeaders }),
+        extraBody,
+        onResponseIdentifiers: (responseIdentifiers) => {
+          identifiers = responseIdentifiers;
+        },
+        onStreamEvent: (event: StreamEvents) => {
+          const eventValue: unknown = event;
+          const rawEvent =
+            isRecord(eventValue) && isRecord(eventValue["raw"])
+              ? eventValue["raw"]
+              : eventValue;
+          if (isRecord(rawEvent)) {
+            const response = rawEvent["response"];
+            if (isRecord(response) && typeof response["id"] === "string") {
+              identifiers = { ...identifiers, generationId: response["id"] };
+            }
+            opts.onStreamEvent?.(rawEvent);
+          }
+        },
+      })
+      .pipe(
+        mapError(toModelError),
+        map((result) =>
+          toResponsesTurn(result, Math.round(performance.now() - startedAt))
+        )
       );
-      return { json: terminalResponse, startedAt, identifiers };
-    });
-    return yield* hasTimeout
-      ? requestAttempt.pipe(
-          timeout(millis(genConfig.timeoutMs!)),
-          catchTag("TimeoutException", () =>
-            fail(
-              new ModelError({
-                status: 408,
-                message: appendModelErrorIdentifiers(
-                  `Request timed out after ${genConfig.timeoutMs}ms`,
-                  identifiers
-                ),
-                ...identifiers,
-              })
-            )
+  });
+  const hasTimeout =
+    genConfig.timeoutMs !== undefined && genConfig.timeoutMs > 0;
+  const timedAttempt = hasTimeout
+    ? requestAttempt.pipe(
+        timeout(millis(genConfig.timeoutMs!)),
+        catchTag("TimeoutException", () =>
+          fail(
+            new ModelError({
+              status: 408,
+              message: appendModelErrorIdentifiers(
+                `Request timed out after ${genConfig.timeoutMs}ms`,
+                identifiers
+              ),
+              ...identifiers,
+            })
           )
         )
-      : requestAttempt;
-  }).pipe(
-    mapError(toModelError),
-    retry(rateLimitRetrySchedule(opts.retry ?? {})),
-    flatMap(({ json, startedAt, identifiers }) =>
-      decodeResult(json, startedAt, identifiers)
-    )
-  );
-}
-
-function consumeSse(
-  response: HttpClientResponseType,
-  initialIdentifiers: ModelErrorIdentifiers,
-  onStreamEvent?: (event: Record<string, unknown>) => void
-): Effect<unknown, ModelError> {
-  return gen(function* () {
-    const decoder = new TextDecoder();
-    let buffer = "";
-    let terminalResponse: unknown;
-    let streamError: ModelError | undefined;
-    const identifiers = initialIdentifiers;
-    const parseFrame = (frame: string): void => {
-      const data = frame
-        .split(/\r?\n/)
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice(5).trimStart())
-        .join("\n");
-      if (data.length === 0 || data === "[DONE]") {
-        return;
-      }
-      const parsed = parseJson(data);
-      if (!isRecord(parsed)) {
-        streamError = new ModelError({
-          status: 500,
-          message: appendModelErrorIdentifiers(
-            "OpenRouter stream emitted invalid JSON",
-            identifiers
-          ),
-          ...identifiers,
-        });
-        return;
-      }
-      const eventResponse = parsed["response"];
-      const eventId =
-        isRecord(eventResponse) && typeof eventResponse["id"] === "string"
-          ? eventResponse["id"]
-          : undefined;
-      if (eventId !== undefined) {
-        Object.assign(identifiers, { generationId: eventId });
-      }
-      onStreamEvent?.(parsed);
-      const type = parsed["type"];
-      if (type === "response.failed" || type === "error") {
-        streamError = new ModelError({
-          status: 500,
-          message: appendModelErrorIdentifiers(
-            `OpenRouter stream error: ${streamErrorMessage(parsed)}`,
-            identifiers
-          ),
-          ...identifiers,
-        });
-        return;
-      }
-      if (type === "response.completed" || type === "response.incomplete") {
-        terminalResponse = parsed["response"];
-      }
-    };
-    yield* response.stream.pipe(
-      runForEach((chunk) =>
-        sync(() => {
-          buffer += decoder.decode(chunk, { stream: true });
-          const frames = buffer.split(/\r?\n\r?\n/);
-          buffer = frames.pop() ?? "";
-          for (const frame of frames) {
-            parseFrame(frame);
-          }
-        })
-      ),
-      mapError(
-        (cause) =>
-          new ModelError({
-            status: 500,
-            message: appendModelErrorIdentifiers(
-              `OpenRouter stream error: ${String(cause)}`,
-              identifiers
-            ),
-            ...identifiers,
-          })
       )
-    );
-    buffer += decoder.decode();
-    if (buffer.length > 0) {
-      parseFrame(buffer);
-    }
-    if (streamError !== undefined) {
-      return yield* fail(streamError);
-    }
-    if (terminalResponse === undefined) {
-      return yield* fail(
-        new ModelError({
-          status: 500,
-          message: appendModelErrorIdentifiers(
-            "OpenRouter stream ended without a terminal response",
-            identifiers
-          ),
-          ...identifiers,
-        })
-      );
-    }
-    return terminalResponse;
-  }).pipe(
-    mapError((cause) =>
-      cause instanceof ModelError
-        ? cause
-        : new ModelError({
-            status: 500,
-            message: appendModelErrorIdentifiers(
-              `OpenRouter stream error: ${String(cause)}`,
-              initialIdentifiers
-            ),
-            ...initialIdentifiers,
-          })
-    )
-  );
+    : requestAttempt;
+  return timedAttempt.pipe(retry(rateLimitRetrySchedule(opts.retry ?? {})));
 }
 
-function streamErrorMessage(event: Record<string, unknown>): string {
-  const response = event["response"];
-  if (
-    isRecord(response) &&
-    isRecord(response["error"]) &&
-    typeof response["error"]["message"] === "string"
-  ) {
-    return response["error"]["message"];
-  }
-  return typeof event["message"] === "string"
-    ? event["message"]
-    : String(response ?? event);
+function toLegacyOutputItem(
+  item: Readonly<Record<string, unknown>>
+): Record<string, unknown> {
+  const { callId, encryptedContent, ...legacyItem } = item;
+  return {
+    ...legacyItem,
+    ...(typeof callId === "string" && { call_id: callId }),
+    ...(typeof encryptedContent === "string" && {
+      encrypted_content: encryptedContent,
+    }),
+  };
 }
 
-function parseJson(data: string): unknown {
-  try {
-    return JSON.parse(data);
-  } catch {
-    return null;
-  }
-}
-
-const ResponsesResultSchema = z.object({
-  id: z.string().nullish(),
-  output: z.array(z.record(z.string(), z.unknown())),
-  usage: z.record(z.string(), z.unknown()).nullish(),
-});
-
-function decodeResult(
-  raw: unknown,
-  startedAt: number,
-  identifiers: ModelErrorIdentifiers
-): Effect<ResponsesTurn, ModelError> {
-  const parseResult = parseSchema(ResponsesResultSchema, raw);
-  if (Either.isLeft(parseResult)) {
-    return fail(
-      new ModelError({
-        message: appendModelErrorIdentifiers(
-          `OpenRouter response failed validation: ${parseResult.left.message}`,
-          identifiers
-        ),
-        ...identifiers,
-      })
-    );
-  }
-  const outputItems = parseResult.right.output;
-  const usage = usageFromResponses(parseResult.right.usage ?? null);
+function toResponsesTurn(
+  result: ResponsesResult,
+  generationTimeMs: number
+): ResponsesTurn {
+  const outputItems = result.output.map(toLegacyOutputItem);
+  const usage = usageFromResponses(result.usage);
   const functionCalls = outputItems.flatMap((item) => {
+    const callId = item["callId"] ?? item["call_id"];
     if (
       item["type"] !== "function_call" ||
-      typeof item["call_id"] !== "string" ||
+      typeof callId !== "string" ||
       typeof item["name"] !== "string" ||
       typeof item["arguments"] !== "string"
     ) {
@@ -450,38 +279,17 @@ function decodeResult(
     }
     return [
       {
-        callId: item["call_id"],
+        callId,
         name: item["name"],
         arguments: item["arguments"],
       },
     ];
   });
-  return recordGenerationId(parseResult.right.id).pipe(
-    flatMap(() =>
-      succeed({
-        outputItems,
-        functionCalls,
-        text: extractMessageText(outputItems),
-        ...(usage !== undefined && { usage }),
-        generationTimeMs: Math.round(performance.now() - startedAt),
-      })
-    )
-  );
-}
-
-function toModelError(cause: unknown): ModelError {
-  if (cause instanceof ModelError) {
-    return cause;
-  }
-  return new ModelError({
-    message: `OpenRouter request failed: ${String(cause)}`,
-  });
-}
-
-function parseRetryAfter(value: string | null): number | undefined {
-  if (value === null) {
-    return undefined;
-  }
-  const seconds = Number(value);
-  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1e3 : undefined;
+  return {
+    outputItems,
+    functionCalls,
+    text: extractMessageText(outputItems),
+    ...(usage !== undefined && { usage }),
+    generationTimeMs,
+  };
 }


### PR DESCRIPTION
## The split transport caused cache-policy drift

Web-search benchmarks use the SDK-backed `responses-client`, while SWE and agent benchmarks used a second hand-written HTTP/SSE transport in `responses-model`. Prompt cache control existed only in the model transport, so search, judge, and Draco requests did not receive the same explicit prompt-cache policy.

## TL;DR

`responses-client` is now the single Responses API transport and defaults every request to `cache_control: { type: "ephemeral" }`. `responses-model` remains the high-level adapter but delegates transport, stream handling, identifier capture, and generation-ID recording to the shared client. Gateway response caching remains out of scope.

## What changed

- Centralized prompt cache control, SDK HTTP/SSE, app attribution headers, transport errors, and generation IDs in `responses-client`.
- Removed the duplicate HTTP/SSE implementation from `responses-model`.
- Preserved model-owned retry/timeout semantics, `retry-after`, endpoint/version headers, and auto-router options.
- Preserved arbitrary raw `extraBody` and legacy checkpoint input by merging after SDK serialization; `cache_control` cannot be removed by that merge.
- Converts known SDK output fields back to wire casing for multi-turn replay while leaving arbitrary tool payloads untouched.
- Classifies malformed SDK event-stream payloads as transient response failures.

## Scope

This enables upstream prompt caching. It does not send `x-openrouter-cache`, add response-cache salts, or change original generation-ID behavior.

## Validation

Run locally against `da1b8ca`:

- `bun run format:check` — passed
- `bun run check` — passed with existing warnings only
- `bun run typecheck` — passed
- `bun test` — 1,180 passed, 0 failed
- `bun run build` — passed
- Focused provider tests — 31 passed, 0 failed

## Reviewer focus

- Post-serialization raw body merging preserves experimental/checkpoint fields while retaining cache control.
- Per-attempt Effect timeout remains outside the SDK request lifecycle.
- Known SDK output casing is restored recursively except inside arbitrary `arguments` and `output` payloads.