### PR TITLE
fix: recover unclassified Responses output items

### DIFF
--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { strict as assert } from "node:assert";
 import { readFile } from "node:fs/promises";
 
@@ -28,6 +28,7 @@ import {
   extractMessageText,
   findOutputItems,
   makeResponsesLayer,
+  recoverOutputItems,
   Responses,
   ResponsesError,
   toModelError,
@@ -77,6 +78,20 @@ async function readUnknownTerminalFixture(): Promise<StreamEvents> {
     throw parsed.error;
   }
   return parsed.value;
+}
+
+async function readUnknownOutputItemFixture(): Promise<
+  Record<string, unknown>
+> {
+  return JSON.parse(
+    await readFile(
+      new URL(
+        "../../test/fixtures/anthropic-unknown-output-item.json",
+        import.meta.url
+      ),
+      "utf8"
+    )
+  ) as Record<string, unknown>;
 }
 describe("extractMessageText", () => {
   it("concatenates output_text from message items", () => {
@@ -232,6 +247,73 @@ describe("usageFromResponses", () => {
   });
 });
 describe("consumeStream", () => {
+  it("recovers unknown output items with a stable synthetic id", async () => {
+    const item = await readUnknownOutputItemFixture();
+    const recovered = recoverOutputItems([item], "resp-local");
+
+    expect(recovered).toEqual([
+      {
+        content: [
+          {
+            text: "deterministic completion turn 1deterministic completion turn 1",
+            type: "output_text",
+          },
+        ],
+        id: "synthetic-resp-local-0",
+        role: "assistant",
+        status: "completed",
+        type: "message",
+      },
+    ]);
+    expect(recovered[0]).toMatchObject({
+      role: "assistant",
+      status: "completed",
+      type: "message",
+    });
+  });
+
+  it("logs and drops output items that cannot be recovered", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const recovered = recoverOutputItems(
+        [
+          {
+            raw: {
+              content: [{ text: "kept", type: "output_text" }],
+              role: "assistant",
+              status: "completed",
+              type: "message",
+            },
+            type: "UNKNOWN",
+            is_unknown: true,
+          },
+          {
+            raw: { type: "unsupported_item" },
+            type: "UNKNOWN",
+            is_unknown: true,
+          },
+        ],
+        "resp-local"
+      );
+
+      expect(recovered).toHaveLength(1);
+      expect(recovered[0]).toMatchObject({
+        id: "synthetic-resp-local-0",
+        type: "message",
+      });
+      expect(warn).toHaveBeenCalledWith(
+        "Unable to recover Responses output item",
+        {
+          item_index: 1,
+          raw_type: "unsupported_item",
+          response_id: "resp-local",
+        }
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("accepts an SDK-unknown terminal event from its raw payload", async () => {
     const event = await readUnknownTerminalFixture();
     expect(event).toMatchObject({

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -13,6 +13,7 @@ import {
 } from "@openrouter/sdk/models/errors/httpclienterrors";
 import { OpenRouterError } from "@openrouter/sdk/models/errors/openroutererror";
 import { SDKValidationError } from "@openrouter/sdk/models/errors/sdkvalidationerror";
+import { outputItemsFromJSON } from "@openrouter/sdk/models/outputitems";
 import { streamEventsFromJSON } from "@openrouter/sdk/models/streamevents";
 import { Responses as ResponsesClient } from "@openrouter/sdk/sdk/responses";
 import { Tag } from "effect/Context";
@@ -26,6 +27,7 @@ import type { Citation, ModelUsage } from "../harness/core";
 import { ModelError } from "../harness/core";
 import { Either } from "../internal/either";
 import { isRecord } from "../internal/guards";
+import { wLog } from "../internal/log";
 import { parseSchema, z } from "../internal/zod";
 import { recordGenerationId } from "../runtime/generation-ids";
 import {
@@ -299,6 +301,85 @@ function normalizeRawTerminalEvent(
   };
 }
 
+function outputItemRawType(value: unknown): string {
+  if (!isRecord(value)) {
+    return typeof value;
+  }
+  const raw = value["raw"];
+  if (isRecord(raw) && typeof raw["type"] === "string") {
+    return raw["type"];
+  }
+  return typeof value["type"] === "string" ? value["type"] : typeof value;
+}
+
+function logUnrecoverableOutputItem(
+  item: unknown,
+  responseId: string,
+  index: number
+): void {
+  wLog("Unable to recover Responses output item", {
+    item_index: index,
+    raw_type: outputItemRawType(item),
+    response_id: responseId,
+  });
+}
+
+export function recoverOutputItems(
+  output: readonly unknown[],
+  responseId: string
+): Record<string, unknown>[] {
+  const recovered: Record<string, unknown>[] = [];
+  for (const [index, item] of output.entries()) {
+    if (
+      !isRecord(item) ||
+      (item["type"] !== "UNKNOWN" &&
+        item["isUnknown"] !== true &&
+        item["is_unknown"] !== true)
+    ) {
+      if (isRecord(item)) {
+        recovered.push(item);
+      } else {
+        logUnrecoverableOutputItem(item, responseId, index);
+      }
+      continue;
+    }
+    const raw = item["raw"];
+    if (!isRecord(raw)) {
+      logUnrecoverableOutputItem(item, responseId, index);
+      continue;
+    }
+    const candidate = {
+      ...raw,
+      ...(typeof raw["id"] !== "string" && {
+        id: `synthetic-${responseId}-${index}`,
+      }),
+    };
+    let parsed: ReturnType<typeof outputItemsFromJSON>;
+    try {
+      parsed = outputItemsFromJSON(JSON.stringify(candidate));
+    } catch {
+      logUnrecoverableOutputItem(item, responseId, index);
+      continue;
+    }
+    if (!parsed.ok) {
+      logUnrecoverableOutputItem(item, responseId, index);
+      continue;
+    }
+    const parsedValue: unknown = parsed.value;
+    if (
+      !isRecord(parsedValue) ||
+      parsedValue["type"] === "UNKNOWN" ||
+      parsedValue["isUnknown"] === true ||
+      parsedValue["is_unknown"] === true
+    ) {
+      logUnrecoverableOutputItem(item, responseId, index);
+      continue;
+    }
+    recovered.push(parsedValue);
+  }
+  return recovered;
+}
+
 export async function consumeStream(
   stream: AsyncIterable<StreamEvents>,
   onEvent?: (event: StreamEvents) => void,
@@ -350,12 +431,25 @@ export async function consumeStream(
             rawEvent
           );
           if (Either.isLeft(parsedRawEvent)) {
+            if (
+              rawType === "response.completed" ||
+              rawType === "response.incomplete"
+            ) {
+              wLog("Unable to recover Responses terminal event", {
+                raw_type: rawType,
+                response_id: identifiers.generationId,
+              });
+            }
             break;
           }
           const parsedTerminalEvent = streamEventsFromJSON(
             JSON.stringify(normalizeRawTerminalEvent(parsedRawEvent.right))
           );
           if (!parsedTerminalEvent.ok) {
+            wLog("Unable to recover Responses terminal event", {
+              raw_type: rawType,
+              response_id: identifiers.generationId,
+            });
             break;
           }
           switch (parsedTerminalEvent.value.type) {
@@ -381,6 +475,7 @@ export async function consumeStream(
     return null;
   }
   const { output } = finalResponse;
+  const recoveredOutput = recoverOutputItems(output, finalResponse.id);
   const usage = finalResponse.usage ?? null;
   const { id } = finalResponse;
   const providerRaw: unknown = finalResponse;
@@ -392,9 +487,9 @@ export async function consumeStream(
     id,
     model: finalResponse.model,
     status: finalResponse.status,
-    output,
+    output: recoveredOutput,
     usage,
-    text: extractMessageText(output),
+    text: extractMessageText(recoveredOutput),
     generationId: id,
     provider,
     generationTimeMs: Math.round(performance.now() - startedAt),

--- a/test/fixtures/anthropic-unknown-output-item.json
+++ b/test/fixtures/anthropic-unknown-output-item.json
@@ -1,0 +1,15 @@
+{
+  "raw": {
+    "content": [
+      {
+        "text": "deterministic completion turn 1deterministic completion turn 1",
+        "type": "output_text"
+      }
+    ],
+    "role": "assistant",
+    "status": "completed",
+    "type": "message"
+  },
+  "type": "UNKNOWN",
+  "is_unknown": true
+}


### PR DESCRIPTION
## TL;DR

Recover Responses output items the SDK cannot classify, so an agent loop no longer replays an `UNKNOWN` wrapper as an input item and kill the sample on the next request.

## What changed?

- `recoverOutputItems` rebuilds an unclassified output item from its raw payload, adds only the envelope fields the SDK requires, and revalidates the result through `outputItemsFromJSON`.
- A missing item `id` is filled with a deterministic synthetic value derived from the response id and the item index, so a repeated turn produces the same id. Role, status, content, arguments and call ids are never altered.
- `consumeStream` returns recovered items in `output` and derives `text` from them, so every downstream consumer and the conversation the agent loop accumulates see typed items only.
- An item that still cannot be recovered is dropped and logged with its raw type, the response id and its index, instead of being appended and failing validation later.
- The terminal-event fallback added in #28 now logs its unrecoverable branch the same way, which was flagged in review of that change.

## Why?

An upstream that omits required response-envelope fields also omits them on individual output items. The SDK is forward compatible, so an output message missing `id` comes back as `{ type: "UNKNOWN", is_unknown: true, raw: { ... } }` rather than raising.

The agent loop appends whatever a turn returned into the conversation without restricting item types, so that wrapper is sent as an input item on the following turn. `UNKNOWN` matches none of the 44 accepted input item types, so the SDK rejects the outbound request before any HTTP call with `Input validation failed`, and the sample is recorded as a model error. The generation that produced the item completed and was billed.

Dropping such items instead of recovering them would silently remove an assistant turn or a tool call from the transcript, which corrupts the conversation rather than fixing it, so recovery is attempted first and only genuine failures are dropped and logged.

## How to test

Drive a multi-turn tool-bearing exchange against an upstream whose Responses output message items omit `id`. Before this change the third request fails with `Input validation failed` naming an input item deep in the accumulated conversation. After it, the exchange continues, the recovered item carries a `synthetic-<response id>-<index>` id, and the upstream accepts the replayed item.

## Benchmark impact

Agentic benchmarks against such an upstream lose whole samples today, which suppresses the affected arm's completion rate without affecting the model's actual output. Recovering the items restores those samples. No dataset, solver or scorer logic changes, and behavior against an upstream that emits complete items is unchanged, since recovery only runs for items the SDK failed to classify.

## Reviewer focus

- Whether a synthetic id is acceptable to place on a replayed item, and whether deriving it from the response id and index is the right stability guarantee.
- The decision to drop and log an unrecoverable item rather than fail the turn.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/014dc0a17f314a0fb5a8741be8e66fba
Requested by: @bjoerndanz
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->