### PR TITLE
feat(search): forward provider flags to OpenRouter

### DIFF
--- a/src/benchmarks/search/core/config.ts
+++ b/src/benchmarks/search/core/config.ts
@@ -60,6 +60,7 @@ export const SearchLaneConfigSchema = z.object({
   allowedDomains: z.array(z.string()).optional(),
   excludedDomains: z.array(z.string()).optional(),
   searchPrompt: z.string().optional(),
+  providerFlags: z.array(z.string().min(1)).optional(),
   webFetch: WebFetchConfigSchema.optional(),
 });
 

--- a/src/benchmarks/search/core/solver.test.ts
+++ b/src/benchmarks/search/core/solver.test.ts
@@ -34,6 +34,7 @@ import { assertRight } from "../../../internal/testing";
 import { parseSchema, z } from "../../../internal/zod";
 import type {
   ResponsesResult,
+  ResponsesSendOptions,
   ResponsesService,
 } from "../../../providers/responses-client";
 import { ResponsesError } from "../../../providers/responses-client";
@@ -61,10 +62,11 @@ function runSolverExit(
   return runPromiseExit(effect.pipe(provide(noopLayers)));
 }
 
-function makeLane(): SearchLaneConfig {
+function makeLane(overrides: Record<string, unknown> = {}): SearchLaneConfig {
   const result = parseSchema(SearchLaneConfigSchema, {
     engine: "exa",
     maxAgentTurns: 3,
+    ...overrides,
   });
   assertRight(result);
   return result.right;
@@ -251,6 +253,68 @@ describe("searchSolver", () => {
       },
     ]);
     expect(state.requestBody).toEqual(sent);
+  });
+  it("forwards provider flags as a joined header", async () => {
+    let sentOptions: ResponsesSendOptions | undefined;
+    const solver = searchSolver(
+      {
+        send: (_body, options) => {
+          sentOptions = options;
+          return effectSucceed(fixtureResult({ text: "x" }));
+        },
+      },
+      {
+        model: "m",
+        instructions: "i",
+        lane: makeLane({ providerFlags: ["alpha", "beta:value"] }),
+        endpointId: "endpoint",
+      }
+    );
+    await runSolver(
+      solver(initialTaskState({ id: "s", input: "q", target: { text: "t" } }))
+    );
+    expect(sentOptions?.extraHeaders).toEqual({
+      "X-OR-Endpoint-Id": "endpoint",
+      "X-Provider-Flags": "alpha,beta:value",
+    });
+  });
+  it("omits the provider flags header when flags are unset", async () => {
+    let sentOptions: ResponsesSendOptions | undefined;
+    const solver = searchSolver(
+      {
+        send: (_body, options) => {
+          sentOptions = options;
+          return effectSucceed(fixtureResult({ text: "x" }));
+        },
+      },
+      { model: "m", instructions: "i", lane: LANE }
+    );
+    await runSolver(
+      solver(initialTaskState({ id: "s", input: "q", target: { text: "t" } }))
+    );
+    expect(sentOptions?.extraHeaders).toBeUndefined();
+  });
+  it("forwards provider flags without an endpoint id", async () => {
+    let sentOptions: ResponsesSendOptions | undefined;
+    const solver = searchSolver(
+      {
+        send: (_body, options) => {
+          sentOptions = options;
+          return effectSucceed(fixtureResult({ text: "x" }));
+        },
+      },
+      {
+        model: "m",
+        instructions: "i",
+        lane: makeLane({ providerFlags: ["alpha"] }),
+      }
+    );
+    await runSolver(
+      solver(initialTaskState({ id: "s", input: "q", target: { text: "t" } }))
+    );
+    expect(sentOptions?.extraHeaders).toEqual({
+      "X-Provider-Flags": "alpha",
+    });
   });
   it("trims whitespace from the answer", async () => {
     const solver = searchSolver(

--- a/src/benchmarks/search/core/solver.ts
+++ b/src/benchmarks/search/core/solver.ts
@@ -112,11 +112,21 @@ export function searchSolver(
         }),
         ...(opts.costTier !== undefined && { costTier: opts.costTier }),
       });
