### PR TITLE
feat(exports): expose terminal-bench sandbox modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "./benchmarks/search/provenance": "./src/benchmarks/search/provenance.ts",
     "./benchmarks/swe-atlas/schema": "./src/benchmarks/swe-atlas/schema.ts",
     "./benchmarks/terminal-bench/schema": "./src/benchmarks/terminal-bench/schema.ts",
+    "./benchmarks/terminal-bench/sandbox": "./src/benchmarks/terminal-bench/sandbox.ts",
+    "./benchmarks/terminal-bench/modal-sandbox": "./src/benchmarks/terminal-bench/modal-sandbox.ts",
     "./core": "./src/harness/core.ts",
     "./constants": "./src/harness/constants.ts",
     "./dataset": "./src/harness/dataset.ts",


### PR DESCRIPTION
## TL;DR

Publishes the two terminal-bench sandbox modules as package subpath exports so a host application can run its own benchmark on the harness's Modal sandbox without vendoring a copy of it.

## What changed?

- `exports` gains `./benchmarks/terminal-bench/sandbox` and `./benchmarks/terminal-bench/modal-sandbox`.

## Why?

OpenRouter is keeping an internal agent-experience benchmark inside `openrouter-web` rather than shipping it here, and it provides its own dataset, solver, and scorer layers to the exported `runBenchmark`. The `SandboxSession` tag, its `CreateSessionInput` contract, and `makeModalSandboxLayer` are the only pieces it cannot supply itself, since re-implementing Modal sandbox provisioning would duplicate harness behavior that has to stay in step with the sandbox lifecycle.

`./dataset`, `./solver`, and `./scorer` already became public in #21, so these two entries complete the surface an externally-owned benchmark needs. No source, interface, registry, or configuration change accompanies them.

## How to test

```bash
bun -e 'import("@openrouter/bench-harness/benchmarks/terminal-bench/modal-sandbox").then((m) => console.log(Object.keys(m)))'
```

Resolves through the exports map and prints `makeModalSandboxLayer`.

## Reviewer focus

- Whether `modal-sandbox` should stay private and only the `sandbox` contract be published. Publishing both is deliberate: an external benchmark needs the tag and input type to build a session, and the Modal layer to satisfy it.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/58ddb9e5bf0b4b2c80858d33f8acccfe
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/22" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->