### PR TITLE
fix: recover unclassified Responses terminal events

### DIFF
--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 
 import type { StreamEvents } from "@openrouter/sdk/models";
 import { OpenRouterError } from "@openrouter/sdk/models/errors/openroutererror";
+import { streamEventsFromJSON } from "@openrouter/sdk/models/streamevents";
 import { failureOption } from "effect/Cause";
 import {
   flatMap,
@@ -61,6 +62,21 @@ async function readStreamFixture(): Promise<string> {
     ),
     "utf8"
   );
+}
+
+async function readUnknownTerminalFixture(): Promise<StreamEvents> {
+  const raw = await readFile(
+    new URL(
+      "../../test/fixtures/anthropic-responses-unknown-terminal.json",
+      import.meta.url
+    ),
+    "utf8"
+  );
+  const parsed = streamEventsFromJSON(raw);
+  if (!parsed.ok) {
+    throw parsed.error;
+  }
+  return parsed.value;
 }
 describe("extractMessageText", () => {
   it("concatenates output_text from message items", () => {
@@ -216,6 +232,29 @@ describe("usageFromResponses", () => {
   });
 });
 describe("consumeStream", () => {
+  it("accepts an SDK-unknown terminal event from its raw payload", async () => {
+    const event = await readUnknownTerminalFixture();
+    expect(event).toMatchObject({
+      type: "UNKNOWN",
+      isUnknown: true,
+    });
+    async function* stream(): AsyncGenerator<StreamEvents> {
+      yield event;
+    }
+
+    const result = await consumeStream(stream());
+
+    expect(result).toMatchObject({
+      id: "resp_gen-1786655075-eVP4Gc0sViFYYwAW3jR0",
+      model: "anthropic/claude-opus-4.8",
+      status: "completed",
+      usage: {
+        inputTokens: 414,
+        outputTokens: 69,
+        totalTokens: 483,
+      },
+    });
+  });
   it("forwards every stream event to onEvent, including the terminal one", async () => {
     const events: StreamEvents[] = [
       {

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -13,6 +13,7 @@ import {
 } from "@openrouter/sdk/models/errors/httpclienterrors";
 import { OpenRouterError } from "@openrouter/sdk/models/errors/openroutererror";
 import { SDKValidationError } from "@openrouter/sdk/models/errors/sdkvalidationerror";
+import { streamEventsFromJSON } from "@openrouter/sdk/models/streamevents";
 import { Responses as ResponsesClient } from "@openrouter/sdk/sdk/responses";
 import { Tag } from "effect/Context";
 import { TaggedError } from "effect/Data";
@@ -23,8 +24,9 @@ import { succeed as layerSucceed } from "effect/Layer";
 
 import type { Citation, ModelUsage } from "../harness/core";
 import { ModelError } from "../harness/core";
+import { Either } from "../internal/either";
 import { isRecord } from "../internal/guards";
-import { z } from "../internal/zod";
+import { parseSchema, z } from "../internal/zod";
 import { recordGenerationId } from "../runtime/generation-ids";
 import {
   BENCH_HARNESS_APP_REFERRER,
@@ -50,6 +52,27 @@ export const ResponsesResultSchema = z.object({
 });
 
 export type ResponsesResult = z.infer<typeof ResponsesResultSchema>;
+
+const RawResponsesTerminalEventSchema = z.object({
+  type: z.union([
+    z.literal("response.completed"),
+    z.literal("response.incomplete"),
+  ]),
+  response: z
+    .object({
+      id: z.string(),
+      model: z.string(),
+      output: z.array(z.record(z.string(), z.unknown())),
+      status: z.string(),
+      usage: z.record(z.string(), z.unknown()).nullable().optional(),
+    })
+    .passthrough(),
+  sequence_number: z.number().int().optional(),
+});
+
+type RawResponsesTerminalEvent = z.infer<
+  typeof RawResponsesTerminalEventSchema
+>;
 
 export interface ResponsesSendOptions {
   readonly timeoutMs?: number;
@@ -238,6 +261,44 @@ function isAsyncIterable(value: unknown): value is AsyncIterable<StreamEvents> {
   );
 }
 
+function normalizeRawTerminalEvent(
+  event: RawResponsesTerminalEvent
+): RawResponsesTerminalEvent {
+  const usage = event.response.usage;
+  return {
+    ...event,
+    sequence_number: event.sequence_number ?? 0,
+    response: {
+      ...event.response,
+      completed_at: event.response["completed_at"] ?? null,
+      created_at: event.response["created_at"] ?? 0,
+      error: event.response["error"] ?? null,
+      frequency_penalty: event.response["frequency_penalty"] ?? null,
+      incomplete_details: event.response["incomplete_details"] ?? null,
+      instructions: event.response["instructions"] ?? null,
+      metadata: event.response["metadata"] ?? null,
+      parallel_tool_calls: event.response["parallel_tool_calls"] ?? false,
+      presence_penalty: event.response["presence_penalty"] ?? null,
+      temperature: event.response["temperature"] ?? null,
+      tool_choice: event.response["tool_choice"] ?? "auto",
+      tools: event.response["tools"] ?? [],
+      top_p: event.response["top_p"] ?? null,
+      ...(usage !== undefined &&
+        usage !== null && {
+          usage: {
+            ...usage,
+            input_tokens_details: usage["input_tokens_details"] ?? {
+              cached_tokens: 0,
+            },
+            output_tokens_details: usage["output_tokens_details"] ?? {
+              reasoning_tokens: 0,
+            },
+          },
+        }),
+    },
+  };
+}
+
 export async function consumeStream(
   stream: AsyncIterable<StreamEvents>,
   onEvent?: (event: StreamEvents) => void,
@@ -282,6 +343,31 @@ export async function consumeStream(
         case "response.incomplete": {
           finalResponse = event.response;
           break;
+        }
+        default: {
+          const parsedRawEvent = parseSchema(
+            RawResponsesTerminalEventSchema,
+            rawEvent
+          );
+          if (Either.isLeft(parsedRawEvent)) {
+            break;
+          }
+          const parsedTerminalEvent = streamEventsFromJSON(
+            JSON.stringify(normalizeRawTerminalEvent(parsedRawEvent.right))
+          );
+          if (!parsedTerminalEvent.ok) {
+            break;
+          }
+          switch (parsedTerminalEvent.value.type) {
+            case "response.completed": {
+              finalResponse = parsedTerminalEvent.value.response;
+              break;
+            }
+            case "response.incomplete": {
+              finalResponse = parsedTerminalEvent.value.response;
+              break;
+            }
+          }
         }
       }
     }

--- a/test/fixtures/anthropic-responses-unknown-terminal.json
+++ b/test/fixtures/anthropic-responses-unknown-terminal.json
@@ -1,0 +1,41 @@
+{
+  "type": "response.completed",
+  "response": {
+    "id": "resp_gen-1786655075-eVP4Gc0sViFYYwAW3jR0",
+    "model": "anthropic/claude-opus-4.8",
+    "object": "response",
+    "output": [
+      {
+        "content": [
+          {
+            "text": "I'll run that command for you.",
+            "type": "output_text"
+          }
+        ],
+        "role": "assistant",
+        "status": "completed",
+        "type": "message"
+      },
+      {
+        "arguments": "{\"command\": \"printf 'anthropic-tool-first'\"}",
+        "call_id": "toolu_01Q7DaGvVv8A3zKATEfxEmHY",
+        "id": "fc_1",
+        "name": "bash",
+        "status": "completed",
+        "type": "function_call"
+      }
+    ],
+    "status": "completed",
+    "usage": {
+      "input_tokens": 414,
+      "input_tokens_details": {
+        "cached_tokens": 0
+      },
+      "output_tokens": 69,
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 483
+    }
+  }
+}


### PR DESCRIPTION
## TL;DR

Recover a Responses terminal event that the SDK does not classify, so an upstream that omits envelope fields no longer turns every sample into a lost one.

## What changed?

- The stream consumer now falls back to an unclassified event's raw payload, and honors a terminal `response.completed` or `response.incomplete` found there.
- The raw payload is validated, then the envelope fields the SDK requires are filled with inert defaults and revalidated through the SDK's own schema, so a fallback result is derived from SDK-validated data and is indistinguishable downstream from a parsed one.
- Raw `response.failed` and `error` events still raise before any fallback runs, and a stream that genuinely carries no terminal event still fails with the existing error.

## Why?

The consumer decided it had seen a terminal event solely from the SDK's discriminated `event.type`. The SDK is forward compatible, so an event it cannot validate is yielded as an unknown wrapper rather than throwing, and the consumer then finished the loop with no final response and reported

```text
Stream ended without a response.completed event
```

even though the wire carried a well-formed terminal event. The failure is silent and total, the request succeeded, the provider billed a completed generation, and the sample was recorded as a model error.

We hit this against an upstream whose terminal event omits `sequence_number` and thirteen response-level fields the SDK requires, which cost roughly four in five samples on the affected arm while every corresponding generation completed with a finish reason and non-zero output tokens. A benchmark harness should not discard completed work because an upstream omitted optional-looking envelope fields, so the tolerance is worth having regardless of who emits the event.

## How to test

Stream a Responses request through an upstream whose terminal event omits `sequence_number`, or replay the committed fixture, which is a trimmed capture of a real terminal event from such a path. Before this change the run fails with the message above, after it the result carries the response id, model, status and token counts.

The fixture reproduces the exact SDK unknown-wrapper shape, so the regression test fails without the fallback.

## Benchmark impact

Scores are unaffected for runs that were already succeeding, since the recognized path is unchanged and the fallback only fires where the previous behavior was a lost sample. Arms that were failing this way become measurable, which will move their aggregate scores from artificially low values to real ones. Runs already recorded with these model errors should be treated as invalid rather than noisy.

## Reviewer focus

- The defaults filled in before revalidation are envelope-only, and none of them reach the result the harness returns, which reads the id, model, status, output, usage, text, provider and timing. If you disagree with filling them at all, the alternative is deriving the result from the locally validated payload without the SDK round trip, at the cost of duplicating the result construction.
- Ordering of the error paths, the failure and error events must keep raising ahead of the fallback so a failed stream cannot be mistaken for a complete one.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] No credentials, private results, or restricted dataset contents are included


Link to Devin session: https://openrouter.devinenterprise.com/sessions/014dc0a17f314a0fb5a8741be8e66fba
Requested by: @bjoerndanz
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->