+      const extraHeaders =
+        opts.endpointId === undefined && !opts.lane.providerFlags?.length
+          ? undefined
+          : {
+              ...(opts.endpointId !== undefined && {
+                "X-OR-Endpoint-Id": opts.endpointId,
+              }),
+              ...(opts.lane.providerFlags !== undefined &&
+                opts.lane.providerFlags.length > 0 && {
+                  "X-Provider-Flags": opts.lane.providerFlags.join(","),
+                }),
+            };
       const sendOptions = (): ResponsesSendOptions => ({
         timeoutMs: opts.timeoutMs ?? DEFAULT_SEARCH_TIMEOUT_MS,
-        ...(opts.endpointId !== undefined && {
-          extraHeaders: { "X-OR-Endpoint-Id": opts.endpointId },
-        }),
+        ...(extraHeaders !== undefined && { extraHeaders }),
         ...(opts.versionOverride !== undefined && {
           versionOverride: opts.versionOverride,
         }),


### PR DESCRIPTION
## TL;DR

Adds an optional `providerFlags` list to the search lane, forwarded verbatim as an `X-Provider-Flags` request header, so a run can ask the resolved search provider for non-default behavior without a new tool parameter.

## What changed?

- `SearchLaneConfigSchema` gains `providerFlags?: string[]` (each entry non-empty).
- `searchSolver` joins the list with `,` and sends it as `X-Provider-Flags`, alongside the existing `X-OR-Endpoint-Id`. The header is omitted when the list is unset or empty, and is sent independently of whether `endpointId` is set.
- Regression tests for the joined value, absence when unset, presence without an endpoint ID, and coexistence with the endpoint header.

Tokens are `<provider>:<flag>` (e.g. `exa:some_flag`, `exa:some_setting:high`), so the header stays meaningful once more than one provider consumes it. The harness treats the strings as opaque — no parsing, no validation, no vocabulary.

## Why?

Tuning search-provider behavior per run currently requires a named parameter on `openrouter:web_search` for every knob, which means an API change plus an SDK regen per knob, and puts provider-internal settings on a public tool schema. A header keeps it off the tool schema, needs no `@openrouter/sdk` change (`extraHeaders` already exists and already carries `X-OR-Endpoint-Id`), and stays per-request, so two lanes in one sweep can differ — which account-level configuration cannot do.

Server-side support does not exist yet; until it does the header is inert and nothing changes. This is the client half so the server change has a consumer.

A request-body field would be preferable on reproducibility grounds, since body fields land in the generation record and headers do not, but it needs an SDK regen before any client can send it. The header ships today and does not foreclose that: the lane field stays as-is and only the transport would change.

Two things worth deciding in review, since they are cross-cutting rather than local to this diff:

- The header should be honored only for allowlisted teams. All web_search traffic reaches a given provider on one shared credential, so the provider cannot distinguish a benchmark request from an arbitrary customer's request, and anything it enables for that credential is enabled for both. The team gate is the only boundary, not defence-in-depth.
- Leaving it undocumented keeps it from becoming an API commitment on either side.

## How to test

```sh
bun install
bun test src/benchmarks/search/core/solver.test.ts
```

End to end, the header appears on the outbound request:

```sh
OPENROUTER_API_KEY=... bun run bench -- \
  --benchmark search_simpleqa --model <model> --limit 1 \
  --solver-config '{"lane":{"engine":"exa","providerFlags":["exa:some_flag"]}}'
```

Expected: requests carry `X-Provider-Flags: exa:some_flag`; results are unchanged, since nothing consumes the header yet.

## Benchmark impact

None by default — `providerFlags` is optional and no header is sent when it is absent, so every existing lane produces byte-identical requests. Scores can only change for a run that explicitly sets flags, and only once a server honors them; such a run is not comparable to a run without them and should be labeled accordingly.

## Reviewer focus

- Whether the lane config is the right home for this versus `SearchBenchmarkOptionsSchema`. It is on the lane because it is search-surface-specific.
- Flags deliberately do not propagate to the judge/grading stages — they describe search behavior and judge calls do not search. `versionOverride` does propagate, so this is an intentional divergence.
- The `,`-joined header value and `<provider>:<flag>` token shape, since both become a contract with the server side.
- `extraHeaders` construction: previously set only when `endpointId` was defined, now built from either input.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [ ] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [ ] Documentation is updated where needed