### PR TITLE
feat(providers): enable OpenRouter response caching with per-epoch salts

### DIFF
--- a/src/benchmarks/draco/solver-cache.test.ts
+++ b/src/benchmarks/draco/solver-cache.test.ts
@@ -5,10 +5,12 @@ import { join } from "node:path";
 
 import type { ResponsesRequest } from "@openrouter/sdk/models";
 import {
+  flatMap,
   gen,
   provide,
   runPromise,
   succeed as effectSucceed,
+  zipRight,
 } from "effect/Effect";
 import {
   effect,
@@ -29,6 +31,12 @@ import type {
   ResponsesSendOptions,
 } from "../../providers/responses-client";
 import { Responses } from "../../providers/responses-client";
+import type { GenerationIdEntry } from "../../runtime/generation-ids";
+import {
+  getCollectedGenerationIdEntries,
+  recordGenerationId,
+  resetGenerationIds,
+} from "../../runtime/generation-ids";
 import {
   ArtifactStoreService,
   makeFsArtifactStoreLayer,
@@ -76,7 +84,9 @@ function fixtureResponsesLayer(
       provider: "fixture",
       generationTimeMs: 0,
     };
-    return effectSucceed(result);
+    return recordGenerationId(`gen-${model}`).pipe(
+      zipRight(effectSucceed(result))
+    );
   };
   return layerSucceed(Responses, Responses.of({ send }));
 }
@@ -104,6 +114,7 @@ async function runSolver(
 ): Promise<{
   calls: string[];
   state: ReturnType<typeof initialTaskState>;
+  generationIdEntries: readonly GenerationIdEntry[];
 }> {
   const calls: string[] = [];
   const responsesLayer = fixtureResponsesLayer(
@@ -119,21 +130,29 @@ async function runSolver(
       return Solver.of(dracoSolver(responses, artifactStore, { config }));
     })
   );
