### PR TITLE
fix(providers): tolerate OpenRouter responses omitting unused required fields

### DIFF
--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -846,6 +846,21 @@ describe("openrouter-model 2xx error envelope", () => {
     assertSuccess(exit);
     expect(fetchCalls.count).toBe(1);
   });
+  it("decodes a 200 body that omits required unused fields", async () => {
+    silenceWarnings();
+    const fetchCalls = { count: 0 };
+    const {
+      system_fingerprint: _systemFingerprint,
+      created: _created,
+      object: _object,
+      ...body
+    } = CHAT_RESULT;
+    restore = installBodyFetch(JSON.stringify(body), 1, fetchCalls);
+    const exit = await generateWithRetries(5);
+    assertSuccess(exit);
+    expect(exit.value.completion).toBe("Answer: A");
+    expect(fetchCalls.count).toBe(1);
+  });
   it("treats an envelope with null choices as an error envelope", async () => {
     silenceWarnings();
     const fetchCalls = { count: 0 };

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -408,7 +408,10 @@ function decodeResult(
   startedAt: number,
   identifiers: ResponseIdentifiers
 ): Effect<ModelOutput, ModelError> {
-  const parseResult = parseSchema(ChatResult$inboundSchema, raw);
+  const parseResult = parseSchema(
+    ChatResult$inboundSchema,
+    normalizeResultForSchema(raw)
+  );
   if (Either.isLeft(parseResult)) {
     return fail(
       new ModelError({
@@ -460,6 +463,18 @@ function decodeResult(
       })
     )
   );
+}
+
+function normalizeResultForSchema(raw: unknown): unknown {
+  if (!isRecord(raw)) {
+    return raw;
+  }
+  return {
+    ...raw,
+    ...(!("system_fingerprint" in raw) && { system_fingerprint: null }),
+    ...(!("created" in raw) && { created: 0 }),
+    ...(!("object" in raw) && { object: "chat.completion" }),
+  };
 }
 
 function extractReasoningDetails(raw: unknown): ReasoningDetails | undefined {


### PR DESCRIPTION
## TL;DR

A 200 response that omits `system_fingerprint` no longer aborts a benchmark run.

## What changed?

- `decodeResult` in `src/providers/openrouter-model.ts` fills benign defaults for the three fields the SDK schema marks required but the harness never reads, when and only when they are absent: `system_fingerprint` → `null`, `created` → `0`, `object` → `"chat.completion"`. Present values, including explicit `null`, are untouched.
- Validation of `id`, `model`, `choices`, and `usage` is unchanged, so bodies with no usable completion still fail as before.
- Regression test decoding a body with those three keys removed.

## Why?

A production run died with:

```
ModelError: OpenRouter response failed validation: [
  { "expected": "string", "code": "invalid_type", "path": ["system_fingerprint"],
    "message": "Invalid input: expected string, received undefined" } ]
```

`@openrouter/sdk@1.2.9` declares `system_fingerprint: z.nullable(z.string())` — nullable but required (`node_modules/@openrouter/sdk/esm/models/chatresult.js`). OpenRouter legitimately omits the field for many providers, so an otherwise complete completion was discarded.

Client-side retry does not help here and already ran: validation errors carry `status === undefined`, which `isRetryable` in `src/runtime/retry.ts` treats as retryable, so the request was retried up to 6 times and each attempt failed identically on the same response shape.

## How to test

```
bun test src/providers/openrouter-model.test.ts
```

Expected: the new `decodes a 200 body that omits required unused fields` case passes with a single fetch (no retries) and completion `"Answer: A"`.

## Reviewer focus

- Whether defaulting `created` and `object` alongside `system_fingerprint` is desirable, or whether this should be narrowed to `system_fingerprint` only.
- That no genuinely unusable body becomes silently acceptable.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/165a7944d9c44648adbd3a3aba2ec70e
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->