### PR TITLE
feat(search): support web search mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@effect/platform": "0.95.0",
         "@google-cloud/storage": "7.19.0",
-        "@openrouter/sdk": "1.2.34",
+        "@openrouter/sdk": "1.2.14",
         "change-case": "5.4.4",
         "chrono-node": "2.9.0",
         "cli-progress": "3.12.0",
@@ -95,7 +95,7 @@
 
     "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
-    "@openrouter/sdk": ["@openrouter/sdk@1.2.34", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-KdbGP/emkkdl+UG7GXJyMsImSlirCsDe2V2zdoOBAV/FS+omDwIbhWdO6N5nxGTtz6bESgE9fi3MsbMCHaSxYw=="],
+    "@openrouter/sdk": ["@openrouter/sdk@1.2.14", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-eL8PH3vBbqTaCNpYLHF7sfuyDYYBH0lqKVz7wQWx/sHYGlfkOdIIgLwoxSPZiNNE15kfef9BX3WXCjyvHydq4Q=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@effect/platform": "0.95.0",
         "@google-cloud/storage": "7.19.0",
-        "@openrouter/sdk": "1.2.9",
+        "@openrouter/sdk": "1.2.34",
         "change-case": "5.4.4",
         "chrono-node": "2.9.0",
         "cli-progress": "3.12.0",
@@ -95,7 +95,7 @@
 
     "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
-    "@openrouter/sdk": ["@openrouter/sdk@1.2.9", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-yVYYmbUNVkeR2edsrkYvIz5/Ss3mB70bnJYquyPi6vbSkn0pcN3m/oI8zbdktsQZXFbKwJYBKX1IInNI/rfTxA=="],
+    "@openrouter/sdk": ["@openrouter/sdk@1.2.34", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-KdbGP/emkkdl+UG7GXJyMsImSlirCsDe2V2zdoOBAV/FS+omDwIbhWdO6N5nxGTtz6bESgE9fi3MsbMCHaSxYw=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@effect/platform": "0.95.0",
     "@google-cloud/storage": "7.19.0",
-    "@openrouter/sdk": "1.2.34",
+    "@openrouter/sdk": "1.2.14",
     "change-case": "5.4.4",
     "chrono-node": "2.9.0",
     "cli-progress": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@effect/platform": "0.95.0",
     "@google-cloud/storage": "7.19.0",
-    "@openrouter/sdk": "1.2.9",
+    "@openrouter/sdk": "1.2.34",
     "change-case": "5.4.4",
     "chrono-node": "2.9.0",
     "cli-progress": "3.12.0",

--- a/src/benchmarks/search/core/config.test.ts
+++ b/src/benchmarks/search/core/config.test.ts
@@ -22,6 +22,7 @@ describe("SearchLaneConfigSchema", () => {
     const result = parseSchema(SearchLaneConfigSchema, {
       webSearch: "server-tool",
       engine: "perplexity",
+      mode: "fast",
       maxAgentTurns: 25,
       maxResults: 10,
       maxTotalResults: 100,
@@ -29,12 +30,16 @@ describe("SearchLaneConfigSchema", () => {
     });
     assertRight(result);
     expect(result.right.maxAgentTurns).toBe(25);
+    expect(result.right.mode).toBe("fast");
   });
   it("rejects maxAgentTurns above the server hard cap", () => {
     expect(rejects({ maxAgentTurns: MAX_SERVER_TOOL_CALLS + 1 })).toBe(true);
   });
   it("rejects unknown engines", () => {
     expect(rejects({ engine: "bing" })).toBe(true);
+  });
+  it("rejects unknown modes", () => {
+    expect(rejects({ mode: "slow" })).toBe(true);
   });
   it("rejects maxResults beyond 25", () => {
     expect(rejects({ maxResults: 26 })).toBe(true);

--- a/src/benchmarks/search/core/config.ts
+++ b/src/benchmarks/search/core/config.ts
@@ -1,3 +1,5 @@
+import { WebSearchMode } from "@openrouter/sdk/models";
+
 import {
   MAX_SERVER_TOOL_CALLS,
   WEB_SEARCH_MAX_CHARACTERS_MAX,
@@ -31,6 +33,10 @@ export const SEARCH_CONTEXT_SIZES = ["low", "medium", "high"] as const;
 
 export type SearchContextSize = ValueOf<typeof SEARCH_CONTEXT_SIZES>;
 
+export const SearchModeSchema = z.enum(WebSearchMode);
+
+export type SearchMode = z.infer<typeof SearchModeSchema>;
+
 export const WebFetchConfigSchema = z.object({
   fetchEngine: FetchEngineSchema.optional(),
   maxFetchUses: z.number().int().min(1).optional(),
@@ -42,6 +48,7 @@ export type WebFetchConfig = z.infer<typeof WebFetchConfigSchema>;
 export const SearchLaneConfigSchema = z.object({
   webSearch: z.enum(SEARCH_SURFACES).default("server-tool"),
   engine: SearchEngineSchema.default("auto"),
+  mode: SearchModeSchema.optional(),
   maxAgentTurns: z.number().int().min(1).max(MAX_SERVER_TOOL_CALLS).optional(),
   maxResults: z
     .number()

--- a/src/benchmarks/search/core/request.test.ts
+++ b/src/benchmarks/search/core/request.test.ts
@@ -25,7 +25,12 @@ describe("buildSearchRequestBody", () => {
   it("builds a server-tool body with web_search and maxToolCalls", () => {
     const body = buildSearchRequestBody({
       ...BASE,
-      lane: lane({ engine: "exa", maxAgentTurns: 25, maxResults: 10 }),
+      lane: lane({
+        engine: "parallel",
+        mode: "fast",
+        maxAgentTurns: 25,
+        maxResults: 10,
+      }),
     });
     expect(body.model).toBe(BASE.model);
     expect(body.input).toEqual([
@@ -41,12 +46,21 @@ describe("buildSearchRequestBody", () => {
       {
         type: "openrouter:web_search",
         parameters: {
-          engine: "exa",
+          engine: "parallel",
+          mode: "fast",
           maxResults: 10,
           excludedDomains: LEAK_BLOCKLIST,
         },
       },
     ]);
+    expect(JSON.parse(responsesRequestToJSON(body))).toMatchObject({
+      tools: [
+        {
+          type: "openrouter:web_search",
+          parameters: { engine: "parallel", mode: "fast" },
+        },
+      ],
+    });
   });
   it("defaults the leak blocklist into web_search params, omitting engine when auto", () => {
     const body = buildSearchRequestBody({ ...BASE, lane: lane({}) });
@@ -83,6 +97,7 @@ describe("buildSearchRequestBody", () => {
       lane: lane({
         webSearch: "plugin",
         engine: "perplexity",
+        mode: "basic",
         maxResults: 5,
         allowedDomains: ["example.com"],
         excludedDomains: ["spam.example"],
@@ -94,6 +109,7 @@ describe("buildSearchRequestBody", () => {
       {
         id: "web",
         engine: "perplexity",
+        mode: "basic",
         maxResults: 5,
         includeDomains: ["example.com"],
         excludeDomains: ["spam.example"],

--- a/src/benchmarks/search/core/request.ts
+++ b/src/benchmarks/search/core/request.ts
@@ -41,6 +41,7 @@ function toSearchToolParams(
 ): WebSearchServerToolConfig | undefined {
   const params = definedValues({
     engine: lane.engine === "auto" ? undefined : lane.engine,
+    mode: lane.mode,
     maxResults: lane.maxResults,
     maxTotalResults: lane.maxTotalResults,
     searchContextSize: lane.searchContextSize,
@@ -92,6 +93,7 @@ function buildWebPlugin(lane: SearchLaneConfig): WebSearchPlugin {
     id: "web",
     ...definedValues({
       engine: lane.engine === "auto" ? undefined : lane.engine,
+      mode: lane.mode,
       maxResults: lane.maxResults,
       searchPrompt: lane.searchPrompt,
       includeDomains:


### PR DESCRIPTION
## Mode-specific search benchmarks

Search benchmark lanes could select an engine but could not represent its native `mode`. Zod therefore removed mode from parsed benchmark configurations, so mode comparisons such as Parallel `fast` could not reach OpenRouter. The previously pinned SDK also predated mode-aware web-search serialization.

## TL;DR

Add an optional SDK-backed `mode` field to `SearchLaneConfigSchema`, upgrade `@openrouter/sdk` to `1.2.14`, and forward mode through both supported search surfaces: `openrouter:web_search` server-tool parameters and the web plugin. Configurations that omit mode retain their existing behavior.

## What changed

- Validate mode values against the OpenRouter SDK vocabulary.
- Preserve mode in server-tool request parameters and emitted SDK JSON.
- Preserve mode in web-plugin configuration.
- Reject unknown mode values at config parsing.
- Upgrade the SDK from `1.2.9` to `1.2.14`.

## Why the SDK bump is required

`1.2.9` has no `mode` field in `WebSearchServerToolConfig`, so adding a harness field alone cannot put mode on the wire. `1.2.14` is the first published SDK release that exports the mode vocabulary and serializes `parameters.mode`.

## How to test

Locally completed against `@openrouter/sdk@1.2.14`:

- `bun run format:check`
- `bun run check`
- `bun run typecheck`
- `bun test` - 1,187 passing
- `bun run build`

The regression test proves `mode: "fast"` survives `responsesRequestToJSON`, while existing omitted-mode lanes remain unchanged.

## Reviewer focus

The compatibility boundary is omission: existing lane configs without `mode` must serialize exactly as before. The dependency bump is limited to the first SDK version that supports mode-aware web-search serialization.