-  const state = await runPromise(
-    gen(function* () {
-      const solver = yield* Solver;
-      return yield* solver(sample());
-    }).pipe(
-      provide(
-        mergeAll(
-          solverLayer.pipe(layerProvide(infraLayer)),
-          noopProgressLayer,
-          noopCheckpointLayer
+  const { state, generationIdEntries } = await runPromise(
+    resetGenerationIds
+      .pipe(
+        flatMap(() =>
+          gen(function* () {
+            const solver = yield* Solver;
+            const solvedState = yield* solver(sample());
+            const entries = yield* getCollectedGenerationIdEntries;
+            return { state: solvedState, generationIdEntries: entries };
+          })
         )
       )
-    )
+      .pipe(
+        provide(
+          mergeAll(
+            solverLayer.pipe(layerProvide(infraLayer)),
+            noopProgressLayer,
+            noopCheckpointLayer
+          )
+        )
+      )
   );
-  return { calls, state };
+  return { calls, state, generationIdEntries };
 }
 
 function productionFusionConfig(
@@ -165,6 +184,29 @@ describe("dracoSolver production-fusion cache reuse", () => {
       const judgeCalls = calls.filter((m) => m.startsWith("judge/"));
       expect(genCalls).toHaveLength(1);
       expect(judgeCalls).toHaveLength(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+  it("marks judge generation ids as auxiliary and generation ids as counted", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "draco-prod-"));
+    try {
+      const { generationIdEntries } = await runSolver(
+        dir,
+        productionFusionConfig()
+      );
+      const judgeEntries = generationIdEntries.filter((entry) =>
+        entry.id.startsWith("gen-judge/")
+      );
+      const genEntries = generationIdEntries.filter(
+        (entry) => !entry.id.startsWith("gen-judge/")
+      );
+      expect(judgeEntries.length).toBeGreaterThan(0);
+      expect(genEntries.length).toBeGreaterThan(0);
+      expect(judgeEntries.every((entry) => !entry.countsTowardUsage)).toBe(
+        true
+      );
+      expect(genEntries.every((entry) => entry.countsTowardUsage)).toBe(true);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/benchmarks/draco/solver.ts
+++ b/src/benchmarks/draco/solver.ts
@@ -40,6 +40,7 @@ import {
   toModelError,
   usageFromResponses,
 } from "../../providers/responses-client";
+import { withAuxiliaryUsage } from "../../runtime/generation-ids";
 import { withCallCacheSalt } from "../../runtime/response-cache";
 import type { StageKey, ArtifactStore } from "./artifact-store";
 import { stageGet, stagePut, ArtifactStoreService } from "./artifact-store";
@@ -412,16 +413,18 @@ function gradeOneCriterion(opts: {
     const responses = yield* Responses;
     const judged = yield* withCallCacheSalt(
       `judge-run-${runNum}`,
-      judgeCall(responses, dracoJudgeConfig(config), {
-        instructions: JUDGE_SYSTEM_PROMPT,
-        userInput: judgePrompt,
-        schemaName: "draco_verdict",
-        jsonSchema: DRACO_VERDICT_JSON_SCHEMA,
-        parseVerdict: (text) =>
-          Either.right(
-            text.trim().length === 0 ? null : parseSingleVerdict(text)
-          ),
-      })
+      withAuxiliaryUsage(
+        judgeCall(responses, dracoJudgeConfig(config), {
+          instructions: JUDGE_SYSTEM_PROMPT,
+          userInput: judgePrompt,
+          schemaName: "draco_verdict",
+          jsonSchema: DRACO_VERDICT_JSON_SCHEMA,
+          parseVerdict: (text) =>
+            Either.right(
+              text.trim().length === 0 ? null : parseSingleVerdict(text)
+            ),
+        })
+      )
     );
     const cost = judged.usage?.totalCost ?? null;
     let gradeResult: GradeOneResult;

--- a/src/benchmarks/draco/solver.ts
+++ b/src/benchmarks/draco/solver.ts
@@ -40,6 +40,7 @@ import {
   toModelError,
   usageFromResponses,
 } from "../../providers/responses-client";
+import { withCallCacheSalt } from "../../runtime/response-cache";
 import type { StageKey, ArtifactStore } from "./artifact-store";
 import { stageGet, stagePut, ArtifactStoreService } from "./artifact-store";
 import { buildGenerationResult } from "./generation";
@@ -409,16 +410,19 @@ function gradeOneCriterion(opts: {
       }
     }
     const responses = yield* Responses;
-    const judged = yield* judgeCall(responses, dracoJudgeConfig(config), {
-      instructions: JUDGE_SYSTEM_PROMPT,
-      userInput: judgePrompt,
-      schemaName: "draco_verdict",
-      jsonSchema: DRACO_VERDICT_JSON_SCHEMA,
-      parseVerdict: (text) =>
-        Either.right(
-          text.trim().length === 0 ? null : parseSingleVerdict(text)
-        ),
-    });
+    const judged = yield* withCallCacheSalt(
+      `judge-run-${runNum}`,
+      judgeCall(responses, dracoJudgeConfig(config), {
+        instructions: JUDGE_SYSTEM_PROMPT,
+        userInput: judgePrompt,
+        schemaName: "draco_verdict",
+        jsonSchema: DRACO_VERDICT_JSON_SCHEMA,
+        parseVerdict: (text) =>
+          Either.right(
+            text.trim().length === 0 ? null : parseSingleVerdict(text)
+          ),
+      })
+    );
     const cost = judged.usage?.totalCost ?? null;
     let gradeResult: GradeOneResult;
     if (judged.verdict === null) {

--- a/src/benchmarks/search/core/solver.ts
+++ b/src/benchmarks/search/core/solver.ts
@@ -32,6 +32,7 @@ import {
   toModelError,
   usageFromResponses,
 } from "../../../providers/responses-client";
+import { withRetryAttemptSalt } from "../../../runtime/response-cache";
 import type { RetryConfig } from "../../../runtime/retry";
 import { rateLimitRetrySchedule } from "../../../runtime/retry";
 import type { SearchLaneConfig } from "./config";
@@ -179,7 +180,9 @@ function sendWithRetry({
   const blankResults: ResponsesResult[] = [];
   let lastBlankResult: ResponsesResult | undefined;
   let lastBlankError: ModelError | undefined;
-  return suspend(() => responses.send(body, options())).pipe(
+  return withRetryAttemptSalt(
+    suspend(() => responses.send(body, options()))
+  ).pipe(
     mapError(toModelError),
     timeoutFail({
       duration: `${timeoutMs} millis`,

--- a/src/benchmarks/search/core/solver.ts
+++ b/src/benchmarks/search/core/solver.ts
@@ -7,7 +7,6 @@ import {
   gen,
   map,
   mapError,
-  retry,
   succeed,
   suspend,
   timeoutFail,
@@ -32,9 +31,8 @@ import {
   toModelError,
   usageFromResponses,
 } from "../../../providers/responses-client";
-import { withRetryAttemptSalt } from "../../../runtime/response-cache";
 import type { RetryConfig } from "../../../runtime/retry";
-import { rateLimitRetrySchedule } from "../../../runtime/retry";
+import { rateLimitRetrySchedule, retrySalted } from "../../../runtime/retry";
 import type { SearchLaneConfig } from "./config";
 import { makeSearchProgressTracker } from "./progress";
 import { buildSearchRequestBody } from "./request";
@@ -180,39 +178,40 @@ function sendWithRetry({
   const blankResults: ResponsesResult[] = [];
   let lastBlankResult: ResponsesResult | undefined;
   let lastBlankError: ModelError | undefined;
-  return withRetryAttemptSalt(
-    suspend(() => responses.send(body, options()))
-  ).pipe(
-    mapError(toModelError),
-    timeoutFail({
-      duration: `${timeoutMs} millis`,
-      onTimeout: () =>
-        new ModelError({
-          status: 504,
-          message: `search response exceeded the ${timeoutMs}ms wall-clock deadline`,
-        }),
-    }),
-    flatMap((result) => {
-      if (result.status !== "completed") {
-        return fail(
+  return retrySalted(
+    suspend(() => responses.send(body, options())).pipe(
+      mapError(toModelError),
+      timeoutFail({
+        duration: `${timeoutMs} millis`,
+        onTimeout: () =>
           new ModelError({
+            status: 504,
+            message: `search response exceeded the ${timeoutMs}ms wall-clock deadline`,
+          }),
+      }),
+      flatMap((result) => {
+        if (result.status !== "completed") {
+          return fail(
+            new ModelError({
+              status: 503,
+              message: `search response ended with status ${result.status ?? "unknown"}`,
+            })
+          );
+        }
+        if (result.text.trim() === "") {
+          blankResults.push(result);
+          lastBlankResult = result;
+          lastBlankError = new ModelError({
             status: 503,
-            message: `search response ended with status ${result.status ?? "unknown"}`,
-          })
-        );
-      }
-      if (result.text.trim() === "") {
-        blankResults.push(result);
-        lastBlankResult = result;
-        lastBlankError = new ModelError({
-          status: 503,
-          message: EMPTY_SEARCH_RESPONSE_MESSAGE,
-        });
-        return fail(lastBlankError);
-      }
-      return succeed(result);
-    }),
-    retry(rateLimitRetrySchedule(retryConfig ?? {})),
+            message: EMPTY_SEARCH_RESPONSE_MESSAGE,
+          });
+          return fail(lastBlankError);
+        }
+        return succeed(result);
+      })
+    ),
+    rateLimitRetrySchedule(retryConfig ?? {})
+  ).pipe(
     catchTag("ModelError", (error) =>
       error === lastBlankError && lastBlankResult !== undefined
         ? succeed(lastBlankResult)

--- a/src/benchmarks/tau-bench-airline/user-simulator.test.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import assert from "node:assert/strict";
 
 import { FetchHttpClient } from "@effect/platform";
@@ -6,6 +6,7 @@ import { flatMap, provide, runPromise } from "effect/Effect";
 
 import type { CapturedRequest } from "../../../test/helpers/fetch-sequence";
 import { installFetchSequence } from "../../../test/helpers/fetch-sequence";
+import { runHarnessPromise } from "../../internal/effect-logger";
 import { isRecord } from "../../internal/guards";
 import {
   getCollectedGenerationIds,
@@ -247,6 +248,46 @@ describe("UserSimulator", () => {
         expect(callCount).toBe(3);
       } finally {
         globalThis.fetch = originalFetch;
+      }
+    }
+  );
+  it.serial(
+    "logs a structured retry warning for each user-sim retry",
+    async () => {
+      const warn = spyOn(console, "warn").mockImplementation(() => {});
+      const originalFetch = globalThis.fetch;
+      let callCount = 0;
+      const responses = [
+        { choices: [{ message: { content: null } }] },
+        { choices: [{ message: { content: null } }] },
+        { choices: [{ message: { content: "Recovered" } }] },
+      ];
+      globalThis.fetch = async () => {
+        const response = responses[callCount] ?? responses.at(-1);
+        callCount++;
+        return Response.json(response);
+      };
+      try {
+        const simulator = new UserSimulator({
+          apiKey: "sk-test",
+          model: "openai/gpt-4o-mini",
+          baseUrl: "https://example.test",
+        });
+        simulator.reset("scenario", "Hi");
+        const result = await runHarnessPromise(
+          simulator.generateInitial().pipe(provide(FetchHttpClient.layer))
+        );
+        expect(result).toBe("Recovered");
+        expect(warn).toHaveBeenCalledTimes(2);
+        expect(warn.mock.calls[0]?.[0]).toBe("Retrying after transient error");
+        expect(warn.mock.calls[0]?.[1]).toMatchObject({
+          attempt: 1,
+          error_tag: "UserSimError",
+        });
+        expect(warn.mock.calls[1]?.[1]).toMatchObject({ attempt: 2 });
+      } finally {
+        globalThis.fetch = originalFetch;
+        warn.mockRestore();
       }
     }
   );

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -26,6 +26,8 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_STATUS_HEADER,
+  RESPONSE_CACHE_STATUS_HIT,
   withRetryAttemptSalt,
 } from "../../runtime/response-cache";
 import type { UserModelConfig } from "./types";
@@ -186,7 +188,11 @@ export class UserSimulator {
           })
         );
       }
-      yield* recordGenerationId(parsed.right.id);
+      yield* recordGenerationId(
+        parsed.right.id,
+        response.headers[RESPONSE_CACHE_STATUS_HEADER] ===
+          RESPONSE_CACHE_STATUS_HIT
+      );
       const message = parsed.right.choices[0]?.message;
       const content = message?.content ?? "";
       return {

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -30,6 +30,7 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SOURCE_ID_HEADER,
   RESPONSE_CACHE_STATUS_HEADER,
   RESPONSE_CACHE_STATUS_HIT,
   RESPONSE_CACHE_TTL_HEADER,
@@ -203,10 +204,15 @@ export class UserSimulator {
           })
         );
       }
-      yield* recordGenerationId(
-        parsed.right.id,
+      const isCacheHit =
         response.headers[RESPONSE_CACHE_STATUS_HEADER] ===
-          RESPONSE_CACHE_STATUS_HIT
+        RESPONSE_CACHE_STATUS_HIT;
+      const cacheSourceId = response.headers[RESPONSE_CACHE_SOURCE_ID_HEADER];
+      const hasSourceId = isCacheHit && cacheSourceId !== undefined;
+      yield* recordGenerationId(
+        hasSourceId ? cacheSourceId : parsed.right.id,
+        isCacheHit,
+        hasSourceId
       );
       const message = parsed.right.choices[0]?.message;
       const content = message?.content ?? "";

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -20,6 +20,12 @@ import {
   BENCH_HARNESS_APP_TITLE,
 } from "../../providers/openrouter-model";
 import { recordGenerationId } from "../../runtime/generation-ids";
+import {
+  buildResponseCacheSalt,
+  getCurrentEpoch,
+  RESPONSE_CACHE_HEADER,
+  RESPONSE_CACHE_SALT_FIELD,
+} from "../../runtime/response-cache";
 import type { UserModelConfig } from "./types";
 import { USER_SIM_GUIDELINES } from "./user-sim-guidelines";
 
@@ -117,25 +123,32 @@ export class UserSimulator {
   private readonly callModelOnce = (
     model: string
   ): Effect<UserModelResponse, SimError, HttpClient.HttpClient> => {
-    const request = HttpClientRequest.post(
-      `${this.baseUrl}/chat/completions`
-    ).pipe(
-      HttpClientRequest.setHeaders({
-        Authorization: `Bearer ${this.config.apiKey}`,
-        "Content-Type": "application/json",
-        "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
-        "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
-        ...(this.config.sessionId !== undefined && {
-          "x-session-id": this.config.sessionId,
-        }),
-      }),
-      HttpClientRequest.bodyUnsafeJson({
-        model,
-        messages: this.messages,
-        temperature: 0,
-      })
-    );
+    const { baseUrl, config, messages } = this;
     return gen(function* () {
+      const epoch = yield* getCurrentEpoch;
+      const cacheSalt = buildResponseCacheSalt(config.sessionId, epoch);
+      const request = HttpClientRequest.post(
+        `${baseUrl}/chat/completions`
+      ).pipe(
+        HttpClientRequest.setHeaders({
+          Authorization: `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+          "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
+          "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
+          [RESPONSE_CACHE_HEADER]: "true",
+          ...(config.sessionId !== undefined && {
+            "x-session-id": config.sessionId,
+          }),
+        }),
+        HttpClientRequest.bodyUnsafeJson({
+          model,
+          messages,
+          temperature: 0,
+          ...(cacheSalt !== undefined && {
+            [RESPONSE_CACHE_SALT_FIELD]: cacheSalt,
+          }),
+        })
+      );
       const client = yield* HttpClient.HttpClient;
       const response = yield* client.execute(request);
       if (response.status < 200 || response.status >= 300) {

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -26,7 +26,6 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
-  RESPONSE_CACHE_SOURCE_GENERATION_HEADER,
   withRetryAttemptSalt,
 } from "../../runtime/response-cache";
 import type { UserModelConfig } from "./types";
@@ -187,10 +186,7 @@ export class UserSimulator {
           })
         );
       }
-      yield* recordGenerationId(
-        response.headers[RESPONSE_CACHE_SOURCE_GENERATION_HEADER] ??
-          parsed.right.id
-      );
+      yield* recordGenerationId(parsed.right.id);
       const message = parsed.right.choices[0]?.message;
       const content = message?.content ?? "";
       return {

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -23,8 +23,11 @@ import { recordGenerationId } from "../../runtime/generation-ids";
 import {
   buildResponseCacheSalt,
   getCurrentEpoch,
+  getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SOURCE_GENERATION_HEADER,
+  withRetryAttemptSalt,
 } from "../../runtime/response-cache";
 import type { UserModelConfig } from "./types";
 import { USER_SIM_GUIDELINES } from "./user-sim-guidelines";
@@ -102,10 +105,12 @@ export class UserSimulator {
     const messages = this.messages;
     const config = this.config;
     return gen(function* () {
-      const response = yield* callModelOnce(config.model).pipe(
+      const response = yield* withRetryAttemptSalt(
+        callModelOnce(config.model)
+      ).pipe(
         retry(USER_SIM_RESPONSE_RETRY_SCHEDULE),
         catchAll(() =>
-          callModelOnce(USER_FALLBACK_MODEL).pipe(
+          withRetryAttemptSalt(callModelOnce(USER_FALLBACK_MODEL)).pipe(
             retry(USER_SIM_RESPONSE_RETRY_SCHEDULE)
           )
         )
@@ -126,7 +131,12 @@ export class UserSimulator {
     const { baseUrl, config, messages } = this;
     return gen(function* () {
       const epoch = yield* getCurrentEpoch;
-      const cacheSalt = buildResponseCacheSalt(config.sessionId, epoch);
+      const retryAttempt = yield* getCurrentRetryAttempt;
+      const cacheSalt = buildResponseCacheSalt(
+        config.sessionId,
+        epoch,
+        retryAttempt
+      );
       const request = HttpClientRequest.post(
         `${baseUrl}/chat/completions`
       ).pipe(
@@ -177,7 +187,10 @@ export class UserSimulator {
           })
         );
       }
-      yield* recordGenerationId(parsed.right.id);
+      yield* recordGenerationId(
+        response.headers[RESPONSE_CACHE_SOURCE_GENERATION_HEADER] ??
+          parsed.right.id
+      );
       const message = parsed.right.choices[0]?.message;
       const content = message?.content ?? "";
       return {

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -22,6 +22,7 @@ import {
 import { recordGenerationId } from "../../runtime/generation-ids";
 import {
   buildResponseCacheSalt,
+  getCurrentCallSalt,
   getCurrentEpoch,
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
@@ -133,10 +134,12 @@ export class UserSimulator {
     return gen(function* () {
       const epoch = yield* getCurrentEpoch;
       const retryAttempt = yield* getCurrentRetryAttempt;
+      const callSalt = yield* getCurrentCallSalt;
       const cacheSalt = buildResponseCacheSalt(
         config.sessionId,
         epoch,
-        retryAttempt
+        retryAttempt,
+        callSalt
       );
       const request = HttpClientRequest.post(
         `${baseUrl}/chat/completions`

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -5,8 +5,8 @@ import {
 } from "@effect/platform";
 import { TaggedError } from "effect/Data";
 import type { Effect } from "effect/Effect";
-import { catchAll, fail, gen, retry } from "effect/Effect";
-import { fixed, intersect, recurs, whileInput } from "effect/Schedule";
+import { catchAll, fail, gen } from "effect/Effect";
+import { fixed, passthrough, whileInput } from "effect/Schedule";
 
 import type { ReasoningDetails } from "../../harness/reasoning-details";
 import {
@@ -29,8 +29,10 @@ import {
   RESPONSE_CACHE_SALT_FIELD,
   RESPONSE_CACHE_STATUS_HEADER,
   RESPONSE_CACHE_STATUS_HIT,
-  withRetryAttemptSalt,
+  RESPONSE_CACHE_TTL_HEADER,
+  RESPONSE_CACHE_TTL_SECONDS,
 } from "../../runtime/response-cache";
+import { retrySalted, withRetryAttemptLogging } from "../../runtime/retry";
 import type { UserModelConfig } from "./types";
 import { USER_SIM_GUIDELINES } from "./user-sim-guidelines";
 
@@ -55,12 +57,17 @@ class UserSimError extends TaggedError("UserSimError")<{
 
 type SimError = UserSimError | HttpClientError.HttpClientError;
 
-const USER_SIM_RESPONSE_RETRY_SCHEDULE = fixed("100 millis").pipe(
-  intersect(recurs(2)),
-  whileInput(
-    (error: SimError) =>
-      error instanceof UserSimError && error.retryable === true
-  )
+const USER_SIM_MAX_RETRIES = 2;
+
+const USER_SIM_RESPONSE_RETRY_SCHEDULE = withRetryAttemptLogging(
+  fixed("100 millis").pipe(
+    whileInput(
+      (error: SimError) =>
+        error instanceof UserSimError && error.retryable === true
+    ),
+    passthrough
+  ),
+  USER_SIM_MAX_RETRIES
 );
 
 function buildUserSystemPrompt(scenarioInstructions: string): string {
@@ -107,13 +114,14 @@ export class UserSimulator {
     const messages = this.messages;
     const config = this.config;
     return gen(function* () {
-      const response = yield* withRetryAttemptSalt(
-        callModelOnce(config.model)
+      const response = yield* retrySalted(
+        callModelOnce(config.model),
+        USER_SIM_RESPONSE_RETRY_SCHEDULE
       ).pipe(
-        retry(USER_SIM_RESPONSE_RETRY_SCHEDULE),
         catchAll(() =>
-          withRetryAttemptSalt(callModelOnce(USER_FALLBACK_MODEL)).pipe(
-            retry(USER_SIM_RESPONSE_RETRY_SCHEDULE)
+          retrySalted(
+            callModelOnce(USER_FALLBACK_MODEL),
+            USER_SIM_RESPONSE_RETRY_SCHEDULE
           )
         )
       );
@@ -150,6 +158,7 @@ export class UserSimulator {
           "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
           "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
           [RESPONSE_CACHE_HEADER]: "true",
+          [RESPONSE_CACHE_TTL_HEADER]: `${RESPONSE_CACHE_TTL_SECONDS}`,
           ...(config.sessionId !== undefined && {
             "x-session-id": config.sessionId,
           }),

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -19,7 +19,10 @@ import {
   BENCH_HARNESS_APP_REFERRER,
   BENCH_HARNESS_APP_TITLE,
 } from "../../providers/openrouter-model";
-import { recordGenerationId } from "../../runtime/generation-ids";
+import {
+  recordGenerationId,
+  withAuxiliaryUsage,
+} from "../../runtime/generation-ids";
 import {
   buildResponseCacheSalt,
   getCurrentCallSalt,
@@ -115,12 +118,12 @@ export class UserSimulator {
     const config = this.config;
     return gen(function* () {
       const response = yield* retrySalted(
-        callModelOnce(config.model),
+        withAuxiliaryUsage(callModelOnce(config.model)),
         USER_SIM_RESPONSE_RETRY_SCHEDULE
       ).pipe(
         catchAll(() =>
           retrySalted(
-            callModelOnce(USER_FALLBACK_MODEL),
+            withAuxiliaryUsage(callModelOnce(USER_FALLBACK_MODEL)),
             USER_SIM_RESPONSE_RETRY_SCHEDULE
           )
         )

--- a/src/benchmarks/tau3-bench-banking/user-simulator.test.ts
+++ b/src/benchmarks/tau3-bench-banking/user-simulator.test.ts
@@ -3,11 +3,12 @@ import assert from "node:assert/strict";
 
 import { FetchHttpClient, HttpClient } from "@effect/platform";
 import type { Effect } from "effect/Effect";
-import { provide, runPromise } from "effect/Effect";
+import { flatMap, provide, runPromise } from "effect/Effect";
 
 import type { CapturedRequest } from "../../../test/helpers/fetch-sequence";
 import { installFetchSequence } from "../../../test/helpers/fetch-sequence";
 import { isRecord } from "../../internal/guards";
+import { setCurrentEpoch } from "../../runtime/response-cache";
 import { UserSimulator } from "./user-simulator";
 
 const TEST_API_KEY = "test-key-123";
@@ -145,6 +146,32 @@ describe("UserSimulator", () => {
       };
       await runSim(sim.generateInitial());
       expect(authorization).toBe(`Bearer ${TEST_API_KEY}`);
+    });
+    it("sends the response-cache headers and an epoch-scoped cache_salt", async () => {
+      const sim = new UserSimulator(createTestConfig());
+      sim.reset("Help", "Hi");
+      let cacheHeader: string | null = null;
+      let ttlHeader: string | null = null;
+      let capturedBody: unknown;
+      global.fetch = async (input, init) => {
+        const request = new Request(input, init);
+        cacheHeader = request.headers.get("x-openrouter-cache");
+        ttlHeader = request.headers.get("x-openrouter-cache-ttl");
+        capturedBody = await request.clone().json();
+        return new Response(
+          JSON.stringify({
+            choices: [{ message: { content: "Hi" } }],
+          }),
+          { status: 200 }
+        );
+      };
+      await runSim(
+        setCurrentEpoch(2).pipe(flatMap(() => sim.generateInitial()))
+      );
+      expect(cacheHeader).toBe("true");
+      expect(ttlHeader).toBe("7200");
+      assert(isRecord(capturedBody));
+      expect(capturedBody["cache_salt"]).toBe(`${TEST_SESSION}:epoch-2`);
     });
   });
   describe("step", () => {

--- a/src/benchmarks/tau3-bench-banking/user-simulator.ts
+++ b/src/benchmarks/tau3-bench-banking/user-simulator.ts
@@ -19,6 +19,12 @@ import {
   BENCH_HARNESS_APP_REFERRER,
   BENCH_HARNESS_APP_TITLE,
 } from "../../providers/openrouter-model";
+import {
+  buildResponseCacheSalt,
+  getCurrentEpoch,
+  RESPONSE_CACHE_HEADER,
+  RESPONSE_CACHE_SALT_FIELD,
+} from "../../runtime/response-cache";
 import type { UserModelConfig } from "./types";
 import {
   USER_SIM_GUIDELINES,
@@ -148,12 +154,17 @@ export class UserSimulator {
     model: string
   ): Effect<SimulatorTurn, SimError, HttpClient.HttpClient> {
     return gen(this, function* (this: UserSimulator) {
+      const epoch = yield* getCurrentEpoch;
+      const cacheSalt = buildResponseCacheSalt(this.config.sessionId, epoch);
       const requestBody: Record<string, unknown> = {
         model,
         messages: this.messages,
         temperature: 0,
         ...(this.config.userReasoningEffort !== undefined && {
           reasoning_effort: this.config.userReasoningEffort,
+        }),
+        ...(cacheSalt !== undefined && {
+          [RESPONSE_CACHE_SALT_FIELD]: cacheSalt,
         }),
       };
       if (this.availableTools.length > 0) {
@@ -167,6 +178,7 @@ export class UserSimulator {
           "Content-Type": "application/json",
           "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
           "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
+          [RESPONSE_CACHE_HEADER]: "true",
           ...(this.config.sessionId !== undefined && {
             "x-session-id": this.config.sessionId,
           }),

--- a/src/benchmarks/tau3-bench-banking/user-simulator.ts
+++ b/src/benchmarks/tau3-bench-banking/user-simulator.ts
@@ -21,7 +21,9 @@ import {
 } from "../../providers/openrouter-model";
 import {
   buildResponseCacheSalt,
+  getCurrentCallSalt,
   getCurrentEpoch,
+  getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
 } from "../../runtime/response-cache";
@@ -155,7 +157,14 @@ export class UserSimulator {
   ): Effect<SimulatorTurn, SimError, HttpClient.HttpClient> {
     return gen(this, function* (this: UserSimulator) {
       const epoch = yield* getCurrentEpoch;
-      const cacheSalt = buildResponseCacheSalt(this.config.sessionId, epoch);
+      const retryAttempt = yield* getCurrentRetryAttempt;
+      const callSalt = yield* getCurrentCallSalt;
+      const cacheSalt = buildResponseCacheSalt(
+        this.config.sessionId,
+        epoch,
+        retryAttempt,
+        callSalt
+      );
       const requestBody: Record<string, unknown> = {
         model,
         messages: this.messages,

--- a/src/benchmarks/tau3-bench-banking/user-simulator.ts
+++ b/src/benchmarks/tau3-bench-banking/user-simulator.ts
@@ -26,6 +26,8 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_TTL_HEADER,
+  RESPONSE_CACHE_TTL_SECONDS,
 } from "../../runtime/response-cache";
 import type { UserModelConfig } from "./types";
 import {
@@ -188,6 +190,7 @@ export class UserSimulator {
           "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
           "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
           [RESPONSE_CACHE_HEADER]: "true",
+          [RESPONSE_CACHE_TTL_HEADER]: `${RESPONSE_CACHE_TTL_SECONDS}`,
           ...(this.config.sessionId !== undefined && {
             "x-session-id": this.config.sessionId,
           }),

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -18,10 +18,8 @@ import {
   zipWithIndex as streamZipWithIndex,
 } from "effect/Stream";
 
-import {
-  getCollectedGenerationIds,
-  resetGenerationIds,
-} from "../runtime/generation-ids";
+import { resetGenerationIds } from "../runtime/generation-ids";
+import { resolveCollectedGenerationIds } from "../runtime/generation-resolver";
 import { setCurrentEpoch } from "../runtime/response-cache";
 import type {
   DatasetError,
@@ -244,7 +242,7 @@ function evaluateOne(
     effectFlatMap(() =>
       evaluation.pipe(
         effectFlatMap((outcome) =>
-          getCollectedGenerationIds.pipe(
+          resolveCollectedGenerationIds.pipe(
             effectMap((ids) =>
               ids.length > 0
                 ? {

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -19,7 +19,8 @@ import {
 } from "effect/Stream";
 
 import { resetGenerationIds } from "../runtime/generation-ids";
-import { resolveCollectedGenerationIds } from "../runtime/generation-resolver";
+import type { ReplayedUsage } from "../runtime/generation-resolver";
+import { resolveCollectedGenerations } from "../runtime/generation-resolver";
 import { setCurrentEpoch } from "../runtime/response-cache";
 import type {
   DatasetError,
@@ -161,6 +162,29 @@ function finalizeRun(acc: FoldAccumulator): RunResult {
   };
 }
 
+function applyReplayedUsage(
+  outcome: EvalOutcome,
+  replayed: ReplayedUsage | undefined
+): EvalOutcome {
+  if (replayed === undefined) {
+    return outcome;
+  }
+  const u = outcome.usage;
+  return {
+    ...outcome,
+    usage: {
+      ...u,
+      inputTokens: (u?.inputTokens ?? 0) + replayed.inputTokens,
+      outputTokens: (u?.outputTokens ?? 0) + replayed.outputTokens,
+      totalTokens: (u?.totalTokens ?? 0) + replayed.totalTokens,
+      reasoningTokens: (u?.reasoningTokens ?? 0) + replayed.reasoningTokens,
+      totalCost: (u?.totalCost ?? 0) + replayed.totalCost,
+    },
+    generationTimeMs:
+      (outcome.generationTimeMs ?? 0) + replayed.generationTimeMs,
+  };
+}
+
 interface EvaluateOneOpts {
   readonly sampleEpoch: SampleEpoch;
   readonly degradeSolverErrors: boolean;
@@ -242,18 +266,22 @@ function evaluateOne(
     effectFlatMap(() =>
       evaluation.pipe(
         effectFlatMap((outcome) =>
-          resolveCollectedGenerationIds.pipe(
-            effectMap((ids) =>
-              ids.length > 0
+          resolveCollectedGenerations.pipe(
+            effectMap((resolved) => {
+              const withUsage = applyReplayedUsage(
+                outcome,
+                resolved.replayedUsage
+              );
+              return resolved.ids.length > 0
                 ? {
-                    ...outcome,
+                    ...withUsage,
                     sampleScore: {
-                      ...outcome.sampleScore,
-                      generationIds: [...new Set(ids)],
+                      ...withUsage.sampleScore,
+                      generationIds: [...new Set(resolved.ids)],
                     },
                   }
-                : outcome
-            )
+                : withUsage;
+            })
           )
         )
       )

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -22,6 +22,7 @@ import {
   getCollectedGenerationIds,
   resetGenerationIds,
 } from "../runtime/generation-ids";
+import { setCurrentEpoch } from "../runtime/response-cache";
 import type {
   DatasetError,
   ModelError,
@@ -239,6 +240,7 @@ function evaluateOne(
     })
   );
   return resetGenerationIds.pipe(
+    effectFlatMap(() => setCurrentEpoch(epoch)),
     effectFlatMap(() =>
       evaluation.pipe(
         effectFlatMap((outcome) =>

--- a/src/judge/judge.test.ts
+++ b/src/judge/judge.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "bun:test";
 
 import {
   fail as effectFail,
+  flatMap,
   runPromise,
   runPromiseExit,
   succeed,
   suspend,
+  zipRight,
 } from "effect/Effect";
 import { isFailure } from "effect/Exit";
 
@@ -16,6 +18,11 @@ import type {
   ResponsesService,
 } from "../providers/responses-client";
 import { ResponsesError } from "../providers/responses-client";
+import {
+  getCollectedGenerationIdEntries,
+  recordGenerationId,
+  resetGenerationIds,
+} from "../runtime/generation-ids";
 import { judgeCall } from "./judge";
 
 const VerdictSchema = z.object({ verdict: z.enum(["yes", "no"]) });
@@ -92,6 +99,23 @@ describe("judgeCall", () => {
     );
     expect(result.verdict).toEqual({ verdict: "yes" });
     expect(sentText).toBeUndefined();
+  });
+  it("records generation ids that count toward usage", async () => {
+    const service: ResponsesService = {
+      send: () =>
+        recordGenerationId("gen-judge", true).pipe(
+          zipRight(succeed(fixtureResult('{"verdict":"yes"}')))
+        ),
+    };
+    const entries = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() => judgeCall(service, { judgeModel: "j" }, SPEC)),
+        flatMap(() => getCollectedGenerationIdEntries)
+      )
+    );
+    expect(entries).toEqual([
+      { id: "gen-judge", isCacheHit: true, countsTowardUsage: true },
+    ]);
   });
   it("fails with ModelError when the verdict does not parse, without retrying", async () => {
     let calls = 0;

--- a/src/judge/judge.test.ts
+++ b/src/judge/judge.test.ts
@@ -114,7 +114,12 @@ describe("judgeCall", () => {
       )
     );
     expect(entries).toEqual([
-      { id: "gen-judge", isCacheHit: true, countsTowardUsage: true },
+      {
+        id: "gen-judge",
+        isCacheHit: true,
+        countsTowardUsage: true,
+        isResolvedSource: false,
+      },
     ]);
   });
   it("fails with ModelError when the verdict does not parse, without retrying", async () => {

--- a/src/judge/judge.ts
+++ b/src/judge/judge.ts
@@ -15,6 +15,7 @@ import {
   usageFromResponses,
 } from "../providers/responses-client";
 import { responsesMessage } from "../providers/responses-model";
+import { withAuxiliaryUsage } from "../runtime/generation-ids";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule, retrySalted } from "../runtime/retry";
 
@@ -79,7 +80,9 @@ export function judgeCall<T>(
     }),
   };
   return retrySalted(
-    responses.send(body, sendOptions).pipe(mapError(toModelError)),
+    withAuxiliaryUsage(responses.send(body, sendOptions)).pipe(
+      mapError(toModelError)
+    ),
     rateLimitRetrySchedule(config.retry ?? {})
   ).pipe(
     flatMap((result) => {

--- a/src/judge/judge.ts
+++ b/src/judge/judge.ts
@@ -15,7 +15,6 @@ import {
   usageFromResponses,
 } from "../providers/responses-client";
 import { responsesMessage } from "../providers/responses-model";
-import { withAuxiliaryUsage } from "../runtime/generation-ids";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule, retrySalted } from "../runtime/retry";
 
@@ -80,9 +79,7 @@ export function judgeCall<T>(
     }),
   };
   return retrySalted(
-    withAuxiliaryUsage(responses.send(body, sendOptions)).pipe(
-      mapError(toModelError)
-    ),
+    responses.send(body, sendOptions).pipe(mapError(toModelError)),
     rateLimitRetrySchedule(config.retry ?? {})
   ).pipe(
     flatMap((result) => {

--- a/src/judge/judge.ts
+++ b/src/judge/judge.ts
@@ -3,7 +3,7 @@ import type {
   TextExtendedConfig,
 } from "@openrouter/sdk/models";
 import type { Effect } from "effect/Effect";
-import { fail, flatMap, mapError, retry, succeed } from "effect/Effect";
+import { fail, flatMap, mapError, succeed } from "effect/Effect";
 
 import type { ReasoningEffort } from "../harness/constants";
 import type { ModelUsage } from "../harness/core";
@@ -15,9 +15,8 @@ import {
   usageFromResponses,
 } from "../providers/responses-client";
 import { responsesMessage } from "../providers/responses-model";
-import { withRetryAttemptSalt } from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
-import { rateLimitRetrySchedule } from "../runtime/retry";
+import { rateLimitRetrySchedule, retrySalted } from "../runtime/retry";
 
 export interface JudgeConfig {
   readonly judgeModel: string;
@@ -79,9 +78,10 @@ export function judgeCall<T>(
       versionOverride: config.versionOverride,
     }),
   };
-  return withRetryAttemptSalt(responses.send(body, sendOptions)).pipe(
-    mapError(toModelError),
-    retry(rateLimitRetrySchedule(config.retry ?? {})),
+  return retrySalted(
+    responses.send(body, sendOptions).pipe(mapError(toModelError)),
+    rateLimitRetrySchedule(config.retry ?? {})
+  ).pipe(
     flatMap((result) => {
       const parsed = spec.parseVerdict(result.text);
       const usage = usageFromResponses(result.usage);

--- a/src/judge/judge.ts
+++ b/src/judge/judge.ts
@@ -14,6 +14,7 @@ import {
   toModelError,
   usageFromResponses,
 } from "../providers/responses-client";
+import { withRetryAttemptSalt } from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule } from "../runtime/retry";
 
@@ -77,7 +78,7 @@ export function judgeCall<T>(
       versionOverride: config.versionOverride,
     }),
   };
-  return responses.send(body, sendOptions).pipe(
+  return withRetryAttemptSalt(responses.send(body, sendOptions)).pipe(
     mapError(toModelError),
     retry(rateLimitRetrySchedule(config.retry ?? {})),
     flatMap((result) => {

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -353,6 +353,77 @@ describe("openrouter-model response caching", () => {
     );
     expect(salts).toEqual(["wf-123:epoch-0", "wf-123:epoch-1"]);
   });
+  it("appends the retry attempt to cache_salt on in-process retries", async () => {
+    const salts: unknown[] = [];
+    const original = globalThis.fetch;
+    let callCount = 0;
+    const stub: typeof fetch = async (input, init) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      const rawBody = await req.clone().text();
+      salts.push(parseJsonObject(rawBody)["cache_salt"]);
+      callCount += 1;
+      if (callCount === 1) {
+        return new Response(JSON.stringify({ error: { message: "slow" } }), {
+          status: 429,
+          headers: { "content-type": "application/json", "retry-after": "0" },
+        });
+      }
+      return new Response(CHAT_RESULT_JSON, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    globalThis.fetch = stub;
+    restore = () => {
+      globalThis.fetch = original;
+    };
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+      sessionId: "wf-123",
+      retry: { maxRetries: 2, baseDelayMs: 1 },
+    });
+    await runPromiseExit(
+      gen(function* run() {
+        yield* setCurrentEpoch(1);
+        const model = yield* Model;
+        yield* model.generate(MESSAGES, {});
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    expect(salts).toEqual(["wf-123:epoch-1", "wf-123:epoch-1:attempt-1"]);
+  });
+  it("records the source generation id from cache-hit responses", async () => {
+    const original = globalThis.fetch;
+    const stub: typeof fetch = async () =>
+      new Response(CHAT_RESULT_JSON, {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-openrouter-cache-source-generation-id": "gen-original",
+        },
+      });
+    globalThis.fetch = stub;
+    restore = () => {
+      globalThis.fetch = original;
+    };
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+    });
+    const ids = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() =>
+          gen(function* run() {
+            const model = yield* Model;
+            yield* model.generate(MESSAGES, {});
+          })
+        ),
+        flatMap(() => getCollectedGenerationIds),
+        provide(layer.pipe(layerProvide(FetchHttpClient.layer)))
+      )
+    );
+    expect(ids).toEqual(["gen-original"]);
+  });
   it("omits cache_salt when session id and epoch are unset", async () => {
     const captured = newHolder();
     restore = installFetchCapture(captured);

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -28,6 +28,7 @@ import {
   getCollectedGenerationIds,
   resetGenerationIds,
 } from "../runtime/generation-ids";
+import { setCurrentEpoch } from "../runtime/response-cache";
 import { makeOpenRouterModelLayer } from "./openrouter-model";
 
 const CHAT_RESULT = {
@@ -290,6 +291,82 @@ describe("openrouter-model request parity", () => {
     expect(
       captured.value?.headers["cloudflare-workers-version-overrides"]
     ).toBeUndefined();
+  });
+});
+describe("openrouter-model response caching", () => {
+  let restore: (() => void) | undefined;
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+  it("always sends the response-cache header", async () => {
+    const captured = newHolder();
+    restore = installFetchCapture(captured);
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+    });
+    await runPromiseExit(
+      gen(function* run() {
+        const model = yield* Model;
+        yield* model.generate(MESSAGES, {});
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    expect(captured.value?.headers["x-openrouter-cache"]).toBe("true");
+  });
+  it("sends a session- and epoch-scoped cache_salt body field", async () => {
+    const captured = newHolder();
+    restore = installFetchCapture(captured);
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+      sessionId: "wf-123",
+    });
+    await runPromiseExit(
+      gen(function* run() {
+        yield* setCurrentEpoch(1);
+        const model = yield* Model;
+        yield* model.generate(MESSAGES, {});
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    expect(captured.value?.body["cache_salt"]).toBe("wf-123:epoch-1");
+  });
+  it("varies the cache_salt across epochs", async () => {
+    const captured = newHolder();
+    restore = installFetchCapture(captured);
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+      sessionId: "wf-123",
+    });
+    const salts: unknown[] = [];
+    await runPromiseExit(
+      gen(function* run() {
+        const model = yield* Model;
+        yield* setCurrentEpoch(0);
+        yield* model.generate(MESSAGES, {});
+        salts.push(captured.value?.body["cache_salt"]);
+        yield* setCurrentEpoch(1);
+        yield* model.generate(MESSAGES, {});
+        salts.push(captured.value?.body["cache_salt"]);
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    expect(salts).toEqual(["wf-123:epoch-0", "wf-123:epoch-1"]);
+  });
+  it("omits cache_salt when session id and epoch are unset", async () => {
+    const captured = newHolder();
+    restore = installFetchCapture(captured);
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+    });
+    await runPromiseExit(
+      gen(function* run() {
+        const model = yield* Model;
+        yield* model.generate(MESSAGES, {});
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    expect(captured.value?.body["cache_salt"]).toBeUndefined();
   });
 });
 describe("openrouter-model auto-router plugin", () => {

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -392,38 +392,6 @@ describe("openrouter-model response caching", () => {
     );
     expect(salts).toEqual(["wf-123:epoch-1", "wf-123:epoch-1:attempt-1"]);
   });
-  it("records the source generation id from cache-hit responses", async () => {
-    const original = globalThis.fetch;
-    const stub: typeof fetch = async () =>
-      new Response(CHAT_RESULT_JSON, {
-        status: 200,
-        headers: {
-          "content-type": "application/json",
-          "x-openrouter-cache-source-generation-id": "gen-original",
-        },
-      });
-    globalThis.fetch = stub;
-    restore = () => {
-      globalThis.fetch = original;
-    };
-    const layer = makeOpenRouterModelLayer({
-      model: "openai/gpt-4o",
-      apiKey: "sk-test",
-    });
-    const ids = await runPromise(
-      resetGenerationIds.pipe(
-        flatMap(() =>
-          gen(function* run() {
-            const model = yield* Model;
-            yield* model.generate(MESSAGES, {});
-          })
-        ),
-        flatMap(() => getCollectedGenerationIds),
-        provide(layer.pipe(layerProvide(FetchHttpClient.layer)))
-      )
-    );
-    expect(ids).toEqual(["gen-original"]);
-  });
   it("omits cache_salt when session id and epoch are unset", async () => {
     const captured = newHolder();
     restore = installFetchCapture(captured);

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -25,6 +25,7 @@ import { Model } from "../harness/model";
 import { ProviderSort } from "../internal/enums";
 import { isRecord } from "../internal/guards";
 import {
+  getCollectedGenerationIdEntries,
   getCollectedGenerationIds,
   resetGenerationIds,
 } from "../runtime/generation-ids";
@@ -146,6 +147,85 @@ describe("openrouter-model request parity", () => {
       )
     );
     expect(ids).toEqual(["1"]);
+  });
+  it("records the cache source id from the response header on cache hits", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(CHAT_RESULT_JSON, {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-openrouter-cache-status": "HIT",
+          "x-openrouter-cache-source-id": "gen-source",
+        },
+      })) as typeof fetch;
+    try {
+      const layer = makeOpenRouterModelLayer({
+        model: "openai/gpt-4o",
+        apiKey: "sk-test",
+      });
+      const entries = await runPromise(
+        resetGenerationIds.pipe(
+          flatMap(() =>
+            gen(function* run() {
+              const model = yield* Model;
+              yield* model.generate(MESSAGES, {});
+            })
+          ),
+          flatMap(() => getCollectedGenerationIdEntries),
+          provide(layer.pipe(layerProvide(FetchHttpClient.layer)))
+        )
+      );
+      expect(entries).toEqual([
+        {
+          id: "gen-source",
+          isCacheHit: true,
+          countsTowardUsage: true,
+          isResolvedSource: true,
+        },
+      ]);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+  it("records the dummy id when a cache hit has no source id header", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(CHAT_RESULT_JSON, {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-openrouter-cache-status": "HIT",
+        },
+      })) as typeof fetch;
+    try {
+      const layer = makeOpenRouterModelLayer({
+        model: "openai/gpt-4o",
+        apiKey: "sk-test",
+      });
+      const entries = await runPromise(
+        resetGenerationIds.pipe(
+          flatMap(() =>
+            gen(function* run() {
+              const model = yield* Model;
+              yield* model.generate(MESSAGES, {});
+            })
+          ),
+          flatMap(() => getCollectedGenerationIdEntries),
+          provide(layer.pipe(layerProvide(FetchHttpClient.layer)))
+        )
+      );
+      expect(entries).toEqual([
+        {
+          id: "1",
+          isCacheHit: true,
+          countsTowardUsage: true,
+          isResolvedSource: false,
+        },
+      ]);
+    } finally {
+      globalThis.fetch = original;
+    }
   });
   it("suppresses sort when endpointId is set (pinning overrides sorting)", async () => {
     const captured = newHolder();

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -38,8 +38,11 @@ import { recordGenerationId } from "../runtime/generation-ids";
 import {
   buildResponseCacheSalt,
   getCurrentEpoch,
+  getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SOURCE_GENERATION_HEADER,
+  withRetryAttemptSalt,
 } from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule } from "../runtime/retry";
@@ -141,10 +144,15 @@ export function generate(
     autoRouterPlugin === undefined
       ? undefined
       : toWireAutoRouterPlugin(autoRouterPlugin);
-  return gen(function* () {
+  const attempt = gen(function* () {
     const startedAt = performance.now();
     const epoch = yield* getCurrentEpoch;
-    const cacheSalt = buildResponseCacheSalt(opts.sessionId, epoch);
+    const retryAttempt = yield* getCurrentRetryAttempt;
+    const cacheSalt = buildResponseCacheSalt(
+      opts.sessionId,
+      epoch,
+      retryAttempt
+    );
     const body = {
       model,
       messages: messages.map(toApiMessage),
@@ -218,14 +226,22 @@ export function generate(
       logUnusableBody(rawBody, envelopeError, identifiers);
       return yield* fail(envelopeError);
     }
-    return yield* decodeResult(json, startedAt, identifiers).pipe(
+    const sourceGenerationId =
+      response.headers[RESPONSE_CACHE_SOURCE_GENERATION_HEADER];
+    return yield* decodeResult(
+      json,
+      startedAt,
+      identifiers,
+      sourceGenerationId
+    ).pipe(
       tapError((error) =>
         sync(() => {
           logUnusableBody(rawBody, error, identifiers);
         })
       )
     );
-  }).pipe(
+  });
+  return withRetryAttemptSalt(attempt).pipe(
     mapError(toModelError),
     retry(rateLimitRetrySchedule(opts.retry ?? {}))
   );
@@ -398,7 +414,8 @@ function toApiMessage(message: ChatMessage) {
 function decodeResult(
   raw: unknown,
   startedAt: number,
-  identifiers: ResponseIdentifiers
+  identifiers: ResponseIdentifiers,
+  sourceGenerationId?: string
 ): Effect<ModelOutput, ModelError> {
   const parseResult = parseSchema(
     ChatResult$inboundSchema,
@@ -438,7 +455,7 @@ function decodeResult(
   const reasoningDetails = extractReasoningDetails(raw);
   const usage = toModelUsage(result.usage);
   const toolCalls = choice.message.toolCalls ?? [];
-  return recordGenerationId(result.id).pipe(
+  return recordGenerationId(sourceGenerationId ?? result.id).pipe(
     flatMap(() =>
       succeed({
         completion,

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -41,6 +41,7 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SOURCE_ID_HEADER,
   RESPONSE_CACHE_STATUS_HEADER,
   RESPONSE_CACHE_STATUS_HIT,
   RESPONSE_CACHE_TTL_HEADER,
@@ -234,7 +235,14 @@ export function generate(
     const isCacheHit =
       response.headers[RESPONSE_CACHE_STATUS_HEADER] ===
       RESPONSE_CACHE_STATUS_HIT;
-    return yield* decodeResult(json, startedAt, identifiers, isCacheHit).pipe(
+    const cacheSourceId = response.headers[RESPONSE_CACHE_SOURCE_ID_HEADER];
+    return yield* decodeResult(
+      json,
+      startedAt,
+      identifiers,
+      isCacheHit,
+      cacheSourceId
+    ).pipe(
       tapError((error) =>
         sync(() => {
           logUnusableBody(rawBody, error, identifiers);
@@ -416,7 +424,8 @@ function decodeResult(
   raw: unknown,
   startedAt: number,
   identifiers: ResponseIdentifiers,
-  isCacheHit: boolean
+  isCacheHit: boolean,
+  cacheSourceId?: string
 ): Effect<ModelOutput, ModelError> {
   const parseResult = parseSchema(
     ChatResult$inboundSchema,
@@ -456,7 +465,12 @@ function decodeResult(
   const reasoningDetails = extractReasoningDetails(raw);
   const usage = toModelUsage(result.usage);
   const toolCalls = choice.message.toolCalls ?? [];
-  return recordGenerationId(result.id, isCacheHit).pipe(
+  const hasSourceId = isCacheHit && cacheSourceId !== undefined;
+  return recordGenerationId(
+    hasSourceId ? cacheSourceId : result.id,
+    isCacheHit,
+    hasSourceId
+  ).pipe(
     flatMap(() =>
       succeed({
         completion,

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -37,6 +37,7 @@ import { parseSchema, z } from "../internal/zod";
 import { recordGenerationId } from "../runtime/generation-ids";
 import {
   buildResponseCacheSalt,
+  getCurrentCallSalt,
   getCurrentEpoch,
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
@@ -149,10 +150,12 @@ export function generate(
     const startedAt = performance.now();
     const epoch = yield* getCurrentEpoch;
     const retryAttempt = yield* getCurrentRetryAttempt;
+    const callSalt = yield* getCurrentCallSalt;
     const cacheSalt = buildResponseCacheSalt(
       opts.sessionId,
       epoch,
-      retryAttempt
+      retryAttempt,
+      callSalt
     );
     const body = {
       model,

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -8,7 +8,6 @@ import {
   flatMap,
   gen,
   mapError,
-  retry,
   succeed,
   sync,
   tapError,
@@ -44,10 +43,11 @@ import {
   RESPONSE_CACHE_SALT_FIELD,
   RESPONSE_CACHE_STATUS_HEADER,
   RESPONSE_CACHE_STATUS_HIT,
-  withRetryAttemptSalt,
+  RESPONSE_CACHE_TTL_HEADER,
+  RESPONSE_CACHE_TTL_SECONDS,
 } from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
-import { rateLimitRetrySchedule } from "../runtime/retry";
+import { rateLimitRetrySchedule, retrySalted } from "../runtime/retry";
 import {
   buildAutoRouterPlugin,
   toWireAutoRouterPlugin,
@@ -125,6 +125,7 @@ export function generate(
     "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
     "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
     [RESPONSE_CACHE_HEADER]: "true",
+    [RESPONSE_CACHE_TTL_HEADER]: `${RESPONSE_CACHE_TTL_SECONDS}`,
   };
   if (genConfig.endpointId !== undefined) {
     headers["X-OR-Endpoint-Id"] = genConfig.endpointId;
@@ -241,9 +242,9 @@ export function generate(
       )
     );
   });
-  return withRetryAttemptSalt(attempt).pipe(
-    mapError(toModelError),
-    retry(rateLimitRetrySchedule(opts.retry ?? {}))
+  return retrySalted(
+    attempt.pipe(mapError(toModelError)),
+    rateLimitRetrySchedule(opts.retry ?? {})
   );
 }
 

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -35,6 +35,12 @@ import { isDefinedAndNotNull, isRecord } from "../internal/guards";
 import { wLog } from "../internal/log";
 import { parseSchema, z } from "../internal/zod";
 import { recordGenerationId } from "../runtime/generation-ids";
+import {
+  buildResponseCacheSalt,
+  getCurrentEpoch,
+  RESPONSE_CACHE_HEADER,
+  RESPONSE_CACHE_SALT_FIELD,
+} from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule } from "../runtime/retry";
 import {
@@ -113,6 +119,7 @@ export function generate(
     "Content-Type": "application/json",
     "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
     "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
+    [RESPONSE_CACHE_HEADER]: "true",
   };
   if (genConfig.endpointId !== undefined) {
     headers["X-OR-Endpoint-Id"] = genConfig.endpointId;
@@ -136,6 +143,8 @@ export function generate(
       : toWireAutoRouterPlugin(autoRouterPlugin);
   return gen(function* () {
     const startedAt = performance.now();
+    const epoch = yield* getCurrentEpoch;
+    const cacheSalt = buildResponseCacheSalt(opts.sessionId, epoch);
     const body = {
       model,
       messages: messages.map(toApiMessage),
@@ -155,6 +164,9 @@ export function generate(
       ...(sendSort && { provider: { sort: genConfig.sort } }),
       ...(wireAutoRouterPlugin !== undefined && {
         plugins: [wireAutoRouterPlugin],
+      }),
+      ...(cacheSalt !== undefined && {
+        [RESPONSE_CACHE_SALT_FIELD]: cacheSalt,
       }),
       ...genConfig.extraBody,
     };

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -41,6 +41,8 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_STATUS_HEADER,
+  RESPONSE_CACHE_STATUS_HIT,
   withRetryAttemptSalt,
 } from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
@@ -225,7 +227,10 @@ export function generate(
       logUnusableBody(rawBody, envelopeError, identifiers);
       return yield* fail(envelopeError);
     }
-    return yield* decodeResult(json, startedAt, identifiers).pipe(
+    const isCacheHit =
+      response.headers[RESPONSE_CACHE_STATUS_HEADER] ===
+      RESPONSE_CACHE_STATUS_HIT;
+    return yield* decodeResult(json, startedAt, identifiers, isCacheHit).pipe(
       tapError((error) =>
         sync(() => {
           logUnusableBody(rawBody, error, identifiers);
@@ -406,7 +411,8 @@ function toApiMessage(message: ChatMessage) {
 function decodeResult(
   raw: unknown,
   startedAt: number,
-  identifiers: ResponseIdentifiers
+  identifiers: ResponseIdentifiers,
+  isCacheHit: boolean
 ): Effect<ModelOutput, ModelError> {
   const parseResult = parseSchema(
     ChatResult$inboundSchema,
@@ -446,7 +452,7 @@ function decodeResult(
   const reasoningDetails = extractReasoningDetails(raw);
   const usage = toModelUsage(result.usage);
   const toolCalls = choice.message.toolCalls ?? [];
-  return recordGenerationId(result.id).pipe(
+  return recordGenerationId(result.id, isCacheHit).pipe(
     flatMap(() =>
       succeed({
         completion,

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -41,7 +41,6 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
-  RESPONSE_CACHE_SOURCE_GENERATION_HEADER,
   withRetryAttemptSalt,
 } from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
@@ -226,14 +225,7 @@ export function generate(
       logUnusableBody(rawBody, envelopeError, identifiers);
       return yield* fail(envelopeError);
     }
-    const sourceGenerationId =
-      response.headers[RESPONSE_CACHE_SOURCE_GENERATION_HEADER];
-    return yield* decodeResult(
-      json,
-      startedAt,
-      identifiers,
-      sourceGenerationId
-    ).pipe(
+    return yield* decodeResult(json, startedAt, identifiers).pipe(
       tapError((error) =>
         sync(() => {
           logUnusableBody(rawBody, error, identifiers);
@@ -414,8 +406,7 @@ function toApiMessage(message: ChatMessage) {
 function decodeResult(
   raw: unknown,
   startedAt: number,
-  identifiers: ResponseIdentifiers,
-  sourceGenerationId?: string
+  identifiers: ResponseIdentifiers
 ): Effect<ModelOutput, ModelError> {
   const parseResult = parseSchema(
     ChatResult$inboundSchema,
@@ -455,7 +446,7 @@ function decodeResult(
   const reasoningDetails = extractReasoningDetails(raw);
   const usage = toModelUsage(result.usage);
   const toolCalls = choice.message.toolCalls ?? [];
-  return recordGenerationId(sourceGenerationId ?? result.id).pipe(
+  return recordGenerationId(result.id).pipe(
     flatMap(() =>
       succeed({
         completion,

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -506,41 +506,4 @@ describe("makeResponsesLayer", () => {
       globalThis.fetch = originalFetch;
     }
   });
-  it("records the source generation id from cache-hit responses", async () => {
-    const originalFetch = globalThis.fetch;
-    const stream = await readStreamFixture();
-    globalThis.fetch = async () =>
-      new Response(stream, {
-        status: 200,
-        headers: {
-          "content-type": "text/event-stream",
-          "x-openrouter-cache-source-generation-id": "gen-original",
-        },
-      });
-    try {
-      const ids = await runPromise(
-        resetGenerationIds.pipe(
-          flatMap(() =>
-            gen(function* run() {
-              const responses = yield* Responses;
-              yield* responses.send(
-                { model: "m", input: [] },
-                { timeoutMs: 1000 }
-              );
-            })
-          ),
-          flatMap(() => getCollectedGenerationIds),
-          provide(
-            makeResponsesLayer({
-              apiKey: "sk-test",
-              baseUrl: "https://example.test",
-            })
-          )
-        )
-      );
-      expect(ids).toEqual(["gen-original"]);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
 });

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -506,4 +506,41 @@ describe("makeResponsesLayer", () => {
       globalThis.fetch = originalFetch;
     }
   });
+  it("records the source generation id from cache-hit responses", async () => {
+    const originalFetch = globalThis.fetch;
+    const stream = await readStreamFixture();
+    globalThis.fetch = async () =>
+      new Response(stream, {
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream",
+          "x-openrouter-cache-source-generation-id": "gen-original",
+        },
+      });
+    try {
+      const ids = await runPromise(
+        resetGenerationIds.pipe(
+          flatMap(() =>
+            gen(function* run() {
+              const responses = yield* Responses;
+              yield* responses.send(
+                { model: "m", input: [] },
+                { timeoutMs: 1000 }
+              );
+            })
+          ),
+          flatMap(() => getCollectedGenerationIds),
+          provide(
+            makeResponsesLayer({
+              apiKey: "sk-test",
+              baseUrl: "https://example.test",
+            })
+          )
+        )
+      );
+      expect(ids).toEqual(["gen-original"]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -18,6 +18,7 @@ import { assertFailure } from "../../test/helpers/exit-asserts";
 import { assertRight } from "../internal/testing";
 import { parseSchema, z } from "../internal/zod";
 import {
+  getCollectedGenerationIdEntries,
   getCollectedGenerationIds,
   resetGenerationIds,
 } from "../runtime/generation-ids";
@@ -389,6 +390,51 @@ describe("makeResponsesLayer", () => {
       expect(capturedHeaders?.get("x-openrouter-title")).toBe(
         "OpenRouter: Bench Harness"
       );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("records the cache source id from the response header on cache hits", async () => {
+    const originalFetch = globalThis.fetch;
+    const stream = await readStreamFixture();
+    globalThis.fetch = async () =>
+      new Response(stream, {
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream",
+          "x-openrouter-cache-status": "HIT",
+          "x-openrouter-cache-source-id": "gen-source",
+        },
+      });
+    try {
+      const entries = await runPromise(
+        resetGenerationIds.pipe(
+          flatMap(() =>
+            gen(function* run() {
+              const responses = yield* Responses;
+              yield* responses.send(
+                { model: "m", input: [] },
+                { timeoutMs: 1000 }
+              );
+            })
+          ),
+          flatMap(() => getCollectedGenerationIdEntries),
+          provide(
+            makeResponsesLayer({
+              apiKey: "sk-test",
+              baseUrl: "https://example.test",
+            })
+          )
+        )
+      );
+      expect(entries).toEqual([
+        {
+          id: "gen-source",
+          isCacheHit: true,
+          countsTowardUsage: true,
+          isResolvedSource: true,
+        },
+      ]);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -21,6 +21,7 @@ import {
   getCollectedGenerationIds,
   resetGenerationIds,
 } from "../runtime/generation-ids";
+import { setCurrentEpoch } from "../runtime/response-cache";
 import type { ModelErrorIdentifiers } from "./request-identifiers";
 import {
   consumeStream,
@@ -458,6 +459,49 @@ describe("makeResponsesLayer", () => {
       const error = getOrThrow(failureOption(exit.cause));
       expect(error.status).toBe(500);
       expect(error.retryable).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("sends the response-cache header and an epoch-scoped cache_salt", async () => {
+    const originalFetch = globalThis.fetch;
+    const stream = await readStreamFixture();
+    const capturedBodies: unknown[] = [];
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = async (input, init) => {
+      const request =
+        input instanceof Request ? input : new Request(input, init);
+      capturedBodies.push(await request.clone().json());
+      capturedHeaders = request.headers;
+      return new Response(stream, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    };
+    try {
+      await runPromise(
+        gen(function* run() {
+          yield* setCurrentEpoch(2);
+          const responses = yield* Responses;
+          yield* responses.send(
+            { model: "m", input: [] },
+            { timeoutMs: 1000, extraBody: { top_k: 5 } }
+          );
+        }).pipe(
+          provide(
+            makeResponsesLayer({
+              apiKey: "sk-test",
+              baseUrl: "https://example.test",
+              sessionId: "wf-123",
+            })
+          )
+        )
+      );
+      expect(capturedHeaders?.get("x-openrouter-cache")).toBe("true");
+      expect(capturedBodies[0]).toMatchObject({
+        cache_salt: "wf-123:epoch-2",
+        top_k: 5,
+      });
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -33,6 +33,7 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SOURCE_ID_HEADER,
   RESPONSE_CACHE_STATUS_HEADER,
   RESPONSE_CACHE_STATUS_HIT,
   RESPONSE_CACHE_TTL_HEADER,
@@ -134,6 +135,7 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
   ): Effect<ResponsesResult, ResponsesError> => {
     let identifiers: ModelErrorIdentifiers = {};
     let isCacheHit = false;
+    let cacheSourceId: string | undefined;
     const httpClient = new HTTPClient({
       fetcher: async (input, init) => {
         const request = await mergeExtraBody(input, init, effectiveExtraBody);
@@ -142,6 +144,8 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
         isCacheHit =
           response.headers.get(RESPONSE_CACHE_STATUS_HEADER) ===
           RESPONSE_CACHE_STATUS_HIT;
+        cacheSourceId =
+          response.headers.get(RESPONSE_CACHE_SOURCE_ID_HEADER) ?? undefined;
         options.onResponseIdentifiers?.(identifiers);
         return response;
       },
@@ -200,9 +204,13 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     }).pipe(
       flatMap((result) =>
         result
-          ? recordGenerationId(result.generationId, isCacheHit).pipe(
-              map(() => result)
-            )
+          ? recordGenerationId(
+              isCacheHit && cacheSourceId !== undefined
+                ? cacheSourceId
+                : result.generationId,
+              isCacheHit,
+              isCacheHit && cacheSourceId !== undefined
+            ).pipe(map(() => result))
           : fail(
               new ResponsesError({
                 message: appendModelErrorIdentifiers(

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -29,8 +29,10 @@ import { recordGenerationId } from "../runtime/generation-ids";
 import {
   buildResponseCacheSalt,
   getCurrentEpoch,
+  getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SOURCE_GENERATION_HEADER,
 } from "../runtime/response-cache";
 import {
   BENCH_HARNESS_APP_REFERRER,
@@ -127,11 +129,15 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     effectiveExtraBody: Readonly<Record<string, unknown>> | undefined
   ): Effect<ResponsesResult, ResponsesError> => {
     let identifiers: ModelErrorIdentifiers = {};
+    let sourceGenerationId: string | null = null;
     const httpClient = new HTTPClient({
       fetcher: async (input, init) => {
         const request = await mergeExtraBody(input, init, effectiveExtraBody);
         const response = await fetch(request);
         identifiers = modelErrorIdentifiersFromFetchHeaders(response.headers);
+        sourceGenerationId = response.headers.get(
+          RESPONSE_CACHE_SOURCE_GENERATION_HEADER
+        );
         options.onResponseIdentifiers?.(identifiers);
         return response;
       },
@@ -189,7 +195,9 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     }).pipe(
       flatMap((result) =>
         result
-          ? recordGenerationId(result.generationId).pipe(map(() => result))
+          ? recordGenerationId(sourceGenerationId ?? result.generationId).pipe(
+              map(() => result)
+            )
           : fail(
               new ResponsesError({
                 message: appendModelErrorIdentifiers(
@@ -208,8 +216,17 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     options: ResponsesSendOptions
   ): Effect<ResponsesResult, ResponsesError> => {
     return getCurrentEpoch.pipe(
-      flatMap((epoch) => {
-        const cacheSalt = buildResponseCacheSalt(config.sessionId, epoch);
+      flatMap((epoch) =>
+        getCurrentRetryAttempt.pipe(
+          map((retryAttempt) => ({ epoch, retryAttempt }))
+        )
+      ),
+      flatMap(({ epoch, retryAttempt }) => {
+        const cacheSalt = buildResponseCacheSalt(
+          config.sessionId,
+          epoch,
+          retryAttempt
+        );
         const effectiveExtraBody =
           cacheSalt === undefined
             ? options.extraBody

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -35,6 +35,8 @@ import {
   RESPONSE_CACHE_SALT_FIELD,
   RESPONSE_CACHE_STATUS_HEADER,
   RESPONSE_CACHE_STATUS_HIT,
+  RESPONSE_CACHE_TTL_HEADER,
+  RESPONSE_CACHE_TTL_SECONDS,
 } from "../runtime/response-cache";
 import {
   BENCH_HARNESS_APP_REFERRER,
@@ -163,6 +165,7 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
         "x-session-id": config.sessionId,
       }),
       [RESPONSE_CACHE_HEADER]: "true",
+      [RESPONSE_CACHE_TTL_HEADER]: `${RESPONSE_CACHE_TTL_SECONDS}`,
     };
     return tryPromise({
       try: async (signal) => {

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -27,6 +27,12 @@ import { isRecord } from "../internal/guards";
 import { z } from "../internal/zod";
 import { recordGenerationId } from "../runtime/generation-ids";
 import {
+  buildResponseCacheSalt,
+  getCurrentEpoch,
+  RESPONSE_CACHE_HEADER,
+  RESPONSE_CACHE_SALT_FIELD,
+} from "../runtime/response-cache";
+import {
   BENCH_HARNESS_APP_REFERRER,
   BENCH_HARNESS_APP_TITLE,
 } from "./openrouter-model";
@@ -117,12 +123,13 @@ function normalizeBaseUrl(baseUrl: string): string {
 export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
   const send = (
     body: ResponsesRequest,
-    options: ResponsesSendOptions
+    options: ResponsesSendOptions,
+    effectiveExtraBody: Readonly<Record<string, unknown>> | undefined
   ): Effect<ResponsesResult, ResponsesError> => {
     let identifiers: ModelErrorIdentifiers = {};
     const httpClient = new HTTPClient({
       fetcher: async (input, init) => {
-        const request = await mergeExtraBody(input, init, options.extraBody);
+        const request = await mergeExtraBody(input, init, effectiveExtraBody);
         const response = await fetch(request);
         identifiers = modelErrorIdentifiersFromFetchHeaders(response.headers);
         options.onResponseIdentifiers?.(identifiers);
@@ -147,6 +154,7 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
       ...(config.sessionId !== undefined && {
         "x-session-id": config.sessionId,
       }),
+      [RESPONSE_CACHE_HEADER]: "true",
     };
     return tryPromise({
       try: async (signal) => {
@@ -154,7 +162,7 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
         const requestBody = {
           ...body,
           ...(body.cacheControl === undefined &&
-            options.extraBody?.["cache_control"] === undefined && {
+            effectiveExtraBody?.["cache_control"] === undefined && {
               cacheControl: { type: "ephemeral" as const },
             }),
           stream: true,
@@ -195,7 +203,25 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
       )
     );
   };
-  return layerSucceed(Responses, Responses.of({ send }));
+  const sendWithCacheSalt = (
+    body: ResponsesRequest,
+    options: ResponsesSendOptions
+  ): Effect<ResponsesResult, ResponsesError> => {
+    return getCurrentEpoch.pipe(
+      flatMap((epoch) => {
+        const cacheSalt = buildResponseCacheSalt(config.sessionId, epoch);
+        const effectiveExtraBody =
+          cacheSalt === undefined
+            ? options.extraBody
+            : {
+                [RESPONSE_CACHE_SALT_FIELD]: cacheSalt,
+                ...options.extraBody,
+              };
+        return send(body, options, effectiveExtraBody);
+      })
+    );
+  };
+  return layerSucceed(Responses, Responses.of({ send: sendWithCacheSalt }));
 }
 
 async function mergeExtraBody(

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -32,6 +32,8 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_STATUS_HEADER,
+  RESPONSE_CACHE_STATUS_HIT,
 } from "../runtime/response-cache";
 import {
   BENCH_HARNESS_APP_REFERRER,
@@ -128,11 +130,15 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     effectiveExtraBody: Readonly<Record<string, unknown>> | undefined
   ): Effect<ResponsesResult, ResponsesError> => {
     let identifiers: ModelErrorIdentifiers = {};
+    let isCacheHit = false;
     const httpClient = new HTTPClient({
       fetcher: async (input, init) => {
         const request = await mergeExtraBody(input, init, effectiveExtraBody);
         const response = await fetch(request);
         identifiers = modelErrorIdentifiersFromFetchHeaders(response.headers);
+        isCacheHit =
+          response.headers.get(RESPONSE_CACHE_STATUS_HEADER) ===
+          RESPONSE_CACHE_STATUS_HIT;
         options.onResponseIdentifiers?.(identifiers);
         return response;
       },
@@ -190,7 +196,9 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     }).pipe(
       flatMap((result) =>
         result
-          ? recordGenerationId(result.generationId).pipe(map(() => result))
+          ? recordGenerationId(result.generationId, isCacheHit).pipe(
+              map(() => result)
+            )
           : fail(
               new ResponsesError({
                 message: appendModelErrorIdentifiers(

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -28,6 +28,7 @@ import { z } from "../internal/zod";
 import { recordGenerationId } from "../runtime/generation-ids";
 import {
   buildResponseCacheSalt,
+  getCurrentCallSalt,
   getCurrentEpoch,
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
@@ -219,14 +220,19 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     return getCurrentEpoch.pipe(
       flatMap((epoch) =>
         getCurrentRetryAttempt.pipe(
-          map((retryAttempt) => ({ epoch, retryAttempt }))
+          flatMap((retryAttempt) =>
+            getCurrentCallSalt.pipe(
+              map((callSalt) => ({ epoch, retryAttempt, callSalt }))
+            )
+          )
         )
       ),
-      flatMap(({ epoch, retryAttempt }) => {
+      flatMap(({ epoch, retryAttempt, callSalt }) => {
         const cacheSalt = buildResponseCacheSalt(
           config.sessionId,
           epoch,
-          retryAttempt
+          retryAttempt,
+          callSalt
         );
         const effectiveExtraBody =
           cacheSalt === undefined

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -32,7 +32,6 @@ import {
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
-  RESPONSE_CACHE_SOURCE_GENERATION_HEADER,
 } from "../runtime/response-cache";
 import {
   BENCH_HARNESS_APP_REFERRER,
@@ -129,15 +128,11 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     effectiveExtraBody: Readonly<Record<string, unknown>> | undefined
   ): Effect<ResponsesResult, ResponsesError> => {
     let identifiers: ModelErrorIdentifiers = {};
-    let sourceGenerationId: string | null = null;
     const httpClient = new HTTPClient({
       fetcher: async (input, init) => {
         const request = await mergeExtraBody(input, init, effectiveExtraBody);
         const response = await fetch(request);
         identifiers = modelErrorIdentifiersFromFetchHeaders(response.headers);
-        sourceGenerationId = response.headers.get(
-          RESPONSE_CACHE_SOURCE_GENERATION_HEADER
-        );
         options.onResponseIdentifiers?.(identifiers);
         return response;
       },
@@ -195,9 +190,7 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     }).pipe(
       flatMap((result) =>
         result
-          ? recordGenerationId(sourceGenerationId ?? result.generationId).pipe(
-              map(() => result)
-            )
+          ? recordGenerationId(result.generationId).pipe(map(() => result))
           : fail(
               new ResponsesError({
                 message: appendModelErrorIdentifiers(

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -25,6 +25,7 @@ import { ModelError } from "../harness/core";
 import type { GenerateConfig } from "../harness/model";
 import { stripVariantSuffix } from "../harness/model";
 import { isRecord } from "../internal/guards";
+import { withRetryAttemptSalt } from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule } from "../runtime/retry";
 import { buildAutoRouterPlugin } from "./auto-router-plugin";
@@ -213,7 +214,9 @@ export function generate(
           )
         )
       : requestAttempt;
-  return timedAttempt.pipe(retry(rateLimitRetrySchedule(opts.retry ?? {})));
+  return withRetryAttemptSalt(timedAttempt).pipe(
+    retry(rateLimitRetrySchedule(opts.retry ?? {}))
+  );
 }
 
 const RAW_PAYLOAD_KEYS = new Set(["arguments", "output"]);

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -14,7 +14,6 @@ import {
   gen,
   map,
   mapError,
-  retry,
   suspend,
   timeout,
 } from "effect/Effect";
@@ -26,9 +25,8 @@ import { ModelError } from "../harness/core";
 import type { GenerateConfig } from "../harness/model";
 import { stripVariantSuffix } from "../harness/model";
 import { isRecord } from "../internal/guards";
-import { withRetryAttemptSalt } from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
-import { rateLimitRetrySchedule } from "../runtime/retry";
+import { rateLimitRetrySchedule, retrySalted } from "../runtime/retry";
 import { buildAutoRouterPlugin } from "./auto-router-plugin";
 import type { ModelErrorIdentifiers } from "./request-identifiers";
 import { appendModelErrorIdentifiers } from "./request-identifiers";
@@ -228,9 +226,7 @@ export function generate(
           )
         )
       : requestAttempt;
-  return withRetryAttemptSalt(timedAttempt).pipe(
-    retry(rateLimitRetrySchedule(opts.retry ?? {}))
-  );
+  return retrySalted(timedAttempt, rateLimitRetrySchedule(opts.retry ?? {}));
 }
 
 const RAW_PAYLOAD_KEYS = new Set(["arguments", "output"]);

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -27,6 +27,10 @@ import type { AsyncEither } from "../internal/either";
 import { Either } from "../internal/either";
 import { wLog } from "../internal/log";
 import type { ResultStoreService } from "../results/result-store";
+import {
+  GenerationResolver,
+  makeOpenRouterGenerationResolver,
+} from "../runtime/generation-resolver";
 import type { RetryConfig } from "../runtime/retry";
 
 export interface RunBenchmarkInput {
@@ -102,10 +106,18 @@ export function runBenchmarkById(
   const fullBenchmarkLayer = benchmarkLayer.pipe(
     layerProvide(FetchHttpClient.layer)
   );
+  const resolverLayer = layerSucceed(
+    GenerationResolver,
+    makeOpenRouterGenerationResolver({
+      apiKey: input.apiKey,
+      ...(input.baseUrl !== undefined && { baseUrl: input.baseUrl }),
+    })
+  );
   const layers = layerMergeAll(
     fullBenchmarkLayer,
     progressLayer,
-    checkpointLayer
+    checkpointLayer,
+    resolverLayer
   );
   const runOpts =
     input.abortSignal !== undefined ? { signal: input.abortSignal } : undefined;

--- a/src/runtime/generation-ids.test.ts
+++ b/src/runtime/generation-ids.test.ts
@@ -3,11 +3,26 @@ import { describe, expect, it } from "bun:test";
 import { all, flatMap, forEach, runPromise } from "effect/Effect";
 
 import {
+  getCollectedGenerationIdEntries,
   getCollectedGenerationIds,
   recordGenerationId,
   resetGenerationIds,
 } from "./generation-ids";
 describe("generation id collector", () => {
+  it("flags cache-hit ids in collected entries", async () => {
+    const entries = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() => recordGenerationId("gen-real")),
+        flatMap(() => recordGenerationId("gen-dummy", true)),
+        flatMap(() => getCollectedGenerationIdEntries)
+      )
+    );
+    const sorted = [...entries].toSorted((a, b) => a.id.localeCompare(b.id));
+    expect(sorted).toEqual([
+      { id: "gen-dummy", isCacheHit: true },
+      { id: "gen-real", isCacheHit: false },
+    ]);
+  });
   it("records, ignores empty ids, and resets", async () => {
     const ids = await runPromise(
       resetGenerationIds.pipe(

--- a/src/runtime/generation-ids.test.ts
+++ b/src/runtime/generation-ids.test.ts
@@ -15,13 +15,30 @@ describe("generation id collector", () => {
       resetGenerationIds.pipe(
         flatMap(() => recordGenerationId("gen-real")),
         flatMap(() => recordGenerationId("gen-dummy", true)),
+        flatMap(() => recordGenerationId("gen-source", true, true)),
         flatMap(() => getCollectedGenerationIdEntries)
       )
     );
     const sorted = [...entries].toSorted((a, b) => a.id.localeCompare(b.id));
     expect(sorted).toEqual([
-      { id: "gen-dummy", isCacheHit: true, countsTowardUsage: true },
-      { id: "gen-real", isCacheHit: false, countsTowardUsage: true },
+      {
+        id: "gen-dummy",
+        isCacheHit: true,
+        countsTowardUsage: true,
+        isResolvedSource: false,
+      },
+      {
+        id: "gen-real",
+        isCacheHit: false,
+        countsTowardUsage: true,
+        isResolvedSource: false,
+      },
+      {
+        id: "gen-source",
+        isCacheHit: true,
+        countsTowardUsage: true,
+        isResolvedSource: true,
+      },
     ]);
   });
   it("marks ids recorded inside withAuxiliaryUsage as not counting toward usage", async () => {
@@ -36,8 +53,18 @@ describe("generation id collector", () => {
     );
     const sorted = [...entries].toSorted((a, b) => a.id.localeCompare(b.id));
     expect(sorted).toEqual([
-      { id: "gen-judge", isCacheHit: true, countsTowardUsage: false },
-      { id: "gen-solver", isCacheHit: true, countsTowardUsage: true },
+      {
+        id: "gen-judge",
+        isCacheHit: true,
+        countsTowardUsage: false,
+        isResolvedSource: false,
+      },
+      {
+        id: "gen-solver",
+        isCacheHit: true,
+        countsTowardUsage: true,
+        isResolvedSource: false,
+      },
     ]);
   });
   it("records, ignores empty ids, and resets", async () => {

--- a/src/runtime/generation-ids.test.ts
+++ b/src/runtime/generation-ids.test.ts
@@ -7,6 +7,7 @@ import {
   getCollectedGenerationIds,
   recordGenerationId,
   resetGenerationIds,
+  withAuxiliaryUsage,
 } from "./generation-ids";
 describe("generation id collector", () => {
   it("flags cache-hit ids in collected entries", async () => {
@@ -19,8 +20,24 @@ describe("generation id collector", () => {
     );
     const sorted = [...entries].toSorted((a, b) => a.id.localeCompare(b.id));
     expect(sorted).toEqual([
-      { id: "gen-dummy", isCacheHit: true },
-      { id: "gen-real", isCacheHit: false },
+      { id: "gen-dummy", isCacheHit: true, countsTowardUsage: true },
+      { id: "gen-real", isCacheHit: false, countsTowardUsage: true },
+    ]);
+  });
+  it("marks ids recorded inside withAuxiliaryUsage as not counting toward usage", async () => {
+    const entries = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() => recordGenerationId("gen-solver", true)),
+        flatMap(() =>
+          withAuxiliaryUsage(recordGenerationId("gen-judge", true))
+        ),
+        flatMap(() => getCollectedGenerationIdEntries)
+      )
+    );
+    const sorted = [...entries].toSorted((a, b) => a.id.localeCompare(b.id));
+    expect(sorted).toEqual([
+      { id: "gen-judge", isCacheHit: true, countsTowardUsage: false },
+      { id: "gen-solver", isCacheHit: true, countsTowardUsage: true },
     ]);
   });
   it("records, ignores empty ids, and resets", async () => {

--- a/src/runtime/generation-ids.ts
+++ b/src/runtime/generation-ids.ts
@@ -1,11 +1,29 @@
 import type { Effect } from "effect/Effect";
-import { all, map, succeed, zipRight } from "effect/Effect";
-import { get, set, unsafeMakeHashSet, update } from "effect/FiberRef";
+import { all, flatMap, locally, map, succeed, zipRight } from "effect/Effect";
+import type { FiberRef } from "effect/FiberRef";
+import {
+  get,
+  set,
+  unsafeMake,
+  unsafeMakeHashSet,
+  update,
+} from "effect/FiberRef";
 import { add, empty, has } from "effect/HashSet";
 
 export const generationIdCollector = unsafeMakeHashSet<string>(empty());
 
 export const cacheHitGenerationIdCollector = unsafeMakeHashSet<string>(empty());
+
+export const auxiliaryUsageGenerationIdCollector =
+  unsafeMakeHashSet<string>(empty());
+
+export const auxiliaryUsageRef: FiberRef<boolean> = unsafeMake(false);
+
+export function withAuxiliaryUsage<A, E, R>(
+  effect: Effect<A, E, R>
+): Effect<A, E, R> {
+  return locally(effect, auxiliaryUsageRef, true);
+}
 
 export function recordGenerationId(
   id: string | null | undefined,
@@ -14,16 +32,33 @@ export function recordGenerationId(
   if (id === null || id === undefined || id.length === 0) {
     return succeed(undefined);
   }
-  const record = update(generationIdCollector, add(id));
-  return isCacheHit
-    ? record.pipe(zipRight(update(cacheHitGenerationIdCollector, add(id))))
-    : record;
+  const generationId = id;
+  let record = update(generationIdCollector, add(generationId));
+  if (isCacheHit) {
+    record = record.pipe(
+      zipRight(update(cacheHitGenerationIdCollector, add(generationId)))
+    );
+  }
+  return get(auxiliaryUsageRef).pipe(
+    flatMap((isAuxiliary) =>
+      isAuxiliary
+        ? record.pipe(
+            zipRight(
+              update(auxiliaryUsageGenerationIdCollector, add(generationId))
+            )
+          )
+        : record
+    )
+  );
 }
 
 export const resetGenerationIds: Effect<void> = set(
   generationIdCollector,
   empty<string>()
-).pipe(zipRight(set(cacheHitGenerationIdCollector, empty<string>())));
+).pipe(
+  zipRight(set(cacheHitGenerationIdCollector, empty<string>())),
+  zipRight(set(auxiliaryUsageGenerationIdCollector, empty<string>()))
+);
 
 export const getCollectedGenerationIds: Effect<readonly string[]> = get(
   generationIdCollector
@@ -32,12 +67,21 @@ export const getCollectedGenerationIds: Effect<readonly string[]> = get(
 export interface GenerationIdEntry {
   readonly id: string;
   readonly isCacheHit: boolean;
+  readonly countsTowardUsage: boolean;
 }
 
 export const getCollectedGenerationIdEntries: Effect<
   readonly GenerationIdEntry[]
-> = all([get(generationIdCollector), get(cacheHitGenerationIdCollector)]).pipe(
-  map(([ids, cacheHitIds]) =>
-    [...ids].map((id) => ({ id, isCacheHit: has(cacheHitIds, id) }))
+> = all([
+  get(generationIdCollector),
+  get(cacheHitGenerationIdCollector),
+  get(auxiliaryUsageGenerationIdCollector),
+]).pipe(
+  map(([ids, cacheHitIds, auxiliaryIds]) =>
+    [...ids].map((id) => ({
+      id,
+      isCacheHit: has(cacheHitIds, id),
+      countsTowardUsage: !has(auxiliaryIds, id),
+    }))
   )
 );

--- a/src/runtime/generation-ids.ts
+++ b/src/runtime/generation-ids.ts
@@ -1,24 +1,43 @@
 import type { Effect } from "effect/Effect";
-import { map, succeed } from "effect/Effect";
+import { all, map, succeed, zipRight } from "effect/Effect";
 import { get, set, unsafeMakeHashSet, update } from "effect/FiberRef";
-import { add, empty } from "effect/HashSet";
+import { add, empty, has } from "effect/HashSet";
 
 export const generationIdCollector = unsafeMakeHashSet<string>(empty());
 
+export const cacheHitGenerationIdCollector = unsafeMakeHashSet<string>(empty());
+
 export function recordGenerationId(
-  id: string | null | undefined
+  id: string | null | undefined,
+  isCacheHit = false
 ): Effect<void> {
   if (id === null || id === undefined || id.length === 0) {
     return succeed(undefined);
   }
-  return update(generationIdCollector, add(id));
+  const record = update(generationIdCollector, add(id));
+  return isCacheHit
+    ? record.pipe(zipRight(update(cacheHitGenerationIdCollector, add(id))))
+    : record;
 }
 
 export const resetGenerationIds: Effect<void> = set(
   generationIdCollector,
-  empty()
-);
+  empty<string>()
+).pipe(zipRight(set(cacheHitGenerationIdCollector, empty<string>())));
 
 export const getCollectedGenerationIds: Effect<readonly string[]> = get(
   generationIdCollector
 ).pipe(map((ids) => [...ids]));
+
+export interface GenerationIdEntry {
+  readonly id: string;
+  readonly isCacheHit: boolean;
+}
+
+export const getCollectedGenerationIdEntries: Effect<
+  readonly GenerationIdEntry[]
+> = all([get(generationIdCollector), get(cacheHitGenerationIdCollector)]).pipe(
+  map(([ids, cacheHitIds]) =>
+    [...ids].map((id) => ({ id, isCacheHit: has(cacheHitIds, id) }))
+  )
+);

--- a/src/runtime/generation-ids.ts
+++ b/src/runtime/generation-ids.ts
@@ -17,6 +17,9 @@ export const cacheHitGenerationIdCollector = unsafeMakeHashSet<string>(empty());
 export const auxiliaryUsageGenerationIdCollector =
   unsafeMakeHashSet<string>(empty());
 
+export const resolvedSourceGenerationIdCollector =
+  unsafeMakeHashSet<string>(empty());
+
 export const auxiliaryUsageRef: FiberRef<boolean> = unsafeMake(false);
 
 export function withAuxiliaryUsage<A, E, R>(
@@ -27,7 +30,8 @@ export function withAuxiliaryUsage<A, E, R>(
 
 export function recordGenerationId(
   id: string | null | undefined,
-  isCacheHit = false
+  isCacheHit = false,
+  isResolvedSource = false
 ): Effect<void> {
   if (id === null || id === undefined || id.length === 0) {
     return succeed(undefined);
@@ -38,6 +42,11 @@ export function recordGenerationId(
     record = record.pipe(
       zipRight(update(cacheHitGenerationIdCollector, add(generationId)))
     );
+    if (isResolvedSource) {
+      record = record.pipe(
+        zipRight(update(resolvedSourceGenerationIdCollector, add(generationId)))
+      );
+    }
   }
   return get(auxiliaryUsageRef).pipe(
     flatMap((isAuxiliary) =>
@@ -57,7 +66,8 @@ export const resetGenerationIds: Effect<void> = set(
   empty<string>()
 ).pipe(
   zipRight(set(cacheHitGenerationIdCollector, empty<string>())),
-  zipRight(set(auxiliaryUsageGenerationIdCollector, empty<string>()))
+  zipRight(set(auxiliaryUsageGenerationIdCollector, empty<string>())),
+  zipRight(set(resolvedSourceGenerationIdCollector, empty<string>()))
 );
 
 export const getCollectedGenerationIds: Effect<readonly string[]> = get(
@@ -68,6 +78,7 @@ export interface GenerationIdEntry {
   readonly id: string;
   readonly isCacheHit: boolean;
   readonly countsTowardUsage: boolean;
+  readonly isResolvedSource: boolean;
 }
 
 export const getCollectedGenerationIdEntries: Effect<
@@ -76,12 +87,14 @@ export const getCollectedGenerationIdEntries: Effect<
   get(generationIdCollector),
   get(cacheHitGenerationIdCollector),
   get(auxiliaryUsageGenerationIdCollector),
+  get(resolvedSourceGenerationIdCollector),
 ]).pipe(
-  map(([ids, cacheHitIds, auxiliaryIds]) =>
+  map(([ids, cacheHitIds, auxiliaryIds, resolvedSourceIds]) =>
     [...ids].map((id) => ({
       id,
       isCacheHit: has(cacheHitIds, id),
       countsTowardUsage: !has(auxiliaryIds, id),
+      isResolvedSource: has(resolvedSourceIds, id),
     }))
   )
 );

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -288,6 +288,6 @@ describe("makeOpenRouterGenerationResolver", () => {
       resolver.resolveSourceGeneration("gen-dummy")
     );
     expect(resolved).toEqual({ sourceId: "gen-original" });
-    expect(getCalls().length).toBe(2);
+    expect(getCalls().length).toBe(3);
   });
 });

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -242,6 +242,20 @@ describe("makeOpenRouterGenerationResolver", () => {
       3
     );
   });
+  it("does not retry permanent lookup failures", async () => {
+    const getCalls = mockFetch(() => jsonResponse({ error: "denied" }, 401));
+    const resolver = makeOpenRouterGenerationResolver({
+      apiKey: "test-key",
+      baseUrl: "https://example.com",
+      pollIntervalMs: 1,
+      maxAttempts: 5,
+    });
+    const resolved = await runPromise(
+      resolver.resolveSourceGeneration("gen-dummy")
+    );
+    expect(resolved).toBeUndefined();
+    expect(getCalls().length).toBe(1);
+  });
   it("returns undefined after exactly maxAttempts lookups when the source id never becomes available", async () => {
     const getCalls = mockFetch(() =>
       jsonResponse({ data: { response_cache_source_id: null } })

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -119,8 +119,10 @@ describe("makeOpenRouterGenerationResolver", () => {
     expect(sourceId).toBe("gen-original");
     expect(getCalls().length).toBe(3);
   });
-  it("returns undefined when the source id never becomes available", async () => {
-    mockFetch(() => jsonResponse({ data: { response_cache_source_id: null } }));
+  it("returns undefined after exactly maxAttempts lookups when the source id never becomes available", async () => {
+    const getCalls = mockFetch(() =>
+      jsonResponse({ data: { response_cache_source_id: null } })
+    );
     const resolver = makeOpenRouterGenerationResolver({
       apiKey: "test-key",
       baseUrl: "https://example.com",
@@ -131,5 +133,6 @@ describe("makeOpenRouterGenerationResolver", () => {
       resolver.resolveSourceGenerationId("gen-dummy")
     );
     expect(sourceId).toBeUndefined();
+    expect(getCalls().length).toBe(2);
   });
 });

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -201,8 +201,8 @@ describe("makeOpenRouterGenerationResolver", () => {
         : jsonResponse({
             data: {
               response_cache_source_id: null,
-              tokens_prompt: 10,
-              tokens_completion: 25,
+              native_tokens_prompt: 10,
+              native_tokens_completion: 25,
               native_tokens_reasoning: 5,
               total_cost: 0.0015,
               generation_time: 1200,
@@ -289,8 +289,8 @@ describe("makeOpenRouterGenerationResolver", () => {
       jsonResponse({
         data: {
           response_cache_source_id: null,
-          tokens_prompt: 10,
-          tokens_completion: 25,
+          native_tokens_prompt: 10,
+          native_tokens_completion: 25,
           native_tokens_reasoning: 5,
           total_cost: 0.0015,
           generation_time: 1200,

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 import { flatMap, provideService, runPromise, succeed } from "effect/Effect";
 
@@ -308,6 +308,41 @@ describe("makeOpenRouterGenerationResolver", () => {
     );
     expect(resolved).toEqual({ sourceId: "gen-source", usage: SOURCE_USAGE });
     expect(getCalls().length).toBe(1);
+  });
+  it("warns when the source generation has no usage fields", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {
+      // capture warnings
+    });
+    try {
+      mockFetch(() =>
+        jsonResponse({ data: { response_cache_source_id: null } })
+      );
+      const resolver = makeOpenRouterGenerationResolver({
+        apiKey: "test-key",
+        baseUrl: "https://example.com",
+        pollIntervalMs: 1,
+        maxAttempts: 1,
+      });
+      const resolved = await runPromise(
+        resolver.resolveSourceGeneration("gen-source")
+      );
+      expect(resolved?.usage).toEqual({
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        reasoningTokens: 0,
+        totalCost: 0,
+        generationTimeMs: 0,
+      });
+      const messages = warn.mock.calls.map((call) => String(call[0]));
+      expect(
+        messages.some((message) =>
+          message.includes("Source generation has no usage fields")
+        )
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
   });
   it("returns undefined after exactly maxAttempts lookups when the row never lands", async () => {
     const getCalls = mockFetch(() => jsonResponse({ error: "not found" }, 404));

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -148,6 +148,34 @@ describe("resolveCollectedGenerations", () => {
     expect(resolved.ids).toEqual(["gen-dummy"]);
     expect(resolved.replayedUsage).toBeUndefined();
   });
+  it("skips resolution for auxiliary ids whose source is already resolved", async () => {
+    const requested: string[] = [];
+    const resolver: GenerationResolverService = {
+      resolveSourceGeneration: (generationId, options) => {
+        requested.push(generationId);
+        return succeed({
+          sourceId: generationId,
+          ...(options?.includeUsage === false ? {} : { usage: SOURCE_USAGE }),
+        });
+      },
+    };
+    const resolved = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() => recordGenerationId("gen-solver-source", true, true)),
+        flatMap(() =>
+          withAuxiliaryUsage(recordGenerationId("gen-judge-source", true, true))
+        ),
+        flatMap(() => resolveCollectedGenerations),
+        provideService(GenerationResolver, resolver)
+      )
+    );
+    expect(requested).toEqual(["gen-solver-source"]);
+    expect([...resolved.ids].toSorted()).toEqual([
+      "gen-judge-source",
+      "gen-solver-source",
+    ]);
+    expect(resolved.replayedUsage).toEqual(SOURCE_USAGE);
+  });
   it("omits usage for entries that resolve without usage", async () => {
     const resolver: GenerationResolverService = {
       resolveSourceGeneration: (generationId) =>
@@ -256,10 +284,33 @@ describe("makeOpenRouterGenerationResolver", () => {
     expect(resolved).toBeUndefined();
     expect(getCalls().length).toBe(1);
   });
-  it("returns undefined after exactly maxAttempts lookups when the source id never becomes available", async () => {
+  it("treats a record without response_cache_source_id as the source itself", async () => {
     const getCalls = mockFetch(() =>
-      jsonResponse({ data: { response_cache_source_id: null } })
+      jsonResponse({
+        data: {
+          response_cache_source_id: null,
+          tokens_prompt: 10,
+          tokens_completion: 25,
+          native_tokens_reasoning: 5,
+          total_cost: 0.0015,
+          generation_time: 1200,
+        },
+      })
     );
+    const resolver = makeOpenRouterGenerationResolver({
+      apiKey: "test-key",
+      baseUrl: "https://example.com",
+      pollIntervalMs: 1,
+      maxAttempts: 2,
+    });
+    const resolved = await runPromise(
+      resolver.resolveSourceGeneration("gen-source")
+    );
+    expect(resolved).toEqual({ sourceId: "gen-source", usage: SOURCE_USAGE });
+    expect(getCalls().length).toBe(1);
+  });
+  it("returns undefined after exactly maxAttempts lookups when the row never lands", async () => {
+    const getCalls = mockFetch(() => jsonResponse({ error: "not found" }, 404));
     const resolver = makeOpenRouterGenerationResolver({
       apiKey: "test-key",
       baseUrl: "https://example.com",
@@ -288,6 +339,6 @@ describe("makeOpenRouterGenerationResolver", () => {
       resolver.resolveSourceGeneration("gen-dummy")
     );
     expect(resolved).toEqual({ sourceId: "gen-original" });
-    expect(getCalls().length).toBe(3);
+    expect(getCalls().length).toBe(2);
   });
 });

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -3,11 +3,14 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { flatMap, provideService, runPromise, succeed } from "effect/Effect";
 
 import { recordGenerationId, resetGenerationIds } from "./generation-ids";
-import type { GenerationResolverService } from "./generation-resolver";
+import type {
+  GenerationResolverService,
+  ReplayedUsage,
+} from "./generation-resolver";
 import {
   GenerationResolver,
   makeOpenRouterGenerationResolver,
-  resolveCollectedGenerationIds,
+  resolveCollectedGenerations,
 } from "./generation-resolver";
 
 const originalFetch = globalThis.fetch;
@@ -35,55 +38,108 @@ function mockFetch(
   return () => calls;
 }
 
-describe("resolveCollectedGenerationIds", () => {
+const SOURCE_USAGE: ReplayedUsage = {
+  inputTokens: 10,
+  outputTokens: 25,
+  totalTokens: 35,
+  reasoningTokens: 5,
+  totalCost: 0.0015,
+  generationTimeMs: 1200,
+};
+
+describe("resolveCollectedGenerations", () => {
   it("returns collected ids unchanged when no resolver is provided", async () => {
-    const ids = await runPromise(
+    const resolved = await runPromise(
       resetGenerationIds.pipe(
         flatMap(() => recordGenerationId("gen-real")),
         flatMap(() => recordGenerationId("gen-dummy", true)),
-        flatMap(() => resolveCollectedGenerationIds)
+        flatMap(() => resolveCollectedGenerations)
       )
     );
-    expect([...ids].toSorted()).toEqual(["gen-dummy", "gen-real"]);
+    expect([...resolved.ids].toSorted()).toEqual(["gen-dummy", "gen-real"]);
+    expect(resolved.replayedUsage).toBeUndefined();
   });
-  it("resolves only cache-hit ids through the resolver", async () => {
-    const resolved: string[] = [];
+  it("resolves only cache-hit ids through the resolver and sums replayed usage", async () => {
+    const requested: string[] = [];
     const resolver: GenerationResolverService = {
-      resolveSourceGenerationId: (generationId) => {
-        resolved.push(generationId);
-        return succeed(`source-of-${generationId}`);
+      resolveSourceGeneration: (generationId) => {
+        requested.push(generationId);
+        return succeed({
+          sourceId: `source-of-${generationId}`,
+          usage: SOURCE_USAGE,
+        });
       },
     };
-    const ids = await runPromise(
+    const resolved = await runPromise(
       resetGenerationIds.pipe(
         flatMap(() => recordGenerationId("gen-real")),
         flatMap(() => recordGenerationId("gen-dummy", true)),
-        flatMap(() => resolveCollectedGenerationIds),
+        flatMap(() => recordGenerationId("gen-dummy-2", true)),
+        flatMap(() => resolveCollectedGenerations),
         provideService(GenerationResolver, resolver)
       )
     );
-    expect(resolved).toEqual(["gen-dummy"]);
-    expect([...ids].toSorted()).toEqual(["gen-real", "source-of-gen-dummy"]);
+    expect([...requested].toSorted()).toEqual(["gen-dummy", "gen-dummy-2"]);
+    expect([...resolved.ids].toSorted()).toEqual([
+      "gen-real",
+      "source-of-gen-dummy",
+      "source-of-gen-dummy-2",
+    ]);
+    expect(resolved.replayedUsage).toEqual({
+      inputTokens: 20,
+      outputTokens: 50,
+      totalTokens: 70,
+      reasoningTokens: 10,
+      totalCost: 0.003,
+      generationTimeMs: 2400,
+    });
   });
-  it("keeps the dummy id when resolution returns undefined", async () => {
+  it("keeps the dummy id and reports no usage when resolution returns undefined", async () => {
     const resolver: GenerationResolverService = {
-      resolveSourceGenerationId: () => succeed(undefined),
+      resolveSourceGeneration: () => succeed(undefined),
     };
-    const ids = await runPromise(
+    const resolved = await runPromise(
       resetGenerationIds.pipe(
         flatMap(() => recordGenerationId("gen-dummy", true)),
-        flatMap(() => resolveCollectedGenerationIds),
+        flatMap(() => resolveCollectedGenerations),
         provideService(GenerationResolver, resolver)
       )
     );
-    expect(ids).toEqual(["gen-dummy"]);
+    expect(resolved.ids).toEqual(["gen-dummy"]);
+    expect(resolved.replayedUsage).toBeUndefined();
+  });
+  it("omits usage for entries that resolve without usage", async () => {
+    const resolver: GenerationResolverService = {
+      resolveSourceGeneration: (generationId) =>
+        succeed({ sourceId: `source-of-${generationId}` }),
+    };
+    const resolved = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() => recordGenerationId("gen-dummy", true)),
+        flatMap(() => resolveCollectedGenerations),
+        provideService(GenerationResolver, resolver)
+      )
+    );
+    expect(resolved.ids).toEqual(["source-of-gen-dummy"]);
+    expect(resolved.replayedUsage).toBeUndefined();
   });
 });
 
 describe("makeOpenRouterGenerationResolver", () => {
-  it("resolves the source generation id from the generation endpoint", async () => {
-    const getCalls = mockFetch(() =>
-      jsonResponse({ data: { response_cache_source_id: "gen-original" } })
+  it("resolves the source generation id and fetches the source usage", async () => {
+    const getCalls = mockFetch((url) =>
+      url.includes("gen-dummy")
+        ? jsonResponse({ data: { response_cache_source_id: "gen-original" } })
+        : jsonResponse({
+            data: {
+              response_cache_source_id: null,
+              tokens_prompt: 10,
+              tokens_completion: 25,
+              native_tokens_reasoning: 5,
+              total_cost: 0.0015,
+              generation_time: 1200,
+            },
+          })
     );
     const resolver = makeOpenRouterGenerationResolver({
       apiKey: "test-key",
@@ -91,17 +147,24 @@ describe("makeOpenRouterGenerationResolver", () => {
       pollIntervalMs: 1,
       maxAttempts: 1,
     });
-    const sourceId = await runPromise(
-      resolver.resolveSourceGenerationId("gen-dummy")
+    const resolved = await runPromise(
+      resolver.resolveSourceGeneration("gen-dummy")
     );
-    expect(sourceId).toBe("gen-original");
+    expect(resolved).toEqual({
+      sourceId: "gen-original",
+      usage: SOURCE_USAGE,
+    });
     expect(getCalls()).toEqual([
       "https://example.com/api/v1/generation?id=gen-dummy",
+      "https://example.com/api/v1/generation?id=gen-original",
     ]);
   });
   it("polls until the generation row lands", async () => {
     let attempts = 0;
-    const getCalls = mockFetch(() => {
+    const getCalls = mockFetch((url) => {
+      if (url.includes("gen-original")) {
+        return jsonResponse({ data: { response_cache_source_id: null } });
+      }
       attempts += 1;
       return attempts < 3
         ? jsonResponse({ error: "not found" }, 404)
@@ -113,11 +176,13 @@ describe("makeOpenRouterGenerationResolver", () => {
       pollIntervalMs: 1,
       maxAttempts: 5,
     });
-    const sourceId = await runPromise(
-      resolver.resolveSourceGenerationId("gen-dummy")
+    const resolved = await runPromise(
+      resolver.resolveSourceGeneration("gen-dummy")
     );
-    expect(sourceId).toBe("gen-original");
-    expect(getCalls().length).toBe(3);
+    expect(resolved?.sourceId).toBe("gen-original");
+    expect(getCalls().filter((url) => url.includes("gen-dummy")).length).toBe(
+      3
+    );
   });
   it("returns undefined after exactly maxAttempts lookups when the source id never becomes available", async () => {
     const getCalls = mockFetch(() =>
@@ -129,10 +194,28 @@ describe("makeOpenRouterGenerationResolver", () => {
       pollIntervalMs: 1,
       maxAttempts: 2,
     });
-    const sourceId = await runPromise(
-      resolver.resolveSourceGenerationId("gen-dummy")
+    const resolved = await runPromise(
+      resolver.resolveSourceGeneration("gen-dummy")
     );
-    expect(sourceId).toBeUndefined();
+    expect(resolved).toBeUndefined();
+    expect(getCalls().length).toBe(2);
+  });
+  it("returns the source id without usage when the source lookup fails", async () => {
+    const getCalls = mockFetch((url) =>
+      url.includes("gen-dummy")
+        ? jsonResponse({ data: { response_cache_source_id: "gen-original" } })
+        : jsonResponse({ error: "boom" }, 500)
+    );
+    const resolver = makeOpenRouterGenerationResolver({
+      apiKey: "test-key",
+      baseUrl: "https://example.com",
+      pollIntervalMs: 1,
+      maxAttempts: 1,
+    });
+    const resolved = await runPromise(
+      resolver.resolveSourceGeneration("gen-dummy")
+    );
+    expect(resolved).toEqual({ sourceId: "gen-original" });
     expect(getCalls().length).toBe(2);
   });
 });

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -310,9 +310,7 @@ describe("makeOpenRouterGenerationResolver", () => {
     expect(getCalls().length).toBe(1);
   });
   it("warns when the source generation has no usage fields", async () => {
-    const warn = spyOn(console, "warn").mockImplementation(() => {
-      // capture warnings
-    });
+    const warn = spyOn(console, "warn").mockImplementation(() => undefined);
     try {
       mockFetch(() =>
         jsonResponse({ data: { response_cache_source_id: null } })

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -2,7 +2,11 @@ import { afterEach, describe, expect, it } from "bun:test";
 
 import { flatMap, provideService, runPromise, succeed } from "effect/Effect";
 
-import { recordGenerationId, resetGenerationIds } from "./generation-ids";
+import {
+  recordGenerationId,
+  resetGenerationIds,
+  withAuxiliaryUsage,
+} from "./generation-ids";
 import type {
   GenerationResolverService,
   ReplayedUsage,
@@ -94,6 +98,42 @@ describe("resolveCollectedGenerations", () => {
       generationTimeMs: 2400,
     });
   });
+  it("resolves auxiliary cache-hit ids without counting their usage", async () => {
+    const requested: { id: string; includeUsage: boolean | undefined }[] = [];
+    const resolver: GenerationResolverService = {
+      resolveSourceGeneration: (generationId, options) => {
+        requested.push({
+          id: generationId,
+          includeUsage: options?.includeUsage,
+        });
+        return succeed({
+          sourceId: `source-of-${generationId}`,
+          ...(options?.includeUsage === false ? {} : { usage: SOURCE_USAGE }),
+        });
+      },
+    };
+    const resolved = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() => recordGenerationId("gen-solver", true)),
+        flatMap(() =>
+          withAuxiliaryUsage(recordGenerationId("gen-judge", true))
+        ),
+        flatMap(() => resolveCollectedGenerations),
+        provideService(GenerationResolver, resolver)
+      )
+    );
+    expect([...requested].toSorted((a, b) => a.id.localeCompare(b.id))).toEqual(
+      [
+        { id: "gen-judge", includeUsage: false },
+        { id: "gen-solver", includeUsage: true },
+      ]
+    );
+    expect([...resolved.ids].toSorted()).toEqual([
+      "source-of-gen-judge",
+      "source-of-gen-solver",
+    ]);
+    expect(resolved.replayedUsage).toEqual(SOURCE_USAGE);
+  });
   it("keeps the dummy id and reports no usage when resolution returns undefined", async () => {
     const resolver: GenerationResolverService = {
       resolveSourceGeneration: () => succeed(undefined),
@@ -157,6 +197,24 @@ describe("makeOpenRouterGenerationResolver", () => {
     expect(getCalls()).toEqual([
       "https://example.com/api/v1/generation?id=gen-dummy",
       "https://example.com/api/v1/generation?id=gen-original",
+    ]);
+  });
+  it("skips the source usage lookup when includeUsage is false", async () => {
+    const getCalls = mockFetch(() =>
+      jsonResponse({ data: { response_cache_source_id: "gen-original" } })
+    );
+    const resolver = makeOpenRouterGenerationResolver({
+      apiKey: "test-key",
+      baseUrl: "https://example.com",
+      pollIntervalMs: 1,
+      maxAttempts: 1,
+    });
+    const resolved = await runPromise(
+      resolver.resolveSourceGeneration("gen-dummy", { includeUsage: false })
+    );
+    expect(resolved).toEqual({ sourceId: "gen-original" });
+    expect(getCalls()).toEqual([
+      "https://example.com/api/v1/generation?id=gen-dummy",
     ]);
   });
   it("polls until the generation row lands", async () => {

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { flatMap, provideService, runPromise, succeed } from "effect/Effect";
+
+import { recordGenerationId, resetGenerationIds } from "./generation-ids";
+import type { GenerationResolverService } from "./generation-resolver";
+import {
+  GenerationResolver,
+  makeOpenRouterGenerationResolver,
+  resolveCollectedGenerationIds,
+} from "./generation-resolver";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockFetch(
+  handler: (url: string) => Response
+): () => readonly string[] {
+  const calls: string[] = [];
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : new Request(input).url;
+    calls.push(url);
+    return Promise.resolve(handler(url));
+  }) as typeof fetch;
+  return () => calls;
+}
+
+describe("resolveCollectedGenerationIds", () => {
+  it("returns collected ids unchanged when no resolver is provided", async () => {
+    const ids = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() => recordGenerationId("gen-real")),
+        flatMap(() => recordGenerationId("gen-dummy", true)),
+        flatMap(() => resolveCollectedGenerationIds)
+      )
+    );
+    expect([...ids].toSorted()).toEqual(["gen-dummy", "gen-real"]);
+  });
+  it("resolves only cache-hit ids through the resolver", async () => {
+    const resolved: string[] = [];
+    const resolver: GenerationResolverService = {
+      resolveSourceGenerationId: (generationId) => {
+        resolved.push(generationId);
+        return succeed(`source-of-${generationId}`);
+      },
+    };
+    const ids = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() => recordGenerationId("gen-real")),
+        flatMap(() => recordGenerationId("gen-dummy", true)),
+        flatMap(() => resolveCollectedGenerationIds),
+        provideService(GenerationResolver, resolver)
+      )
+    );
+    expect(resolved).toEqual(["gen-dummy"]);
+    expect([...ids].toSorted()).toEqual(["gen-real", "source-of-gen-dummy"]);
+  });
+  it("keeps the dummy id when resolution returns undefined", async () => {
+    const resolver: GenerationResolverService = {
+      resolveSourceGenerationId: () => succeed(undefined),
+    };
+    const ids = await runPromise(
+      resetGenerationIds.pipe(
+        flatMap(() => recordGenerationId("gen-dummy", true)),
+        flatMap(() => resolveCollectedGenerationIds),
+        provideService(GenerationResolver, resolver)
+      )
+    );
+    expect(ids).toEqual(["gen-dummy"]);
+  });
+});
+
+describe("makeOpenRouterGenerationResolver", () => {
+  it("resolves the source generation id from the generation endpoint", async () => {
+    const getCalls = mockFetch(() =>
+      jsonResponse({ data: { response_cache_source_id: "gen-original" } })
+    );
+    const resolver = makeOpenRouterGenerationResolver({
+      apiKey: "test-key",
+      baseUrl: "https://example.com",
+      pollIntervalMs: 1,
+      maxAttempts: 1,
+    });
+    const sourceId = await runPromise(
+      resolver.resolveSourceGenerationId("gen-dummy")
+    );
+    expect(sourceId).toBe("gen-original");
+    expect(getCalls()).toEqual([
+      "https://example.com/api/v1/generation?id=gen-dummy",
+    ]);
+  });
+  it("polls until the generation row lands", async () => {
+    let attempts = 0;
+    const getCalls = mockFetch(() => {
+      attempts += 1;
+      return attempts < 3
+        ? jsonResponse({ error: "not found" }, 404)
+        : jsonResponse({ data: { response_cache_source_id: "gen-original" } });
+    });
+    const resolver = makeOpenRouterGenerationResolver({
+      apiKey: "test-key",
+      baseUrl: "https://example.com",
+      pollIntervalMs: 1,
+      maxAttempts: 5,
+    });
+    const sourceId = await runPromise(
+      resolver.resolveSourceGenerationId("gen-dummy")
+    );
+    expect(sourceId).toBe("gen-original");
+    expect(getCalls().length).toBe(3);
+  });
+  it("returns undefined when the source id never becomes available", async () => {
+    mockFetch(() => jsonResponse({ data: { response_cache_source_id: null } }));
+    const resolver = makeOpenRouterGenerationResolver({
+      apiKey: "test-key",
+      baseUrl: "https://example.com",
+      pollIntervalMs: 1,
+      maxAttempts: 2,
+    });
+    const sourceId = await runPromise(
+      resolver.resolveSourceGenerationId("gen-dummy")
+    );
+    expect(sourceId).toBeUndefined();
+  });
+});

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -53,8 +53,8 @@ export class GenerationResolver extends Tag(
 const GenerationLookupSchema = z.object({
   data: z.object({
     response_cache_source_id: z.string().nullish(),
-    tokens_prompt: z.number().nullish(),
-    tokens_completion: z.number().nullish(),
+    native_tokens_prompt: z.number().nullish(),
+    native_tokens_completion: z.number().nullish(),
     native_tokens_reasoning: z.number().nullish(),
     total_cost: z.number().nullish(),
     generation_time: z.number().nullish(),
@@ -93,16 +93,16 @@ function usageFromLookup(
   generationId: string
 ): ReplayedUsage {
   const hasUsageFields =
-    isDefinedAndNotNull(data.tokens_prompt) ||
-    isDefinedAndNotNull(data.tokens_completion) ||
+    isDefinedAndNotNull(data.native_tokens_prompt) ||
+    isDefinedAndNotNull(data.native_tokens_completion) ||
     isDefinedAndNotNull(data.total_cost);
   if (!hasUsageFields) {
     wLog("Source generation has no usage fields, folding zeros", {
       generation_id: generationId,
     });
   }
-  const inputTokens = data.tokens_prompt ?? 0;
-  const outputTokens = data.tokens_completion ?? 0;
+  const inputTokens = data.native_tokens_prompt ?? 0;
+  const outputTokens = data.native_tokens_completion ?? 0;
   return {
     inputTokens,
     outputTokens,

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -24,10 +24,24 @@ import { parseSchema, z } from "../internal/zod";
 import type { GenerationIdEntry } from "./generation-ids";
 import { getCollectedGenerationIdEntries } from "./generation-ids";
 
+export interface ReplayedUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly totalTokens: number;
+  readonly reasoningTokens: number;
+  readonly totalCost: number;
+  readonly generationTimeMs: number;
+}
+
+export interface ResolvedSourceGeneration {
+  readonly sourceId: string;
+  readonly usage?: ReplayedUsage;
+}
+
 export interface GenerationResolverService {
-  readonly resolveSourceGenerationId: (
+  readonly resolveSourceGeneration: (
     generationId: string
-  ) => Effect<string | undefined>;
+  ) => Effect<ResolvedSourceGeneration | undefined>;
 }
 
 export class GenerationResolver extends Tag(
@@ -37,8 +51,15 @@ export class GenerationResolver extends Tag(
 const GenerationLookupSchema = z.object({
   data: z.object({
     response_cache_source_id: z.string().nullish(),
+    tokens_prompt: z.number().nullish(),
+    tokens_completion: z.number().nullish(),
+    native_tokens_reasoning: z.number().nullish(),
+    total_cost: z.number().nullish(),
+    generation_time: z.number().nullish(),
   }),
 });
+
+type GenerationLookupData = z.infer<typeof GenerationLookupSchema>["data"];
 
 class GenerationLookupError extends TaggedError("GenerationLookupError")<{
   readonly message: string;
@@ -60,15 +81,32 @@ function normalizeBaseUrl(baseUrl: string): string {
   return trimmed.endsWith("/api/v1") ? trimmed : `${trimmed}/api/v1`;
 }
 
+function usageFromLookup(data: GenerationLookupData): ReplayedUsage {
+  const inputTokens = data.tokens_prompt ?? 0;
+  const outputTokens = data.tokens_completion ?? 0;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    reasoningTokens: data.native_tokens_reasoning ?? 0,
+    totalCost: data.total_cost ?? 0,
+    generationTimeMs: data.generation_time ?? 0,
+  };
+}
+
 export function makeOpenRouterGenerationResolver(
   config: GenerationResolverConfig
 ): GenerationResolverService {
   const baseUrl = normalizeBaseUrl(config.baseUrl ?? "https://openrouter.ai");
   const pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const maxAttempts = config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const pollSchedule = () =>
+    spaced(`${pollIntervalMs} millis`).pipe(
+      intersect(recurs(Math.max(maxAttempts - 1, 0)))
+    );
   const lookupOnce = (
     generationId: string
-  ): Effect<string, GenerationLookupError> =>
+  ): Effect<GenerationLookupData, GenerationLookupError> =>
     tryPromise({
       try: async (signal) => {
         const response = await fetch(
@@ -89,14 +127,21 @@ export function makeOpenRouterGenerationResolver(
     }).pipe(
       flatMap((json) => {
         const parsed = parseSchema(GenerationLookupSchema, json);
-        if (Either.isLeft(parsed)) {
-          return fail(
-            new GenerationLookupError({
-              message: unknownErrorToString(parsed.left),
-            })
-          );
-        }
-        const sourceId = parsed.right.data.response_cache_source_id;
+        return Either.isLeft(parsed)
+          ? fail(
+              new GenerationLookupError({
+                message: unknownErrorToString(parsed.left),
+              })
+            )
+          : succeed(parsed.right.data);
+      })
+    );
+  const lookupSourceId = (
+    generationId: string
+  ): Effect<string, GenerationLookupError> =>
+    lookupOnce(generationId).pipe(
+      flatMap((data) => {
+        const sourceId = data.response_cache_source_id;
         return sourceId === null ||
           sourceId === undefined ||
           sourceId.length === 0
@@ -106,17 +151,36 @@ export function makeOpenRouterGenerationResolver(
               })
             )
           : succeed(sourceId);
-      })
+      }),
+      retry(pollSchedule())
+    );
+  const lookupSourceUsage = (
+    sourceId: string
+  ): Effect<ReplayedUsage | undefined> =>
+    lookupOnce(sourceId).pipe(
+      retry(pollSchedule()),
+      map((data): ReplayedUsage | undefined => usageFromLookup(data)),
+      catchAll((error) =>
+        sync(() => {
+          wLog("Failed to fetch source generation usage", {
+            generation_id: sourceId,
+            error: error.message,
+          });
+          return undefined;
+        })
+      )
     );
   return {
-    resolveSourceGenerationId: (generationId) =>
-      lookupOnce(generationId).pipe(
-        retry(
-          spaced(`${pollIntervalMs} millis`).pipe(
-            intersect(recurs(Math.max(maxAttempts - 1, 0)))
+    resolveSourceGeneration: (generationId) =>
+      lookupSourceId(generationId).pipe(
+        flatMap((sourceId) =>
+          lookupSourceUsage(sourceId).pipe(
+            map((usage): ResolvedSourceGeneration => ({
+              sourceId,
+              ...(usage !== undefined && { usage }),
+            }))
           )
         ),
-        map((sourceId): string | undefined => sourceId),
         catchAll((error) =>
           sync(() => {
             wLog("Failed to resolve cache-hit source generation id", {
@@ -130,28 +194,73 @@ export function makeOpenRouterGenerationResolver(
   };
 }
 
+export interface ResolvedGenerations {
+  readonly ids: readonly string[];
+  readonly replayedUsage?: ReplayedUsage;
+}
+
+interface ResolvedEntry {
+  readonly id: string;
+  readonly usage?: ReplayedUsage;
+}
+
 function resolveEntry(
   entry: GenerationIdEntry,
   resolver: GenerationResolverService
-): Effect<string> {
+): Effect<ResolvedEntry> {
   return entry.isCacheHit
-    ? resolver
-        .resolveSourceGenerationId(entry.id)
-        .pipe(map((sourceId) => sourceId ?? entry.id))
-    : succeed(entry.id);
+    ? resolver.resolveSourceGeneration(entry.id).pipe(
+        map((resolved): ResolvedEntry =>
+          resolved === undefined
+            ? { id: entry.id }
+            : {
+                id: resolved.sourceId,
+                ...(resolved.usage && { usage: resolved.usage }),
+              }
+        )
+      )
+    : succeed({ id: entry.id });
 }
 
-export const resolveCollectedGenerationIds: Effect<readonly string[]> = gen(
+function sumReplayedUsage(
+  acc: ReplayedUsage | undefined,
+  usage: ReplayedUsage | undefined
+): ReplayedUsage | undefined {
+  if (usage === undefined) {
+    return acc;
+  }
+  if (acc === undefined) {
+    return usage;
+  }
+  return {
+    inputTokens: acc.inputTokens + usage.inputTokens,
+    outputTokens: acc.outputTokens + usage.outputTokens,
+    totalTokens: acc.totalTokens + usage.totalTokens,
+    reasoningTokens: acc.reasoningTokens + usage.reasoningTokens,
+    totalCost: acc.totalCost + usage.totalCost,
+    generationTimeMs: acc.generationTimeMs + usage.generationTimeMs,
+  };
+}
+
+export const resolveCollectedGenerations: Effect<ResolvedGenerations> = gen(
   function* () {
     const entries = yield* getCollectedGenerationIdEntries;
     const resolver = yield* serviceOption(GenerationResolver);
     if (isNone(resolver) || entries.every((entry) => !entry.isCacheHit)) {
-      return entries.map((entry) => entry.id);
+      return { ids: entries.map((entry) => entry.id) };
     }
-    return yield* forEach(
+    const resolved = yield* forEach(
       entries,
       (entry) => resolveEntry(entry, resolver.value),
       { concurrency: RESOLVE_CONCURRENCY }
     );
+    let replayedUsage: ReplayedUsage | undefined;
+    for (const entry of resolved) {
+      replayedUsage = sumReplayedUsage(replayedUsage, entry.usage);
+    }
+    return {
+      ids: resolved.map((entry) => entry.id),
+      ...(replayedUsage !== undefined && { replayedUsage }),
+    };
   }
 );

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -19,6 +19,7 @@ import { intersect, recurs, spaced, whileInput } from "effect/Schedule";
 
 import { Either } from "../internal/either";
 import { unknownErrorToString } from "../internal/errors";
+import { isDefinedAndNotNull } from "../internal/guards";
 import { wLog } from "../internal/log";
 import { parseSchema, z } from "../internal/zod";
 import type { GenerationIdEntry } from "./generation-ids";
@@ -87,7 +88,19 @@ function normalizeBaseUrl(baseUrl: string): string {
   return trimmed.endsWith("/api/v1") ? trimmed : `${trimmed}/api/v1`;
 }
 
-function usageFromLookup(data: GenerationLookupData): ReplayedUsage {
+function usageFromLookup(
+  data: GenerationLookupData,
+  generationId: string
+): ReplayedUsage {
+  const hasUsageFields =
+    isDefinedAndNotNull(data.tokens_prompt) ||
+    isDefinedAndNotNull(data.tokens_completion) ||
+    isDefinedAndNotNull(data.total_cost);
+  if (!hasUsageFields) {
+    wLog("Source generation has no usage fields, folding zeros", {
+      generation_id: generationId,
+    });
+  }
   const inputTokens = data.tokens_prompt ?? 0;
   const outputTokens = data.tokens_completion ?? 0;
   return {
@@ -165,7 +178,7 @@ export function makeOpenRouterGenerationResolver(
     sourceId: string
   ): Effect<ReplayedUsage | undefined> =>
     lookupGeneration(sourceId).pipe(
-      map((data): ReplayedUsage | undefined => usageFromLookup(data)),
+      map((data): ReplayedUsage | undefined => usageFromLookup(data, sourceId)),
       catchAll((error) =>
         sync(() => {
           wLog("Failed to fetch source generation usage", {
@@ -193,7 +206,7 @@ export function makeOpenRouterGenerationResolver(
           if (sourceId === generationId) {
             return succeed<ResolvedSourceGeneration>({
               sourceId,
-              usage: usageFromLookup(data),
+              usage: usageFromLookup(data, generationId),
             });
           }
           return lookupSourceUsage(sourceId).pipe(

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -40,7 +40,8 @@ export interface ResolvedSourceGeneration {
 
 export interface GenerationResolverService {
   readonly resolveSourceGeneration: (
-    generationId: string
+    generationId: string,
+    options?: { readonly includeUsage?: boolean }
   ) => Effect<ResolvedSourceGeneration | undefined>;
 }
 
@@ -171,15 +172,17 @@ export function makeOpenRouterGenerationResolver(
       )
     );
   return {
-    resolveSourceGeneration: (generationId) =>
+    resolveSourceGeneration: (generationId, options) =>
       lookupSourceId(generationId).pipe(
         flatMap((sourceId) =>
-          lookupSourceUsage(sourceId).pipe(
-            map((usage): ResolvedSourceGeneration => ({
-              sourceId,
-              ...(usage !== undefined && { usage }),
-            }))
-          )
+          options?.includeUsage === false
+            ? succeed<ResolvedSourceGeneration>({ sourceId })
+            : lookupSourceUsage(sourceId).pipe(
+                map((usage): ResolvedSourceGeneration => ({
+                  sourceId,
+                  ...(usage !== undefined && { usage }),
+                }))
+              )
         ),
         catchAll((error) =>
           sync(() => {
@@ -209,16 +212,20 @@ function resolveEntry(
   resolver: GenerationResolverService
 ): Effect<ResolvedEntry> {
   return entry.isCacheHit
-    ? resolver.resolveSourceGeneration(entry.id).pipe(
-        map((resolved): ResolvedEntry =>
-          resolved === undefined
-            ? { id: entry.id }
-            : {
-                id: resolved.sourceId,
-                ...(resolved.usage && { usage: resolved.usage }),
-              }
+    ? resolver
+        .resolveSourceGeneration(entry.id, {
+          includeUsage: entry.countsTowardUsage,
+        })
+        .pipe(
+          map((resolved): ResolvedEntry =>
+            resolved === undefined
+              ? { id: entry.id }
+              : {
+                  id: resolved.sourceId,
+                  ...(resolved.usage && { usage: resolved.usage }),
+                }
+          )
         )
-      )
     : succeed({ id: entry.id });
 }
 

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -15,7 +15,7 @@ import {
   tryPromise,
 } from "effect/Effect";
 import { isNone } from "effect/Option";
-import { intersect, recurs, spaced } from "effect/Schedule";
+import { intersect, recurs, spaced, whileInput } from "effect/Schedule";
 
 import { Either } from "../internal/either";
 import { unknownErrorToString } from "../internal/errors";
@@ -64,7 +64,12 @@ type GenerationLookupData = z.infer<typeof GenerationLookupSchema>["data"];
 
 class GenerationLookupError extends TaggedError("GenerationLookupError")<{
   readonly message: string;
+  readonly retryable: boolean;
 }> {}
+
+function isRetryableLookupStatus(status: number): boolean {
+  return status === 404 || status === 408 || status === 429 || status >= 500;
+}
 
 export interface GenerationResolverConfig {
   readonly apiKey: string;
@@ -103,13 +108,16 @@ export function makeOpenRouterGenerationResolver(
   const maxAttempts = config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
   const pollSchedule = () =>
     spaced(`${pollIntervalMs} millis`).pipe(
-      intersect(recurs(Math.max(maxAttempts - 1, 0)))
+      intersect(recurs(Math.max(maxAttempts - 1, 0))),
+      whileInput((error: GenerationLookupError) => error.retryable)
     );
   const lookupOnce = (
     generationId: string
   ): Effect<GenerationLookupData, GenerationLookupError> =>
     tryPromise({
-      try: async (signal) => {
+      try: async (
+        signal
+      ): Promise<{ readonly status: number } | { readonly json: unknown }> => {
         const response = await fetch(
           `${baseUrl}/generation?id=${encodeURIComponent(generationId)}`,
           {
@@ -119,19 +127,31 @@ export function makeOpenRouterGenerationResolver(
         );
         if (!response.ok) {
           await response.body?.cancel();
-          throw new Error(`generation lookup returned ${response.status}`);
+          return { status: response.status };
         }
-        return (await response.json()) as unknown;
+        return { json: (await response.json()) as unknown };
       },
       catch: (cause) =>
-        new GenerationLookupError({ message: unknownErrorToString(cause) }),
+        new GenerationLookupError({
+          message: unknownErrorToString(cause),
+          retryable: true,
+        }),
     }).pipe(
-      flatMap((json) => {
-        const parsed = parseSchema(GenerationLookupSchema, json);
+      flatMap((result) => {
+        if ("status" in result) {
+          return fail(
+            new GenerationLookupError({
+              message: `generation lookup returned ${result.status}`,
+              retryable: isRetryableLookupStatus(result.status),
+            })
+          );
+        }
+        const parsed = parseSchema(GenerationLookupSchema, result.json);
         return Either.isLeft(parsed)
           ? fail(
               new GenerationLookupError({
                 message: unknownErrorToString(parsed.left),
+                retryable: false,
               })
             )
           : succeed(parsed.right.data);
@@ -149,6 +169,7 @@ export function makeOpenRouterGenerationResolver(
           ? fail(
               new GenerationLookupError({
                 message: "response_cache_source_id not present yet",
+                retryable: true,
               })
             )
           : succeed(sourceId);

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -79,8 +79,7 @@ export interface GenerationResolverConfig {
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 5000;
-const DEFAULT_MAX_ATTEMPTS = 12;
-const USAGE_LOOKUP_MAX_ATTEMPTS = 2;
+const DEFAULT_MAX_ATTEMPTS = 2;
 const RESOLVE_CONCURRENCY = 8;
 
 function normalizeBaseUrl(baseUrl: string): string {
@@ -158,30 +157,14 @@ export function makeOpenRouterGenerationResolver(
           : succeed(parsed.right.data);
       })
     );
-  const lookupSourceId = (
+  const lookupGeneration = (
     generationId: string
-  ): Effect<string, GenerationLookupError> =>
-    lookupOnce(generationId).pipe(
-      flatMap((data) => {
-        const sourceId = data.response_cache_source_id;
-        return sourceId === null ||
-          sourceId === undefined ||
-          sourceId.length === 0
-          ? fail(
-              new GenerationLookupError({
-                message: "response_cache_source_id not present yet",
-                retryable: true,
-              })
-            )
-          : succeed(sourceId);
-      }),
-      retry(pollSchedule(maxAttempts))
-    );
+  ): Effect<GenerationLookupData, GenerationLookupError> =>
+    lookupOnce(generationId).pipe(retry(pollSchedule(maxAttempts)));
   const lookupSourceUsage = (
     sourceId: string
   ): Effect<ReplayedUsage | undefined> =>
-    lookupOnce(sourceId).pipe(
-      retry(pollSchedule(USAGE_LOOKUP_MAX_ATTEMPTS)),
+    lookupGeneration(sourceId).pipe(
       map((data): ReplayedUsage | undefined => usageFromLookup(data)),
       catchAll((error) =>
         sync(() => {
@@ -195,20 +178,34 @@ export function makeOpenRouterGenerationResolver(
     );
   return {
     resolveSourceGeneration: (generationId, options) =>
-      lookupSourceId(generationId).pipe(
-        flatMap((sourceId) =>
-          options?.includeUsage === false
-            ? succeed<ResolvedSourceGeneration>({ sourceId })
-            : lookupSourceUsage(sourceId).pipe(
-                map((usage): ResolvedSourceGeneration => ({
-                  sourceId,
-                  ...(usage !== undefined && { usage }),
-                }))
-              )
-        ),
+      lookupGeneration(generationId).pipe(
+        flatMap((data) => {
+          const dummySourceId = data.response_cache_source_id;
+          const sourceId =
+            dummySourceId === null ||
+            dummySourceId === undefined ||
+            dummySourceId.length === 0
+              ? generationId
+              : dummySourceId;
+          if (options?.includeUsage === false) {
+            return succeed<ResolvedSourceGeneration>({ sourceId });
+          }
+          if (sourceId === generationId) {
+            return succeed<ResolvedSourceGeneration>({
+              sourceId,
+              usage: usageFromLookup(data),
+            });
+          }
+          return lookupSourceUsage(sourceId).pipe(
+            map((usage): ResolvedSourceGeneration => ({
+              sourceId,
+              ...(usage !== undefined && { usage }),
+            }))
+          );
+        }),
         catchAll((error) =>
           sync(() => {
-            wLog("Failed to resolve cache-hit source generation id", {
+            wLog("Failed to resolve cache-hit source generation", {
               generation_id: generationId,
               error: error.message,
             });
@@ -233,6 +230,9 @@ function resolveEntry(
   entry: GenerationIdEntry,
   resolver: GenerationResolverService
 ): Effect<ResolvedEntry> {
+  if (entry.isResolvedSource && !entry.countsTowardUsage) {
+    return succeed({ id: entry.id });
+  }
   return entry.isCacheHit
     ? resolver
         .resolveSourceGeneration(entry.id, {

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -80,7 +80,7 @@ export interface GenerationResolverConfig {
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 5000;
-const DEFAULT_MAX_ATTEMPTS = 2;
+const DEFAULT_MAX_ATTEMPTS = 12;
 const RESOLVE_CONCURRENCY = 8;
 
 function normalizeBaseUrl(baseUrl: string): string {

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -113,7 +113,7 @@ export function makeOpenRouterGenerationResolver(
       lookupOnce(generationId).pipe(
         retry(
           spaced(`${pollIntervalMs} millis`).pipe(
-            intersect(recurs(maxAttempts))
+            intersect(recurs(Math.max(maxAttempts - 1, 0)))
           )
         ),
         map((sourceId): string | undefined => sourceId),

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -80,7 +80,8 @@ export interface GenerationResolverConfig {
 
 const DEFAULT_POLL_INTERVAL_MS = 5000;
 const DEFAULT_MAX_ATTEMPTS = 12;
-const RESOLVE_CONCURRENCY = 4;
+const USAGE_LOOKUP_MAX_ATTEMPTS = 2;
+const RESOLVE_CONCURRENCY = 8;
 
 function normalizeBaseUrl(baseUrl: string): string {
   const trimmed = baseUrl.replace(/\/+$/u, "");
@@ -106,9 +107,9 @@ export function makeOpenRouterGenerationResolver(
   const baseUrl = normalizeBaseUrl(config.baseUrl ?? "https://openrouter.ai");
   const pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const maxAttempts = config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
-  const pollSchedule = () =>
+  const pollSchedule = (attempts: number) =>
     spaced(`${pollIntervalMs} millis`).pipe(
-      intersect(recurs(Math.max(maxAttempts - 1, 0))),
+      intersect(recurs(Math.max(attempts - 1, 0))),
       whileInput((error: GenerationLookupError) => error.retryable)
     );
   const lookupOnce = (
@@ -174,13 +175,13 @@ export function makeOpenRouterGenerationResolver(
             )
           : succeed(sourceId);
       }),
-      retry(pollSchedule())
+      retry(pollSchedule(maxAttempts))
     );
   const lookupSourceUsage = (
     sourceId: string
   ): Effect<ReplayedUsage | undefined> =>
     lookupOnce(sourceId).pipe(
-      retry(pollSchedule()),
+      retry(pollSchedule(USAGE_LOOKUP_MAX_ATTEMPTS)),
       map((data): ReplayedUsage | undefined => usageFromLookup(data)),
       catchAll((error) =>
         sync(() => {

--- a/src/runtime/generation-resolver.ts
+++ b/src/runtime/generation-resolver.ts
@@ -1,0 +1,157 @@
+import { Tag } from "effect/Context";
+import { TaggedError } from "effect/Data";
+import type { Effect } from "effect/Effect";
+import {
+  catchAll,
+  fail,
+  flatMap,
+  forEach,
+  gen,
+  map,
+  retry,
+  serviceOption,
+  succeed,
+  sync,
+  tryPromise,
+} from "effect/Effect";
+import { isNone } from "effect/Option";
+import { intersect, recurs, spaced } from "effect/Schedule";
+
+import { Either } from "../internal/either";
+import { unknownErrorToString } from "../internal/errors";
+import { wLog } from "../internal/log";
+import { parseSchema, z } from "../internal/zod";
+import type { GenerationIdEntry } from "./generation-ids";
+import { getCollectedGenerationIdEntries } from "./generation-ids";
+
+export interface GenerationResolverService {
+  readonly resolveSourceGenerationId: (
+    generationId: string
+  ) => Effect<string | undefined>;
+}
+
+export class GenerationResolver extends Tag(
+  "@openrouter/bench-harness/generation-resolver"
+)<GenerationResolver, GenerationResolverService>() {}
+
+const GenerationLookupSchema = z.object({
+  data: z.object({
+    response_cache_source_id: z.string().nullish(),
+  }),
+});
+
+class GenerationLookupError extends TaggedError("GenerationLookupError")<{
+  readonly message: string;
+}> {}
+
+export interface GenerationResolverConfig {
+  readonly apiKey: string;
+  readonly baseUrl?: string;
+  readonly pollIntervalMs?: number;
+  readonly maxAttempts?: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 5000;
+const DEFAULT_MAX_ATTEMPTS = 12;
+const RESOLVE_CONCURRENCY = 4;
+
+function normalizeBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/u, "");
+  return trimmed.endsWith("/api/v1") ? trimmed : `${trimmed}/api/v1`;
+}
+
+export function makeOpenRouterGenerationResolver(
+  config: GenerationResolverConfig
+): GenerationResolverService {
+  const baseUrl = normalizeBaseUrl(config.baseUrl ?? "https://openrouter.ai");
+  const pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const maxAttempts = config.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const lookupOnce = (
+    generationId: string
+  ): Effect<string, GenerationLookupError> =>
+    tryPromise({
+      try: async (signal) => {
+        const response = await fetch(
+          `${baseUrl}/generation?id=${encodeURIComponent(generationId)}`,
+          {
+            headers: { Authorization: `Bearer ${config.apiKey}` },
+            signal,
+          }
+        );
+        if (!response.ok) {
+          await response.body?.cancel();
+          throw new Error(`generation lookup returned ${response.status}`);
+        }
+        return (await response.json()) as unknown;
+      },
+      catch: (cause) =>
+        new GenerationLookupError({ message: unknownErrorToString(cause) }),
+    }).pipe(
+      flatMap((json) => {
+        const parsed = parseSchema(GenerationLookupSchema, json);
+        if (Either.isLeft(parsed)) {
+          return fail(
+            new GenerationLookupError({
+              message: unknownErrorToString(parsed.left),
+            })
+          );
+        }
+        const sourceId = parsed.right.data.response_cache_source_id;
+        return sourceId === null ||
+          sourceId === undefined ||
+          sourceId.length === 0
+          ? fail(
+              new GenerationLookupError({
+                message: "response_cache_source_id not present yet",
+              })
+            )
+          : succeed(sourceId);
+      })
+    );
+  return {
+    resolveSourceGenerationId: (generationId) =>
+      lookupOnce(generationId).pipe(
+        retry(
+          spaced(`${pollIntervalMs} millis`).pipe(
+            intersect(recurs(maxAttempts))
+          )
+        ),
+        map((sourceId): string | undefined => sourceId),
+        catchAll((error) =>
+          sync(() => {
+            wLog("Failed to resolve cache-hit source generation id", {
+              generation_id: generationId,
+              error: error.message,
+            });
+            return undefined;
+          })
+        )
+      ),
+  };
+}
+
+function resolveEntry(
+  entry: GenerationIdEntry,
+  resolver: GenerationResolverService
+): Effect<string> {
+  return entry.isCacheHit
+    ? resolver
+        .resolveSourceGenerationId(entry.id)
+        .pipe(map((sourceId) => sourceId ?? entry.id))
+    : succeed(entry.id);
+}
+
+export const resolveCollectedGenerationIds: Effect<readonly string[]> = gen(
+  function* () {
+    const entries = yield* getCollectedGenerationIdEntries;
+    const resolver = yield* serviceOption(GenerationResolver);
+    if (isNone(resolver) || entries.every((entry) => !entry.isCacheHit)) {
+      return entries.map((entry) => entry.id);
+    }
+    return yield* forEach(
+      entries,
+      (entry) => resolveEntry(entry, resolver.value),
+      { concurrency: RESOLVE_CONCURRENCY }
+    );
+  }
+);

--- a/src/runtime/response-cache.test.ts
+++ b/src/runtime/response-cache.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { TaggedError } from "effect/Data";
-import { all, fail, flatMap, retry, runPromise, suspend } from "effect/Effect";
-import { recurs } from "effect/Schedule";
+import { all, flatMap, runPromise } from "effect/Effect";
 
 import {
   buildResponseCacheSalt,
@@ -11,7 +9,6 @@ import {
   getCurrentRetryAttempt,
   setCurrentEpoch,
   withCallCacheSalt,
-  withRetryAttemptSalt,
 } from "./response-cache";
 
 describe("buildResponseCacheSalt", () => {
@@ -57,38 +54,9 @@ describe("withCallCacheSalt", () => {
   });
 });
 
-class BoomError extends TaggedError("BoomError")<{
-  readonly message: string;
-}> {}
-
-describe("withRetryAttemptSalt", () => {
-  it("exposes an attempt index that increments on each retry", async () => {
-    const seen: (number | undefined)[] = [];
-    const failing = withRetryAttemptSalt(
-      getCurrentRetryAttempt.pipe(
-        flatMap((attempt) =>
-          suspend(() => {
-            seen.push(attempt);
-            return fail(new BoomError({ message: "boom" }));
-          })
-        )
-      )
-    ).pipe(retry(recurs(2)));
-    await expect(runPromise(failing)).rejects.toThrow("boom");
-    expect(seen).toEqual([0, 1, 2]);
-  });
-  it("defaults to undefined outside withRetryAttemptSalt", async () => {
+describe("currentRetryAttemptRef", () => {
+  it("defaults to undefined", async () => {
     expect(await runPromise(getCurrentRetryAttempt)).toBeUndefined();
-  });
-  it("restarts at zero for a fresh wrapped effect", async () => {
-    const first = await runPromise(
-      withRetryAttemptSalt(getCurrentRetryAttempt)
-    );
-    const second = await runPromise(
-      withRetryAttemptSalt(getCurrentRetryAttempt)
-    );
-    expect(first).toBe(0);
-    expect(second).toBe(0);
   });
 });
 

--- a/src/runtime/response-cache.test.ts
+++ b/src/runtime/response-cache.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+
+import { flatMap, runPromise } from "effect/Effect";
+
+import {
+  buildResponseCacheSalt,
+  getCurrentEpoch,
+  setCurrentEpoch,
+} from "./response-cache";
+
+describe("buildResponseCacheSalt", () => {
+  it("joins session id and epoch", () => {
+    expect(buildResponseCacheSalt("wf-123", 2)).toBe("wf-123:epoch-2");
+  });
+  it("uses only the session id when epoch is undefined", () => {
+    expect(buildResponseCacheSalt("wf-123", undefined)).toBe("wf-123");
+  });
+  it("uses only the epoch when session id is undefined", () => {
+    expect(buildResponseCacheSalt(undefined, 0)).toBe("epoch-0");
+  });
+  it("returns undefined when both are undefined", () => {
+    expect(buildResponseCacheSalt(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("currentEpochRef", () => {
+  it("defaults to undefined", async () => {
+    expect(await runPromise(getCurrentEpoch)).toBeUndefined();
+  });
+  it("returns the epoch set on the current fiber", async () => {
+    const epoch = await runPromise(
+      setCurrentEpoch(3).pipe(flatMap(() => getCurrentEpoch))
+    );
+    expect(epoch).toBe(3);
+  });
+});

--- a/src/runtime/response-cache.test.ts
+++ b/src/runtime/response-cache.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "bun:test";
 
-import { flatMap, runPromise } from "effect/Effect";
+import { TaggedError } from "effect/Data";
+import { fail, flatMap, retry, runPromise, suspend } from "effect/Effect";
+import { recurs } from "effect/Schedule";
 
 import {
   buildResponseCacheSalt,
   getCurrentEpoch,
+  getCurrentRetryAttempt,
   setCurrentEpoch,
+  withRetryAttemptSalt,
 } from "./response-cache";
 
 describe("buildResponseCacheSalt", () => {
@@ -20,6 +24,52 @@ describe("buildResponseCacheSalt", () => {
   });
   it("returns undefined when both are undefined", () => {
     expect(buildResponseCacheSalt(undefined, undefined)).toBeUndefined();
+  });
+  it("omits the attempt segment for the first attempt", () => {
+    expect(buildResponseCacheSalt("wf-123", 2, 0)).toBe("wf-123:epoch-2");
+  });
+  it("appends the attempt segment for retries", () => {
+    expect(buildResponseCacheSalt("wf-123", 2, 1)).toBe(
+      "wf-123:epoch-2:attempt-1"
+    );
+  });
+  it("appends the attempt segment without session or epoch", () => {
+    expect(buildResponseCacheSalt(undefined, undefined, 2)).toBe("attempt-2");
+  });
+});
+
+class BoomError extends TaggedError("BoomError")<{
+  readonly message: string;
+}> {}
+
+describe("withRetryAttemptSalt", () => {
+  it("exposes an attempt index that increments on each retry", async () => {
+    const seen: (number | undefined)[] = [];
+    const failing = withRetryAttemptSalt(
+      getCurrentRetryAttempt.pipe(
+        flatMap((attempt) =>
+          suspend(() => {
+            seen.push(attempt);
+            return fail(new BoomError({ message: "boom" }));
+          })
+        )
+      )
+    ).pipe(retry(recurs(2)));
+    await expect(runPromise(failing)).rejects.toThrow("boom");
+    expect(seen).toEqual([0, 1, 2]);
+  });
+  it("defaults to undefined outside withRetryAttemptSalt", async () => {
+    expect(await runPromise(getCurrentRetryAttempt)).toBeUndefined();
+  });
+  it("restarts at zero for a fresh wrapped effect", async () => {
+    const first = await runPromise(
+      withRetryAttemptSalt(getCurrentRetryAttempt)
+    );
+    const second = await runPromise(
+      withRetryAttemptSalt(getCurrentRetryAttempt)
+    );
+    expect(first).toBe(0);
+    expect(second).toBe(0);
   });
 });
 

--- a/src/runtime/response-cache.test.ts
+++ b/src/runtime/response-cache.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from "bun:test";
 
 import { TaggedError } from "effect/Data";
-import { fail, flatMap, retry, runPromise, suspend } from "effect/Effect";
+import { all, fail, flatMap, retry, runPromise, suspend } from "effect/Effect";
 import { recurs } from "effect/Schedule";
 
 import {
   buildResponseCacheSalt,
+  getCurrentCallSalt,
   getCurrentEpoch,
   getCurrentRetryAttempt,
   setCurrentEpoch,
+  withCallCacheSalt,
   withRetryAttemptSalt,
 } from "./response-cache";
 
@@ -35,6 +37,23 @@ describe("buildResponseCacheSalt", () => {
   });
   it("appends the attempt segment without session or epoch", () => {
     expect(buildResponseCacheSalt(undefined, undefined, 2)).toBe("attempt-2");
+  });
+  it("places the call salt between the epoch and attempt segments", () => {
+    expect(buildResponseCacheSalt("wf-123", 2, 1, "judge-run-3")).toBe(
+      "wf-123:epoch-2:judge-run-3:attempt-1"
+    );
+  });
+});
+
+describe("withCallCacheSalt", () => {
+  it("scopes the call salt to the wrapped effect", async () => {
+    const salts = await runPromise(
+      all([
+        withCallCacheSalt("judge-run-2", getCurrentCallSalt),
+        getCurrentCallSalt,
+      ])
+    );
+    expect(salts).toEqual(["judge-run-2", undefined]);
   });
 });
 

--- a/src/runtime/response-cache.ts
+++ b/src/runtime/response-cache.ts
@@ -5,6 +5,10 @@ import { get, set, unsafeMake } from "effect/FiberRef";
 
 export const RESPONSE_CACHE_HEADER = "x-openrouter-cache";
 
+export const RESPONSE_CACHE_STATUS_HEADER = "x-openrouter-cache-status";
+
+export const RESPONSE_CACHE_STATUS_HIT = "HIT";
+
 export const RESPONSE_CACHE_SALT_FIELD = "cache_salt";
 
 export const currentEpochRef: FiberRef<number | undefined> = unsafeMake<

--- a/src/runtime/response-cache.ts
+++ b/src/runtime/response-cache.ts
@@ -7,9 +7,6 @@ export const RESPONSE_CACHE_HEADER = "x-openrouter-cache";
 
 export const RESPONSE_CACHE_SALT_FIELD = "cache_salt";
 
-export const RESPONSE_CACHE_SOURCE_GENERATION_HEADER =
-  "x-openrouter-cache-source-generation-id";
-
 export const currentEpochRef: FiberRef<number | undefined> = unsafeMake<
   number | undefined
 >(undefined);

--- a/src/runtime/response-cache.ts
+++ b/src/runtime/response-cache.ts
@@ -29,6 +29,20 @@ export const getCurrentRetryAttempt: Effect<number | undefined> = get(
   currentRetryAttemptRef
 );
 
+export const currentCallSaltRef: FiberRef<string | undefined> = unsafeMake<
+  string | undefined
+>(undefined);
+
+export const getCurrentCallSalt: Effect<string | undefined> =
+  get(currentCallSaltRef);
+
+export function withCallCacheSalt<A, E, R>(
+  callSalt: string,
+  effect: Effect<A, E, R>
+): Effect<A, E, R> {
+  return locally(effect, currentCallSaltRef, callSalt);
+}
+
 export function withRetryAttemptSalt<A, E, R>(
   effect: Effect<A, E, R>
 ): Effect<A, E, R> {
@@ -42,11 +56,13 @@ export function withRetryAttemptSalt<A, E, R>(
 export function buildResponseCacheSalt(
   sessionId: string | undefined,
   epoch: number | undefined,
-  retryAttempt?: number
+  retryAttempt?: number,
+  callSalt?: string
 ): string | undefined {
   const parts = [
     ...(sessionId !== undefined ? [sessionId] : []),
     ...(epoch !== undefined ? [`epoch-${epoch}`] : []),
+    ...(callSalt !== undefined ? [callSalt] : []),
     ...(retryAttempt !== undefined && retryAttempt > 0
       ? [`attempt-${retryAttempt}`]
       : []),

--- a/src/runtime/response-cache.ts
+++ b/src/runtime/response-cache.ts
@@ -1,9 +1,13 @@
 import type { Effect } from "effect/Effect";
-import { locally, suspend } from "effect/Effect";
+import { locally } from "effect/Effect";
 import type { FiberRef } from "effect/FiberRef";
 import { get, set, unsafeMake } from "effect/FiberRef";
 
 export const RESPONSE_CACHE_HEADER = "x-openrouter-cache";
+
+export const RESPONSE_CACHE_TTL_HEADER = "x-openrouter-cache-ttl";
+
+export const RESPONSE_CACHE_TTL_SECONDS = 7200;
 
 export const RESPONSE_CACHE_STATUS_HEADER = "x-openrouter-cache-status";
 
@@ -41,16 +45,6 @@ export function withCallCacheSalt<A, E, R>(
   effect: Effect<A, E, R>
 ): Effect<A, E, R> {
   return locally(effect, currentCallSaltRef, callSalt);
-}
-
-export function withRetryAttemptSalt<A, E, R>(
-  effect: Effect<A, E, R>
-): Effect<A, E, R> {
-  let attempt = -1;
-  return suspend(() => {
-    attempt += 1;
-    return locally(effect, currentRetryAttemptRef, attempt);
-  });
 }
 
 export function buildResponseCacheSalt(

--- a/src/runtime/response-cache.ts
+++ b/src/runtime/response-cache.ts
@@ -1,10 +1,14 @@
 import type { Effect } from "effect/Effect";
+import { locally, suspend } from "effect/Effect";
 import type { FiberRef } from "effect/FiberRef";
 import { get, set, unsafeMake } from "effect/FiberRef";
 
 export const RESPONSE_CACHE_HEADER = "x-openrouter-cache";
 
 export const RESPONSE_CACHE_SALT_FIELD = "cache_salt";
+
+export const RESPONSE_CACHE_SOURCE_GENERATION_HEADER =
+  "x-openrouter-cache-source-generation-id";
 
 export const currentEpochRef: FiberRef<number | undefined> = unsafeMake<
   number | undefined
@@ -16,13 +20,35 @@ export function setCurrentEpoch(epoch: number | undefined): Effect<void> {
 
 export const getCurrentEpoch: Effect<number | undefined> = get(currentEpochRef);
 
+export const currentRetryAttemptRef: FiberRef<number | undefined> = unsafeMake<
+  number | undefined
+>(undefined);
+
+export const getCurrentRetryAttempt: Effect<number | undefined> = get(
+  currentRetryAttemptRef
+);
+
+export function withRetryAttemptSalt<A, E, R>(
+  effect: Effect<A, E, R>
+): Effect<A, E, R> {
+  let attempt = -1;
+  return suspend(() => {
+    attempt += 1;
+    return locally(effect, currentRetryAttemptRef, attempt);
+  });
+}
+
 export function buildResponseCacheSalt(
   sessionId: string | undefined,
-  epoch: number | undefined
+  epoch: number | undefined,
+  retryAttempt?: number
 ): string | undefined {
   const parts = [
     ...(sessionId !== undefined ? [sessionId] : []),
     ...(epoch !== undefined ? [`epoch-${epoch}`] : []),
+    ...(retryAttempt !== undefined && retryAttempt > 0
+      ? [`attempt-${retryAttempt}`]
+      : []),
   ];
   return parts.length > 0 ? parts.join(":") : undefined;
 }

--- a/src/runtime/response-cache.ts
+++ b/src/runtime/response-cache.ts
@@ -13,6 +13,8 @@ export const RESPONSE_CACHE_STATUS_HEADER = "x-openrouter-cache-status";
 
 export const RESPONSE_CACHE_STATUS_HIT = "HIT";
 
+export const RESPONSE_CACHE_SOURCE_ID_HEADER = "x-openrouter-cache-source-id";
+
 export const RESPONSE_CACHE_SALT_FIELD = "cache_salt";
 
 export const currentEpochRef: FiberRef<number | undefined> = unsafeMake<

--- a/src/runtime/response-cache.ts
+++ b/src/runtime/response-cache.ts
@@ -1,0 +1,28 @@
+import type { Effect } from "effect/Effect";
+import type { FiberRef } from "effect/FiberRef";
+import { get, set, unsafeMake } from "effect/FiberRef";
+
+export const RESPONSE_CACHE_HEADER = "x-openrouter-cache";
+
+export const RESPONSE_CACHE_SALT_FIELD = "cache_salt";
+
+export const currentEpochRef: FiberRef<number | undefined> = unsafeMake<
+  number | undefined
+>(undefined);
+
+export function setCurrentEpoch(epoch: number | undefined): Effect<void> {
+  return set(currentEpochRef, epoch);
+}
+
+export const getCurrentEpoch: Effect<number | undefined> = get(currentEpochRef);
+
+export function buildResponseCacheSalt(
+  sessionId: string | undefined,
+  epoch: number | undefined
+): string | undefined {
+  const parts = [
+    ...(sessionId !== undefined ? [sessionId] : []),
+    ...(epoch !== undefined ? [`epoch-${epoch}`] : []),
+  ];
+  return parts.length > 0 ? parts.join(":") : undefined;
+}

--- a/src/runtime/retry.test.ts
+++ b/src/runtime/retry.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import {
   exit as exitEffect,
   fail,
+  flatMap,
   retry,
   succeed,
   suspend,
@@ -11,7 +12,12 @@ import {
 import { assertFailure } from "../../test/helpers/exit-asserts";
 import { ModelError, SolverError } from "../harness/core";
 import { runHarnessPromise } from "../internal/effect-logger";
-import { rateLimitRetrySchedule, transientSolverRetrySchedule } from "./retry";
+import { getCurrentRetryAttempt } from "./response-cache";
+import {
+  rateLimitRetrySchedule,
+  retrySalted,
+  transientSolverRetrySchedule,
+} from "./retry";
 
 const schedule = rateLimitRetrySchedule({ maxRetries: 5, baseDelayMs: 0 });
 
@@ -174,5 +180,43 @@ describe("transientSolverRetrySchedule", () => {
       error_tag: "SolverError",
       error_message: "sandbox unavailable",
     });
+  });
+});
+describe("retrySalted", () => {
+  it("increments the retry-attempt salt on each retry and logs each retry", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    warnSpies.push(warn);
+    const seen: (number | undefined)[] = [];
+    let attempts = 0;
+    const flaky = getCurrentRetryAttempt.pipe(
+      flatMap((attempt) =>
+        suspend(() => {
+          seen.push(attempt);
+          attempts++;
+          return attempts < 3 ? fail(rateLimit) : succeed(attempts);
+        })
+      )
+    );
+    const result = await runHarnessPromise(
+      retrySalted(
+        flaky,
+        rateLimitRetrySchedule({ maxRetries: 5, baseDelayMs: 0 })
+      )
+    );
+    expect(result).toBe(3);
+    expect(seen).toEqual([0, 1, 2]);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({ attempt: 1 });
+    expect(warn.mock.calls[1]?.[1]).toMatchObject({ attempt: 2 });
+  });
+  it("restarts the attempt salt at zero for each fresh call", async () => {
+    const first = await runHarnessPromise(
+      retrySalted(getCurrentRetryAttempt, rateLimitRetrySchedule({}))
+    );
+    const second = await runHarnessPromise(
+      retrySalted(getCurrentRetryAttempt, rateLimitRetrySchedule({}))
+    );
+    expect(first).toBe(0);
+    expect(second).toBe(0);
   });
 });

--- a/src/runtime/retry.ts
+++ b/src/runtime/retry.ts
@@ -1,6 +1,6 @@
 import type { DurationInput } from "effect/Duration";
 import type { Effect } from "effect/Effect";
-import { logWarning, succeed } from "effect/Effect";
+import { locally, logWarning, retry, succeed, suspend } from "effect/Effect";
 import type { Schedule } from "effect/Schedule";
 import {
   exponential,
@@ -23,6 +23,7 @@ import {
   SolverError,
 } from "../harness/core";
 import { unknownErrorToString } from "../internal/errors";
+import { currentRetryAttemptRef } from "./response-cache";
 
 type EvalError = ModelError | SolverError;
 
@@ -97,6 +98,29 @@ export function withRetryAttemptLogging<Error>(
     })),
     onDecision(logRetryDecision)
   );
+}
+
+function withRetryAttemptSalt<A, E, R>(
+  effect: Effect<A, E, R>
+): Effect<A, E, R> {
+  let attempt = -1;
+  return suspend(() => {
+    attempt += 1;
+    return locally(effect, currentRetryAttemptRef, attempt);
+  });
+}
+
+export function retrySalted<A, In, E extends In, R>(
+  effect: Effect<A, E, R>,
+  schedule: Schedule<
+    {
+      readonly error: In;
+      readonly attempt: number;
+    },
+    In
+  >
+): Effect<A, E, R> {
+  return withRetryAttemptSalt(effect).pipe(retry(schedule));
 }
 
 function errorTagFrom(error: unknown): string {


### PR DESCRIPTION
## TL;DR

Every harness request to OpenRouter now opts into response caching with a 2-hour TTL and a per-epoch `cache_salt` body field. Temporal activity restarts replay cached responses and do not pay for regeneration. Parquet keeps only real generation IDs, and run usage reflects the original generations.

## What changed?

- Cache headers: all four OpenRouter request paths send `x-openrouter-cache: true` and `x-openrouter-cache-ttl: 7200`. The paths are the chat-completions provider, the Responses client, and the tau airline and tau3 banking user simulators.
- Cache salt: each request carries an unknown top-level body field `cache_salt` with the shape `sessionId:epoch-N[:callSalt][:attempt-K]`. The API hashes the raw body for the cache key and strips the field before it forwards the request upstream. Draco judge runs get a `judge-run-N` call salt, so independent resamples stay independent.
- Retry enforcement: the new `retrySalted(effect, schedule)` in `src/runtime/retry.ts` pairs the retry-attempt cache salt with a logging schedule. `withRetryAttemptSalt` is no longer exported. `retrySalted` only type-checks with logging-wrapped schedules (the `{ error, attempt }` output shape from `withRetryAttemptLogging`). A retry site can no longer salt without logging, and it can no longer log without salting. All model-call retry sites now use it: `openrouter-model`, `responses-model`, `judge`, `search/core/solver`, and the tau airline user simulator. The tau airline schedule now emits the same structured retry warnings.
- Generation resolution: for responses with `x-openrouter-cache-status: HIT`, the harness calls `GET /api/v1/generation` and polls for the asynchronous dummy row. It replaces the dummy ID with `response_cache_source_id`, so parquet stores only real generation IDs.
- Replay usage: the resolver also fetches the source generation's `tokens_prompt`, `tokens_completion`, `native_tokens_reasoning`, `total_cost`, and `generation_time`. It folds these values into `RunResult.usage` and `generationTimeMs` before the parquet write, because cache hits return zeroed usage. If a lookup fails, the harness logs a warning, keeps the dummy ID, and omits the replay usage.
- Usage comparability: judge and user-simulator calls tag their generation IDs as auxiliary at record time (`withAuxiliaryUsage`). The replay fold only counts generations whose usage feeds `RunResult.usage` in a fresh run. Auxiliary cache hits still resolve to real source IDs for parquet, but the harness does not fetch their usage.

## Why?

A Temporal activity retry runs a full sample chunk again. Without caching, each restart pays the model generation cost again. The epoch salt keeps epochs independent. The attempt salt lets an in-process retry escape a cached response that the harness rejected. Source-generation resolution keeps parquet analytics and usage accounting truthful on replays.

## How to test

- `bun run format:check && bun run check && bun run typecheck && bun test && bun run build` — all pass locally (1218 tests).
- Retry logging and salting: `bun test src/runtime/retry.test.ts src/benchmarks/tau-bench-airline/user-simulator.test.ts`.
- Replay usage: `bun test src/runtime/generation-resolver.test.ts src/runtime/generation-ids.test.ts`.

## Benchmark impact

Scores do not change on first attempts. Attempt-0 salts are deterministic, and behavior on a cache miss does not change. Activity restarts now replay each epoch's own cached responses. Reported usage and cost on replays reflect the original generations, not zeroes.

## Reviewer focus

- The `retrySalted` type-level pairing in `src/runtime/retry.ts` and the migrated call sites.
- Replay usage summation in `src/runtime/generation-resolver.ts` and `applyReplayedUsage` in `src/harness/run.ts`. Cache-hit responses report zeroed usage, so the addition does not double count.
- The auxiliary-usage tagging in `src/runtime/generation-ids.ts` and its use in `judge.ts` and the tau airline user simulator.
- The tau airline user-simulator schedule conversion. It keeps 2 retries at 100ms and retries only retryable `UserSimError`, and it now logs.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [ ] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [ ] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/627adb18f0f54821b186e701d6b7fa22
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->