### PR TITLE
fix: type Responses message inputs

### DIFF
--- a/src/benchmarks/deep-swe/solver.ts
+++ b/src/benchmarks/deep-swe/solver.ts
@@ -24,6 +24,7 @@ import type {
   ResponsesGenerateConfig,
   ResponsesModelService,
 } from "../../providers/responses-model";
+import { responsesMessage } from "../../providers/responses-model";
 import type { InferenceOverride } from "../benchmark-config";
 import { AGENT_ENV, probeSystemInfo, runAgentLoop } from "../harbor/agent-loop";
 import {
@@ -159,10 +160,10 @@ export function makeDeepSweSolver(
           model,
           session: agentSession,
           initialInput: [
-            {
-              role: "user",
-              content: buildInstanceMessage(state.sample.input, systemInfo),
-            },
+            responsesMessage(
+              "user",
+              buildInstanceMessage(state.sample.input, systemInfo)
+            ),
           ],
           genConfig,
           stepLimit: opts.stepLimit,

--- a/src/benchmarks/draco/request-body.test.ts
+++ b/src/benchmarks/draco/request-body.test.ts
@@ -160,6 +160,9 @@ describe("buildSoloBody", () => {
   it("builds a tooled solo body with instructions + tools + budget prefix", () => {
     const body = buildSoloBody("Q?", config());
     expect(body.model).toBe("openai/gpt-4o-mini");
+    expect(body.input).toEqual([
+      expect.objectContaining({ type: "message", role: "user" }),
+    ]);
     expect(body.instructions).toEqual(expect.any(String));
     expect(body.maxToolCalls).toBe(16);
     expect(body.maxOutputTokens).toBe(16384);
@@ -193,6 +196,9 @@ describe("buildFusionBody", () => {
       })
     );
     expect(body.model).toBe("openrouter/fusion");
+    expect(body.input).toEqual([
+      expect.objectContaining({ type: "message", role: "user" }),
+    ]);
     expect(body.instructions).toEqual(expect.stringContaining("Use Fusion."));
     const fusionTool = (body.tools ?? []).find(isFusion)!;
     const params = fusionTool.parameters ?? {};

--- a/src/benchmarks/draco/request-body.ts
+++ b/src/benchmarks/draco/request-body.ts
@@ -18,6 +18,7 @@ import { getOrNull } from "effect/Option";
 
 import type { ValueOf } from "../../internal/guards";
 import { isRecord } from "../../internal/guards";
+import { responsesMessage } from "../../providers/responses-model";
 import {
   AGENT_SYSTEM_PROMPT,
   FUSION_CLASSIFIER_DIRECTIVE,
@@ -313,10 +314,7 @@ export function buildFusionBody(
     model: "openrouter/fusion",
     instructions: FUSION_CLASSIFIER_DIRECTIVE + AGENT_SYSTEM_PROMPT,
     input: [
-      {
-        role: "user" as const,
-        content: buildInputPrefix(MAX_TOOL_CALLS) + problem,
-      },
+      responsesMessage("user", buildInputPrefix(MAX_TOOL_CALLS) + problem),
     ],
     maxToolCalls: MAX_TOOL_CALLS,
     maxOutputTokens: MAX_OUTPUT_TOKENS,
@@ -334,7 +332,7 @@ export function buildSoloBody(
   const input = hasTools ? buildInputPrefix(MAX_TOOL_CALLS) + problem : problem;
   return {
     model: config.model,
-    input: [{ role: "user" as const, content: input }],
+    input: [responsesMessage("user", input)],
     maxToolCalls: MAX_TOOL_CALLS,
     maxOutputTokens: MAX_OUTPUT_TOKENS,
     ...(hasTools && { instructions: AGENT_SYSTEM_PROMPT, tools }),

--- a/src/benchmarks/harbor/agent-loop.test.ts
+++ b/src/benchmarks/harbor/agent-loop.test.ts
@@ -90,7 +90,9 @@ function failingThenSucceedingSandbox(failTimes: number): {
   };
 }
 
-const INITIAL_INPUT = [{ role: "user", content: "do the task" }];
+const INITIAL_INPUT = [
+  { type: "message", role: "user", content: "do the task" },
+];
 
 const GEN_CONFIG = { instructions: "Use bash." };
 

--- a/src/benchmarks/harbor/agent-loop.ts
+++ b/src/benchmarks/harbor/agent-loop.ts
@@ -24,6 +24,7 @@ import type {
   ResponsesInputItem,
   ResponsesModelService,
 } from "../../providers/responses-model";
+import { responsesMessage } from "../../providers/responses-model";
 import type { RetryConfig } from "../../runtime/retry";
 import { transientSolverRetrySchedule } from "../../runtime/retry";
 import { makeHarborStreamTracker } from "./agent-progress";
@@ -241,7 +242,7 @@ function handleFormatError(
     );
   }
   if (commands.length === 0) {
-    input.push({ role: MessageRole.User, content: NO_TOOL_CALL_NUDGE });
+    input.push(responsesMessage(MessageRole.User, NO_TOOL_CALL_NUDGE));
   }
   return consecutiveFormatErrors + 1;
 }

--- a/src/benchmarks/search/core/request.test.ts
+++ b/src/benchmarks/search/core/request.test.ts
@@ -28,6 +28,13 @@ describe("buildSearchRequestBody", () => {
       lane: lane({ engine: "exa", maxAgentTurns: 25, maxResults: 10 }),
     });
     expect(body.model).toBe(BASE.model);
+    expect(body.input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: BASE.problem,
+      },
+    ]);
     expect(body.maxToolCalls).toBe(25);
     expect(body.plugins).toBeUndefined();
     expect(body.tools).toEqual([

--- a/src/benchmarks/search/core/request.ts
+++ b/src/benchmarks/search/core/request.ts
@@ -12,6 +12,7 @@ import type { CostTier, ReasoningEffort } from "../../../harness/constants";
 import type { ProviderSort } from "../../../internal/enums";
 import { definedValues } from "../../../internal/guards";
 import { buildAutoRouterPlugin } from "../../../providers/auto-router-plugin";
+import { responsesMessage } from "../../../providers/responses-model";
 import { BENCHMARK_LEAK_EXCLUDED_DOMAINS } from "./blocklist";
 import type { SearchLaneConfig, WebFetchConfig } from "./config";
 
@@ -113,7 +114,7 @@ export function buildSearchRequestBody(
   const base: ResponsesRequest = {
     model: opts.model,
     instructions: opts.instructions,
-    input: [{ role: "user" as const, content: opts.problem }],
+    input: [responsesMessage("user", opts.problem)],
     ...definedValues({
       maxOutputTokens: opts.maxOutputTokens,
       temperature: opts.temperature,

--- a/src/benchmarks/search/core/solver.test.ts
+++ b/src/benchmarks/search/core/solver.test.ts
@@ -227,7 +227,7 @@ describe("searchSolver", () => {
       )
     );
     expect(state.responseItems).toEqual([
-      { role: "user", content: "Who?" },
+      { type: "message", role: "user", content: "Who?" },
       ...output,
     ]);
   });

--- a/src/benchmarks/swe-atlas/solver.ts
+++ b/src/benchmarks/swe-atlas/solver.ts
@@ -8,6 +8,7 @@ import type {
   ResponsesGenerateConfig,
   ResponsesModelService,
 } from "../../providers/responses-model";
+import { responsesMessage } from "../../providers/responses-model";
 import type { InferenceOverride } from "../benchmark-config";
 import { AGENT_ENV, probeSystemInfo, runAgentLoop } from "../harbor/agent-loop";
 import {
@@ -115,14 +116,10 @@ export function makeSweAtlasSolver(
           model,
           session,
           initialInput: [
-            {
-              role: "user",
-              content: buildInstanceMessage(
-                meta.track,
-                state.sample.input,
-                systemInfo
-              ),
-            },
+            responsesMessage(
+              "user",
+              buildInstanceMessage(meta.track, state.sample.input, systemInfo)
+            ),
           ],
           genConfig,
           stepLimit: opts.stepLimit,

--- a/src/benchmarks/wandr/solver.ts
+++ b/src/benchmarks/wandr/solver.ts
@@ -38,6 +38,7 @@ import type {
   ResponsesGenerateConfig,
   ResponsesModelService,
 } from "../../providers/responses-model";
+import { responsesMessage } from "../../providers/responses-model";
 import type { InferenceOverride } from "../benchmark-config";
 import { AGENT_ENV, runAgentLoop } from "../harbor/agent-loop";
 import { BASH_RESPONSES_TOOL_DEFINITION } from "../harbor/prompts";
@@ -232,13 +233,13 @@ export function makeWandrSolver(
           model,
           session: agentSession,
           initialInput: [
-            {
-              role: "user",
-              content: buildWandrInstanceMessage(
+            responsesMessage(
+              "user",
+              buildWandrInstanceMessage(
                 state.sample.input,
                 meta.requiredFilePaths
-              ),
-            },
+              )
+            ),
           ],
           genConfig: generationConfig,
           stepLimit: options.stepLimit,

--- a/src/judge/judge.ts
+++ b/src/judge/judge.ts
@@ -14,6 +14,7 @@ import {
   toModelError,
   usageFromResponses,
 } from "../providers/responses-client";
+import { responsesMessage } from "../providers/responses-model";
 import type { RetryConfig } from "../runtime/retry";
 import { rateLimitRetrySchedule } from "../runtime/retry";
 
@@ -61,7 +62,7 @@ export function judgeCall<T>(
         };
   const body: ResponsesRequest = {
     model: config.judgeModel,
-    input: [{ role: "user" as const, content: spec.userInput }],
+    input: [responsesMessage("user", spec.userInput)],
     ...(text !== undefined && { text }),
     ...(spec.instructions !== undefined && { instructions: spec.instructions }),
     ...(config.temperature !== undefined && {

--- a/src/providers/responses-model.test.ts
+++ b/src/providers/responses-model.test.ts
@@ -26,6 +26,7 @@ import {
   generate,
   ResponsesModel,
   makeResponsesModelLayer,
+  responsesMessage,
 } from "./responses-model";
 
 interface CapturedRequest {
@@ -139,6 +140,14 @@ function withFunctionCallOutput(stream: string): string {
 }
 
 describe("responses-model", () => {
+  it("constructs explicit Responses message items", () => {
+    expect(responsesMessage("user", "solve this")).toEqual({
+      type: "message",
+      role: "user",
+      content: "solve this",
+    });
+  });
+
   let restore: (() => void) | undefined;
   afterEach(() => {
     restore?.();

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -1,4 +1,5 @@
 import type {
+  EasyInputMessage,
   InputsUnion,
   ResponsesRequest,
   StreamEvents,
@@ -41,6 +42,19 @@ import {
 } from "./responses-client";
 
 export type ResponsesInputItem = Record<string, unknown>;
+
+export type ResponsesMessageRole =
+  | "user"
+  | "assistant"
+  | "system"
+  | "developer";
+
+export function responsesMessage(
+  role: ResponsesMessageRole,
+  content: string
+): EasyInputMessage {
+  return { type: "message", role, content };
+}
 
 export interface ResponsesFunctionTool {
   readonly type: "function";


### PR DESCRIPTION
## TL;DR

Responses input messages the harness constructs now carry `type: "message"`, because a proxy that translates the request away from Responses format serializes an untyped item into the prompt as JSON.

## What changed?

- Added a shared `responsesMessage()` helper returning an SDK-typed `EasyInputMessage` with the discriminator set.
- Routed every hand-built Responses input message through it, in the SWE-Atlas, search, deep-swe, wandr, draco and harbor paths and in the judge.
- Updated the colocated tests and fixtures to assert the constructed shape.

Chat transcript structures in tau-bench, tau3-bench and terminal-bench are untouched, they are not Responses request items.

## Why?

`type` is optional on a role-bearing input item in the OpenAI Responses API, and OpenAI accepts our current shape, so this went unnoticed. A proxy in front of the provider does not necessarily agree. Some Responses decoder recognizes a message only when `type: "message"` is present. Without it the item falls into a catch-all that wraps the whole object as unknown content, and its Chat and Anthropic encoders then render that by serializing it, so the model receives

```text
{"content":"<the instance message>","role":"user"}
```

in place of the instruction. A prior assistant turn additionally loses its role and arrives as a user message.

The failure is silent. The provider accepts the request and the model answers, it just answers about a JSON object, so no error surfaces and only the score moves. Emitting the discriminator is more correct on our side regardless of who is downstream, and it fixes every translating format at once.

## How to test

Point the harness at any proxy that translates Responses to Chat Completions or to Anthropic Messages, capture the body that proxy sends upstream, and confirm the user text arrives as native text rather than as a serialized JSON object, that a prior assistant turn keeps `role: "assistant"`, and that a tool call and its result stay structural and correlated.

Before this change the same input arrived as `{"type":"text","text":"{\"content\":\"...\",\"role\":\"user\"}"}` on both formats, and after it arrives as clean text with the assistant role preserved. A direct Responses call is unaffected in both cases, which is why this is invisible without a translating proxy in the path.

## Benchmark impact

Scores can move for any run whose path translates the request away from Responses format, and should be unchanged for direct runs, where the wire payload gains only the explicit discriminator. Runs affected before this change were solving a JSON-wrapped restatement of the task rather than the task, so treat their scores as invalid rather than merely noisy.

Reproduction, run one task through a translating proxy before and after this change and compare the prompt the provider receives.

Note for cached benchmarks, a generation cache keyed on task, model, prompt and tool surface does not observe this change, so previously cached generations from an affected run are reused until the cache namespace or version is bumped.

## Reviewer focus

- Whether any remaining site builds a Responses input message without the helper, since one omission reintroduces the corruption silently.
- The helper's role union, which is deliberately narrower than the SDK's input item type because these call sites only construct plain message turns.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/014dc0a17f314a0fb5a8741be8e66fba
Requested by: @bjoerndanz
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->