### PR TITLE
fix: honor provider pins with provider.only routing in requests

### DIFF
--- a/src/benchmarks/benchmark-config.ts
+++ b/src/benchmarks/benchmark-config.ts
@@ -37,6 +37,8 @@ export const InferenceOverrideSchema = z.object({
   costTier: z.enum(COST_TIERS).optional(),
   timeoutMs: z.number().optional(),
   sort: z.nativeEnum(ProviderSort).optional(),
+  providerOnly: z.array(z.string()).optional(),
+  allowFallbacks: z.boolean().optional(),
   cloudflareVersion: z.string().optional(),
   costQualityTradeoff: z.number().int().min(0).max(10).optional(),
   pinModel: z.boolean().optional(),

--- a/src/benchmarks/deep-swe/benchmark.ts
+++ b/src/benchmarks/deep-swe/benchmark.ts
@@ -75,6 +75,8 @@ function makeDeepSweLayer(
             reasoningEffort: benchmarkConfig.reasoningEffort,
             timeoutMs: benchmarkConfig.timeoutMs,
             sort: benchmarkConfig.sort,
+            providerOnly: benchmarkConfig.providerOnly,
+            allowFallbacks: benchmarkConfig.allowFallbacks,
             cloudflareVersion: benchmarkConfig.cloudflareVersion,
             costTier: benchmarkConfig.costTier,
             costQualityTradeoff: benchmarkConfig.costQualityTradeoff,

--- a/src/benchmarks/gpqa-solver.test.ts
+++ b/src/benchmarks/gpqa-solver.test.ts
@@ -81,6 +81,8 @@ describe("gpqaSolver inference overrides (openbench parity)", () => {
         reasoningEffort: "low",
         timeoutMs: 5000,
         sort: ProviderSort.Price,
+        providerOnly: ["google-vertex"],
+        allowFallbacks: false,
         cloudflareVersion: "ver-1",
       },
     });
@@ -90,6 +92,8 @@ describe("gpqaSolver inference overrides (openbench parity)", () => {
       reasoningEffort: "low",
       timeoutMs: 5000,
       sort: ProviderSort.Price,
+      providerOnly: ["google-vertex"],
+      allowFallbacks: false,
       cloudflareVersion: "ver-1",
       endpointId: "ep-1",
     });

--- a/src/benchmarks/gpqa.ts
+++ b/src/benchmarks/gpqa.ts
@@ -135,6 +135,8 @@ export const GPQA_BENCHMARK: Benchmark = defineChatBenchmark({
         reasoningEffort: config.reasoningEffort,
         timeoutMs: config.timeoutMs,
         sort: config.sort,
+        providerOnly: config.providerOnly,
+        allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,
         costQualityTradeoff: config.costQualityTradeoff,

--- a/src/benchmarks/ifstruct/benchmark.ts
+++ b/src/benchmarks/ifstruct/benchmark.ts
@@ -160,6 +160,8 @@ export const IFSTRUCT_BENCHMARK: Benchmark = defineChatBenchmark({
         reasoningEffort: config.reasoningEffort,
         timeoutMs: config.timeoutMs,
         sort: config.sort,
+        providerOnly: config.providerOnly,
+        allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,
         costQualityTradeoff: config.costQualityTradeoff,

--- a/src/benchmarks/mmlu-pro.ts
+++ b/src/benchmarks/mmlu-pro.ts
@@ -165,6 +165,8 @@ const MMLU_PRO_CHAT_BENCHMARK = defineChatBenchmark({
         reasoningEffort: config.reasoningEffort,
         timeoutMs: config.timeoutMs,
         sort: config.sort,
+        providerOnly: config.providerOnly,
+        allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,
         costQualityTradeoff: config.costQualityTradeoff,

--- a/src/benchmarks/mmmu-pro-vision.ts
+++ b/src/benchmarks/mmmu-pro-vision.ts
@@ -167,6 +167,8 @@ export const MMMU_PRO_VISION_BENCHMARK: Benchmark = defineChatBenchmark({
         reasoningEffort: config.reasoningEffort,
         timeoutMs: config.timeoutMs,
         sort: config.sort,
+        providerOnly: config.providerOnly,
+        allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,
         costQualityTradeoff: config.costQualityTradeoff,

--- a/src/benchmarks/swe-atlas/benchmark.ts
+++ b/src/benchmarks/swe-atlas/benchmark.ts
@@ -84,6 +84,8 @@ function makeSweAtlasLayer(
             reasoningEffort: benchmarkConfig.reasoningEffort,
             timeoutMs: benchmarkConfig.timeoutMs,
             sort: benchmarkConfig.sort,
+            providerOnly: benchmarkConfig.providerOnly,
+            allowFallbacks: benchmarkConfig.allowFallbacks,
             cloudflareVersion: benchmarkConfig.cloudflareVersion,
             costTier: benchmarkConfig.costTier,
             costQualityTradeoff: benchmarkConfig.costQualityTradeoff,

--- a/src/benchmarks/tau-bench-airline/benchmark.ts
+++ b/src/benchmarks/tau-bench-airline/benchmark.ts
@@ -104,6 +104,8 @@ function makeAirlineLayer(
       reasoningEffort: benchmarkConfig.reasoningEffort,
       timeoutMs: benchmarkConfig.timeoutMs,
       sort: benchmarkConfig.sort,
+      providerOnly: benchmarkConfig.providerOnly,
+      allowFallbacks: benchmarkConfig.allowFallbacks,
       cloudflareVersion: benchmarkConfig.cloudflareVersion,
       costTier: benchmarkConfig.costTier,
       costQualityTradeoff: benchmarkConfig.costQualityTradeoff,

--- a/src/benchmarks/tau3-bench-banking/benchmark.ts
+++ b/src/benchmarks/tau3-bench-banking/benchmark.ts
@@ -58,6 +58,8 @@ function makeBankingLayer(
       reasoningEffort: config.reasoningEffort,
       timeoutMs: config.timeoutMs,
       sort: config.sort,
+      providerOnly: config.providerOnly,
+      allowFallbacks: config.allowFallbacks,
       cloudflareVersion: config.cloudflareVersion,
       costTier: config.costTier,
       costQualityTradeoff: config.costQualityTradeoff,

--- a/src/benchmarks/vgi-bench/benchmark.ts
+++ b/src/benchmarks/vgi-bench/benchmark.ts
@@ -278,6 +278,8 @@ const VGI_BENCH_CHAT_BENCHMARK = defineChatBenchmark({
         reasoningEffort: config.reasoningEffort,
         timeoutMs: config.timeoutMs,
         sort: config.sort,
+        providerOnly: config.providerOnly,
+        allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,
         costQualityTradeoff: config.costQualityTradeoff,

--- a/src/benchmarks/wandr/benchmark.ts
+++ b/src/benchmarks/wandr/benchmark.ts
@@ -35,6 +35,8 @@ export function wandrInferenceOverride(config: WandrConfig): InferenceOverride {
     reasoningEffort: config.reasoningEffort,
     timeoutMs: config.timeoutMs,
     sort: config.sort,
+    providerOnly: config.providerOnly,
+    allowFallbacks: config.allowFallbacks,
     cloudflareVersion: config.cloudflareVersion,
     costTier: config.costTier,
     costQualityTradeoff: config.costQualityTradeoff,

--- a/src/harness/model.ts
+++ b/src/harness/model.ts
@@ -24,6 +24,8 @@ export interface GenerateConfig {
   readonly costTier?: CostTier;
   readonly timeoutMs?: number;
   readonly sort?: ProviderSort;
+  readonly providerOnly?: readonly string[];
+  readonly allowFallbacks?: boolean;
   readonly cloudflareVersion?: string;
   readonly costQualityTradeoff?: number;
   readonly pinModel?: boolean;

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -127,6 +127,50 @@ describe("openrouter-model request parity", () => {
     );
     expect(captured.value?.body["provider"]).toEqual({ sort: "price" });
   });
+  it("sends provider.only with fallbacks disabled on pinned runs", async () => {
+    const captured = newHolder();
+    restore = installFetchCapture(captured);
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+    });
+    await runPromiseExit(
+      gen(function* run() {
+        const model = yield* Model;
+        yield* model.generate(MESSAGES, {
+          providerOnly: ["google-vertex"],
+          allowFallbacks: false,
+        });
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    expect(captured.value?.body["provider"]).toEqual({
+      only: ["google-vertex"],
+      allow_fallbacks: false,
+    });
+  });
+  it("merges sort with provider.only on pinned runs", async () => {
+    const captured = newHolder();
+    restore = installFetchCapture(captured);
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+    });
+    await runPromiseExit(
+      gen(function* run() {
+        const model = yield* Model;
+        yield* model.generate(MESSAGES, {
+          sort: ProviderSort.Price,
+          providerOnly: ["google-vertex"],
+          allowFallbacks: false,
+        });
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    expect(captured.value?.body["provider"]).toEqual({
+      sort: "price",
+      only: ["google-vertex"],
+      allow_fallbacks: false,
+    });
+  });
   it("records the chat completion generation id", async () => {
     const captured = newHolder();
     restore = installFetchCapture(captured);

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -140,6 +140,16 @@ export function generate(
   }
   const sendSort =
     genConfig.sort !== undefined && genConfig.endpointId === undefined;
+  const providerPreferences = {
+    ...(sendSort && { sort: genConfig.sort }),
+    ...(genConfig.providerOnly !== undefined && {
+      only: [...genConfig.providerOnly],
+    }),
+    ...(genConfig.allowFallbacks !== undefined && {
+      allow_fallbacks: genConfig.allowFallbacks,
+    }),
+  };
+  const sendProvider = Object.keys(providerPreferences).length > 0;
   const hasTimeout =
     genConfig.timeoutMs !== undefined && genConfig.timeoutMs > 0;
   const baseModel = stripVariantSuffix(model);
@@ -175,7 +185,7 @@ export function generate(
       ...(genConfig.reasoningEffort !== undefined && {
         reasoning_effort: genConfig.reasoningEffort,
       }),
-      ...(sendSort && { provider: { sort: genConfig.sort } }),
+      ...(sendProvider && { provider: providerPreferences }),
       ...(wireAutoRouterPlugin !== undefined && {
         plugins: [wireAutoRouterPlugin],
       }),

--- a/src/providers/responses-model.test.ts
+++ b/src/providers/responses-model.test.ts
@@ -359,6 +359,31 @@ describe("responses-model", () => {
     expect(captured.value?.body["provider"]).toBeUndefined();
     expect(captured.value?.headers["x-or-endpoint-id"]).toBe("endpoint-1");
   });
+  it("sends provider.only with fallbacks disabled on pinned runs", async () => {
+    const captured: {
+      value: CapturedRequest | undefined;
+    } = { value: undefined };
+    restore = installFetchStub(await readStreamFixture(), 200, captured);
+    const layer = makeResponsesModelLayer({
+      model: "openai/gpt-5",
+      apiKey: "sk-test",
+      retry: { baseDelayMs: 0, maxRetries: 0 },
+    });
+    const exit = await runPromiseExit(
+      gen(function* run() {
+        const model = yield* ResponsesModel;
+        return yield* model.generate([], {
+          providerOnly: ["google-vertex"],
+          allowFallbacks: false,
+        });
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    assertSuccess(exit);
+    expect(captured.value?.body["provider"]).toEqual({
+      only: ["google-vertex"],
+      allow_fallbacks: false,
+    });
+  });
   for (const [model, pluginId] of [
     ["openrouter/auto", "auto-router"],
     ["openrouter/auto-beta", "auto-beta-router"],

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -145,6 +145,16 @@ export function generate(
   const { genConfig } = opts;
   const sendSort =
     genConfig.sort !== undefined && genConfig.endpointId === undefined;
+  const providerPreferences = {
+    ...(sendSort && { sort: genConfig.sort }),
+    ...(genConfig.providerOnly !== undefined && {
+      only: [...genConfig.providerOnly],
+    }),
+    ...(genConfig.allowFallbacks !== undefined && {
+      allowFallbacks: genConfig.allowFallbacks,
+    }),
+  };
+  const sendProvider = Object.keys(providerPreferences).length > 0;
   const baseModel = stripVariantSuffix(opts.model);
   const autoRouterPlugin = buildAutoRouterPlugin(baseModel, genConfig);
   const body = {
@@ -166,7 +176,7 @@ export function generate(
     ...(genConfig.maxTokens !== undefined && {
       maxOutputTokens: genConfig.maxTokens,
     }),
-    ...(sendSort && { provider: { sort: genConfig.sort } }),
+    ...(sendProvider && { provider: providerPreferences }),
     ...(autoRouterPlugin !== undefined && { plugins: [autoRouterPlugin] }),
   } satisfies ResponsesRequest;
   const extraHeaders = {


### PR DESCRIPTION
## TL;DR

Add `providerOnly` / `allowFallbacks` inference options so provider-pinned runs actually send `provider: { only: [...], allow_fallbacks: false }` in requests instead of being default-routed.

## What changed?

- `InferenceOverrideSchema` (shared by all model benchmarks) gains optional `providerOnly: string[]` and `allowFallbacks: boolean`, generalizing the fields the search options schema already had.
- `GenerateConfig` carries `providerOnly` / `allowFallbacks`.
- `openrouter-model` builds one provider-preferences object, merging the existing `sort` gating with the new fields:

  ```ts
  provider: {
    ...(sendSort && { sort }),
    ...(providerOnly && { only: [...providerOnly] }),
    ...(allowFallbacks !== undefined && { allow_fallbacks: allowFallbacks }),
  }
  ```

- `responses-model` does the same using the SDK's camelCase `allowFallbacks` field.
- Every benchmark `makeSolver` inference block forwards the two new fields (gpqa, mmlu-pro, mmmu-pro-vision, ifstruct, vgi-bench, wandr, tau-bench-airline, tau3-bench-banking, swe-atlas, deep-swe).

## Why?

Callers that fan out one run per (model, provider) pair — e.g. the Temporal `benchmarkWorkflow` in openrouter-web — label results with the pinned provider, but the run config had no way to express the pin, so every request was default-routed. In a vgi_bench sweep launched 2026-08-14, ClickHouse `default.generations.provider_name` matched the pinned provider on only ~4-17% of generations per model. This adds the missing typed path from run config to the request body.

## How to test

Pinned config routes to the provider:

```sh
OPENROUTER_API_KEY=... bun run bench -- --benchmark gpqa_diamond --model openai/gpt-4o-mini --limit 2
```

then re-run with a config whose inference block sets `providerOnly: ["<provider>"]` and `allowFallbacks: false`, and confirm the generations' `provider_name` matches the pin. Requests without the new fields are byte-identical to before (covered by the existing request-parity tests).

## Benchmark impact

No score/solver/scorer changes. Runs that start passing `providerOnly` will route all requests to the pinned provider without fallbacks, so per-provider results become accurate (previously they reflected default routing).

## Reviewer focus

- `src/providers/openrouter-model.ts` / `src/providers/responses-model.ts`: the merged provider-preferences object must not change behavior when the new fields are unset.
- Default routing: configs without `providerOnly` still omit the `provider` field entirely (asserted in tests).

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed

Link to Devin session: https://openrouter.devinenterprise.com/sessions/b20a1edc1e9f46f4b9e43590fafbf589
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->