### PR TITLE
fix: log response-cache misses on benchmark run retries

### DIFF
--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -29,7 +29,7 @@ import {
   getCollectedGenerationIds,
   resetGenerationIds,
 } from "../runtime/generation-ids";
-import { setCurrentEpoch } from "../runtime/response-cache";
+import { setCurrentEpoch, withRunAttempt } from "../runtime/response-cache";
 import { makeOpenRouterModelLayer } from "./openrouter-model";
 
 const CHAT_RESULT = {
@@ -1175,5 +1175,77 @@ describe("openrouter-model 2xx error envelope", () => {
     assertSuccess(exit);
     expect(fetchCalls.count).toBe(2);
     expect(warnContextFor(warn)["raw_body"]).toBe(body);
+  });
+});
+
+describe("openrouter-model response cache miss logging", () => {
+  let restore: (() => void) | undefined;
+  let warn: Mock<(...args: unknown[]) => void> | undefined;
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+    warn?.mockRestore();
+    warn = undefined;
+  });
+  function installCacheStatusFetch(cacheStatus: string): () => void {
+    const original = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(CHAT_RESULT_JSON, {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "x-openrouter-cache-status": cacheStatus,
+        },
+      });
+    return () => {
+      globalThis.fetch = original;
+    };
+  }
+  function generateOnRunAttempt(
+    runAttempt: number
+  ): Promise<Exit<ModelOutput, ModelError>> {
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+      sessionId: "wf-123",
+    });
+    return runPromiseExit(
+      withRunAttempt(
+        runAttempt,
+        gen(function* run() {
+          const model = yield* Model;
+          return yield* model.generate(MESSAGES, {});
+        })
+      ).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+  }
+  it("warns when a retried run misses the response cache", async () => {
+    warn = spyOn(console, "warn").mockImplementation(() => {});
+    restore = installCacheStatusFetch("MISS");
+    const exit = await generateOnRunAttempt(2);
+    assertSuccess(exit);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message, context] = warn.mock.calls[0] ?? [];
+    expect(message).toBe("Expected response cache hit on run retry but missed");
+    expect(context).toMatchObject({
+      run_attempt: 2,
+      cache_salt: "wf-123",
+      cache_status: "MISS",
+      model: "openai/gpt-4o",
+    });
+  });
+  it("stays silent when a retried run hits the response cache", async () => {
+    warn = spyOn(console, "warn").mockImplementation(() => {});
+    restore = installCacheStatusFetch("HIT");
+    const exit = await generateOnRunAttempt(2);
+    assertSuccess(exit);
+    expect(warn).not.toHaveBeenCalled();
+  });
+  it("stays silent on the first run attempt", async () => {
+    warn = spyOn(console, "warn").mockImplementation(() => {});
+    restore = installCacheStatusFetch("MISS");
+    const exit = await generateOnRunAttempt(1);
+    assertSuccess(exit);
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -39,6 +39,8 @@ import {
   getCurrentCallSalt,
   getCurrentEpoch,
   getCurrentRetryAttempt,
+  getCurrentRunAttempt,
+  logUnexpectedResponseCacheMiss,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
   RESPONSE_CACHE_SOURCE_ID_HEADER,
@@ -162,6 +164,7 @@ export function generate(
     const startedAt = performance.now();
     const epoch = yield* getCurrentEpoch;
     const retryAttempt = yield* getCurrentRetryAttempt;
+    const runAttempt = yield* getCurrentRunAttempt;
     const callSalt = yield* getCurrentCallSalt;
     const cacheSalt = buildResponseCacheSalt(
       opts.sessionId,
@@ -246,6 +249,17 @@ export function generate(
       response.headers[RESPONSE_CACHE_STATUS_HEADER] ===
       RESPONSE_CACHE_STATUS_HIT;
     const cacheSourceId = response.headers[RESPONSE_CACHE_SOURCE_ID_HEADER];
+    logUnexpectedResponseCacheMiss({
+      isCacheHit,
+      runAttempt,
+      retryAttempt,
+      cacheSalt,
+      model,
+      ...(response.headers[RESPONSE_CACHE_STATUS_HEADER] !== undefined && {
+        cacheStatus: response.headers[RESPONSE_CACHE_STATUS_HEADER],
+      }),
+      ...identifiers,
+    });
     return yield* decodeResult(
       json,
       startedAt,

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { strict as assert } from "node:assert";
 import { readFile } from "node:fs/promises";
 
@@ -23,7 +23,7 @@ import {
   getCollectedGenerationIds,
   resetGenerationIds,
 } from "../runtime/generation-ids";
-import { setCurrentEpoch } from "../runtime/response-cache";
+import { setCurrentEpoch, withRunAttempt } from "../runtime/response-cache";
 import type { ModelErrorIdentifiers } from "./request-identifiers";
 import {
   consumeStream,
@@ -588,6 +588,56 @@ describe("makeResponsesLayer", () => {
         top_k: 5,
       });
     } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+  it("warns when a retried run misses the response cache", async () => {
+    const originalFetch = globalThis.fetch;
+    const stream = await readStreamFixture();
+    globalThis.fetch = async () =>
+      new Response(stream, {
+        status: 200,
+        headers: {
+          "content-type": "text/event-stream",
+          "x-openrouter-cache-status": "MISS",
+        },
+      });
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await runPromise(
+        withRunAttempt(
+          2,
+          gen(function* run() {
+            yield* setCurrentEpoch(2);
+            const responses = yield* Responses;
+            yield* responses.send(
+              { model: "m", input: [] },
+              { timeoutMs: 1000 }
+            );
+          })
+        ).pipe(
+          provide(
+            makeResponsesLayer({
+              apiKey: "sk-test",
+              baseUrl: "https://example.test",
+              sessionId: "wf-123",
+            })
+          )
+        )
+      );
+      expect(warn).toHaveBeenCalledTimes(1);
+      const [message, context] = warn.mock.calls[0] ?? [];
+      expect(message).toBe(
+        "Expected response cache hit on run retry but missed"
+      );
+      expect(context).toMatchObject({
+        run_attempt: 2,
+        cache_salt: "wf-123:epoch-2",
+        cache_status: "MISS",
+        model: "m",
+      });
+    } finally {
+      warn.mockRestore();
       globalThis.fetch = originalFetch;
     }
   });

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -18,7 +18,7 @@ import { Responses as ResponsesClient } from "@openrouter/sdk/sdk/responses";
 import { Tag } from "effect/Context";
 import { TaggedError } from "effect/Data";
 import type { Effect } from "effect/Effect";
-import { fail, flatMap, map, tryPromise } from "effect/Effect";
+import { all, fail, flatMap, map, sync, tap, tryPromise } from "effect/Effect";
 import type { Layer } from "effect/Layer";
 import { succeed as layerSucceed } from "effect/Layer";
 
@@ -28,11 +28,14 @@ import { Either } from "../internal/either";
 import { isRecord } from "../internal/guards";
 import { parseSchema, z } from "../internal/zod";
 import { recordGenerationId } from "../runtime/generation-ids";
+import type { ResponseCacheAttemptState } from "../runtime/response-cache";
 import {
   buildResponseCacheSalt,
   getCurrentCallSalt,
   getCurrentEpoch,
   getCurrentRetryAttempt,
+  getCurrentRunAttempt,
+  logUnexpectedResponseCacheMiss,
   RESPONSE_CACHE_HEADER,
   RESPONSE_CACHE_SALT_FIELD,
   RESPONSE_CACHE_SOURCE_ID_HEADER,
@@ -154,19 +157,21 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
   const send = (
     body: ResponsesRequest,
     options: ResponsesSendOptions,
-    effectiveExtraBody: Readonly<Record<string, unknown>> | undefined
+    effectiveExtraBody: Readonly<Record<string, unknown>> | undefined,
+    attemptState: ResponseCacheAttemptState
   ): Effect<ResponsesResult, ResponsesError> => {
     let identifiers: ModelErrorIdentifiers = {};
     let isCacheHit = false;
+    let cacheStatus: string | undefined;
     let cacheSourceId: string | undefined;
     const httpClient = new HTTPClient({
       fetcher: async (input, init) => {
         const request = await mergeExtraBody(input, init, effectiveExtraBody);
         const response = await fetch(request);
         identifiers = modelErrorIdentifiersFromFetchHeaders(response.headers);
-        isCacheHit =
-          response.headers.get(RESPONSE_CACHE_STATUS_HEADER) ===
-          RESPONSE_CACHE_STATUS_HIT;
+        cacheStatus =
+          response.headers.get(RESPONSE_CACHE_STATUS_HEADER) ?? undefined;
+        isCacheHit = cacheStatus === RESPONSE_CACHE_STATUS_HIT;
         cacheSourceId =
           response.headers.get(RESPONSE_CACHE_SOURCE_ID_HEADER) ?? undefined;
         options.onResponseIdentifiers?.(identifiers);
@@ -225,6 +230,17 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
       },
       catch: (cause) => toResponsesError(cause, identifiers),
     }).pipe(
+      tap(() =>
+        sync(() => {
+          logUnexpectedResponseCacheMiss({
+            ...attemptState,
+            isCacheHit,
+            ...(typeof body.model === "string" && { model: body.model }),
+            ...(cacheStatus !== undefined && { cacheStatus }),
+            ...identifiers,
+          });
+        })
+      ),
       flatMap((result) =>
         result
           ? recordGenerationId(
@@ -251,17 +267,13 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
     body: ResponsesRequest,
     options: ResponsesSendOptions
   ): Effect<ResponsesResult, ResponsesError> => {
-    return getCurrentEpoch.pipe(
-      flatMap((epoch) =>
-        getCurrentRetryAttempt.pipe(
-          flatMap((retryAttempt) =>
-            getCurrentCallSalt.pipe(
-              map((callSalt) => ({ epoch, retryAttempt, callSalt }))
-            )
-          )
-        )
-      ),
-      flatMap(({ epoch, retryAttempt, callSalt }) => {
+    return all({
+      epoch: getCurrentEpoch,
+      retryAttempt: getCurrentRetryAttempt,
+      runAttempt: getCurrentRunAttempt,
+      callSalt: getCurrentCallSalt,
+    }).pipe(
+      flatMap(({ epoch, retryAttempt, runAttempt, callSalt }) => {
         const cacheSalt = buildResponseCacheSalt(
           config.sessionId,
           epoch,
@@ -275,7 +287,11 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
                 [RESPONSE_CACHE_SALT_FIELD]: cacheSalt,
                 ...options.extraBody,
               };
-        return send(body, options, effectiveExtraBody);
+        return send(body, options, effectiveExtraBody, {
+          runAttempt,
+          retryAttempt,
+          cacheSalt,
+        });
       })
     );
   };

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -31,6 +31,7 @@ import {
   GenerationResolver,
   makeOpenRouterGenerationResolver,
 } from "../runtime/generation-resolver";
+import { withRunAttempt } from "../runtime/response-cache";
 import type { RetryConfig } from "../runtime/retry";
 
 export interface RunBenchmarkInput {
@@ -45,6 +46,7 @@ export interface RunBenchmarkInput {
     readonly end?: number;
   };
   readonly sessionId: string;
+  readonly runAttempt?: number;
   readonly datasetRetry?: RetryConfig;
   readonly progressReporter?: ProgressReporterService;
   readonly checkpointStore?: CheckpointStoreService;
@@ -101,6 +103,9 @@ export function runBenchmarkById(
       benchmark: input.benchmarkId,
       session_id: input.sessionId,
       ...(model !== undefined && { model }),
+      ...(input.runAttempt !== undefined && {
+        run_attempt: `${input.runAttempt}`,
+      }),
     },
   };
   const fullBenchmarkLayer = benchmarkLayer.pipe(
@@ -121,8 +126,11 @@ export function runBenchmarkById(
   );
   const runOpts =
     input.abortSignal !== undefined ? { signal: input.abortSignal } : undefined;
+  const program = runBenchmark(runConfig).pipe(provide(layers));
   return runHarnessPromise(
-    runBenchmark(runConfig).pipe(provide(layers)),
+    input.runAttempt === undefined
+      ? program
+      : withRunAttempt(input.runAttempt, program),
     runOpts
   )
     .then((result) => {

--- a/src/runtime/response-cache.test.ts
+++ b/src/runtime/response-cache.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import type { Mock } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 import { all, flatMap, runPromise } from "effect/Effect";
 
@@ -7,8 +8,12 @@ import {
   getCurrentCallSalt,
   getCurrentEpoch,
   getCurrentRetryAttempt,
+  getCurrentRunAttempt,
+  logUnexpectedResponseCacheMiss,
   setCurrentEpoch,
+  shouldExpectResponseCacheHit,
   withCallCacheSalt,
+  withRunAttempt,
 } from "./response-cache";
 
 describe("buildResponseCacheSalt", () => {
@@ -57,6 +62,122 @@ describe("withCallCacheSalt", () => {
 describe("currentRetryAttemptRef", () => {
   it("defaults to undefined", async () => {
     expect(await runPromise(getCurrentRetryAttempt)).toBeUndefined();
+  });
+});
+
+describe("currentRunAttemptRef", () => {
+  it("defaults to undefined", async () => {
+    expect(await runPromise(getCurrentRunAttempt)).toBeUndefined();
+  });
+  it("scopes the run attempt to the wrapped effect", async () => {
+    const attempts = await runPromise(
+      all([withRunAttempt(2, getCurrentRunAttempt), getCurrentRunAttempt])
+    );
+    expect(attempts).toEqual([2, undefined]);
+  });
+});
+
+describe("shouldExpectResponseCacheHit", () => {
+  it("expects a hit on a retried run replaying the same salt", () => {
+    expect(
+      shouldExpectResponseCacheHit({
+        runAttempt: 2,
+        retryAttempt: 0,
+        cacheSalt: "wf-123:epoch-0",
+      })
+    ).toBe(true);
+  });
+  it("expects nothing on the first run attempt", () => {
+    expect(
+      shouldExpectResponseCacheHit({
+        runAttempt: 1,
+        retryAttempt: 0,
+        cacheSalt: "wf-123:epoch-0",
+      })
+    ).toBe(false);
+  });
+  it("expects nothing when the run attempt is unknown", () => {
+    expect(
+      shouldExpectResponseCacheHit({
+        runAttempt: undefined,
+        retryAttempt: 0,
+        cacheSalt: "wf-123:epoch-0",
+      })
+    ).toBe(false);
+  });
+  it("expects nothing for in-process retries that change the salt", () => {
+    expect(
+      shouldExpectResponseCacheHit({
+        runAttempt: 3,
+        retryAttempt: 1,
+        cacheSalt: "wf-123:epoch-0:attempt-1",
+      })
+    ).toBe(false);
+  });
+  it("expects nothing when no cache salt is sent", () => {
+    expect(
+      shouldExpectResponseCacheHit({
+        runAttempt: 2,
+        retryAttempt: 0,
+        cacheSalt: undefined,
+      })
+    ).toBe(false);
+  });
+});
+
+describe("logUnexpectedResponseCacheMiss", () => {
+  let warn: Mock<(...args: unknown[]) => void> | undefined;
+  afterEach(() => {
+    warn?.mockRestore();
+    warn = undefined;
+  });
+  function silenceWarnings(): Mock<(...args: unknown[]) => void> {
+    warn = spyOn(console, "warn").mockImplementation(() => {});
+    return warn;
+  }
+  it("logs the cache salt and attempt when an expected hit misses", () => {
+    const spy = silenceWarnings();
+    logUnexpectedResponseCacheMiss({
+      isCacheHit: false,
+      runAttempt: 2,
+      retryAttempt: 0,
+      cacheSalt: "wf-123:epoch-0",
+      model: "openai/gpt-4o",
+      cacheStatus: "MISS",
+      cfRay: "ray-1",
+      generationId: "gen-1",
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [message, context] = spy.mock.calls[0] ?? [];
+    expect(message).toBe("Expected response cache hit on run retry but missed");
+    expect(context).toMatchObject({
+      run_attempt: 2,
+      cache_salt: "wf-123:epoch-0",
+      model: "openai/gpt-4o",
+      cache_status: "MISS",
+      cf_ray: "ray-1",
+      generation_id: "gen-1",
+    });
+  });
+  it("stays silent when the retried run hits the cache", () => {
+    const spy = silenceWarnings();
+    logUnexpectedResponseCacheMiss({
+      isCacheHit: true,
+      runAttempt: 2,
+      retryAttempt: 0,
+      cacheSalt: "wf-123:epoch-0",
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+  it("stays silent on a first-attempt miss", () => {
+    const spy = silenceWarnings();
+    logUnexpectedResponseCacheMiss({
+      isCacheHit: false,
+      runAttempt: 1,
+      retryAttempt: 0,
+      cacheSalt: "wf-123:epoch-0",
+    });
+    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/runtime/response-cache.ts
+++ b/src/runtime/response-cache.ts
@@ -3,6 +3,8 @@ import { locally } from "effect/Effect";
 import type { FiberRef } from "effect/FiberRef";
 import { get, set, unsafeMake } from "effect/FiberRef";
 
+import { wLog } from "../internal/log";
+
 export const RESPONSE_CACHE_HEADER = "x-openrouter-cache";
 
 export const RESPONSE_CACHE_TTL_HEADER = "x-openrouter-cache-ttl";
@@ -35,6 +37,20 @@ export const getCurrentRetryAttempt: Effect<number | undefined> = get(
   currentRetryAttemptRef
 );
 
+export const currentRunAttemptRef: FiberRef<number | undefined> = unsafeMake<
+  number | undefined
+>(undefined);
+
+export const getCurrentRunAttempt: Effect<number | undefined> =
+  get(currentRunAttemptRef);
+
+export function withRunAttempt<A, E, R>(
+  runAttempt: number,
+  effect: Effect<A, E, R>
+): Effect<A, E, R> {
+  return locally(effect, currentRunAttemptRef, runAttempt);
+}
+
 export const currentCallSaltRef: FiberRef<string | undefined> = unsafeMake<
   string | undefined
 >(undefined);
@@ -64,4 +80,55 @@ export function buildResponseCacheSalt(
       : []),
   ];
   return parts.length > 0 ? parts.join(":") : undefined;
+}
+
+export interface ResponseCacheAttemptState {
+  readonly runAttempt: number | undefined;
+  readonly retryAttempt: number | undefined;
+  readonly cacheSalt: string | undefined;
+}
+
+export function shouldExpectResponseCacheHit({
+  runAttempt,
+  retryAttempt,
+  cacheSalt,
+}: ResponseCacheAttemptState): boolean {
+  return (
+    cacheSalt !== undefined &&
+    runAttempt !== undefined &&
+    runAttempt > 1 &&
+    (retryAttempt === undefined || retryAttempt <= 0)
+  );
+}
+
+export interface ResponseCacheMissContext extends ResponseCacheAttemptState {
+  readonly isCacheHit: boolean;
+  readonly model?: string;
+  readonly cacheStatus?: string;
+  readonly cfRay?: string;
+  readonly xRequestId?: string;
+  readonly generationId?: string;
+}
+
+export function logUnexpectedResponseCacheMiss(
+  context: ResponseCacheMissContext
+): void {
+  if (context.isCacheHit || !shouldExpectResponseCacheHit(context)) {
+    return;
+  }
+  wLog("Expected response cache hit on run retry but missed", {
+    run_attempt: context.runAttempt,
+    cache_salt: context.cacheSalt,
+    ...(context.model !== undefined && { model: context.model }),
+    ...(context.cacheStatus !== undefined && {
+      cache_status: context.cacheStatus,
+    }),
+    ...(context.cfRay !== undefined && { cf_ray: context.cfRay }),
+    ...(context.xRequestId !== undefined && {
+      x_request_id: context.xRequestId,
+    }),
+    ...(context.generationId !== undefined && {
+      generation_id: context.generationId,
+    }),
+  });
 }


### PR DESCRIPTION
## TL;DR

When a benchmark run is retried by its orchestrator (e.g. a Temporal activity retry), provider requests reuse the same `cache_salt` and should hit OpenRouter response caching — this adds a `wLog` warning whenever such a request misses instead.

## What changed?

- `src/runtime/response-cache.ts`: new `currentRunAttemptRef` FiberRef (`withRunAttempt`, `getCurrentRunAttempt`), a `shouldExpectResponseCacheHit` predicate, and `logUnexpectedResponseCacheMiss`, which logs only when a hit was expected and the response was a miss:

  ```ts
  cacheSalt !== undefined &&
    runAttempt !== undefined &&
    runAttempt > 1 &&
    (retryAttempt === undefined || retryAttempt <= 0);
  ```

- `src/providers/openrouter-model.ts` and `src/providers/responses-client.ts`: after reading the response cache headers, both call `logUnexpectedResponseCacheMiss` with `run_attempt`, `cache_salt`, `cache_status`, `model`, and the request identifiers (`cf_ray`, `x_request_id`, `generation_id`).
- `src/runner/run-by-id.ts`: optional `runAttempt` on `RunBenchmarkInput`; when present it is added to the log annotations and the benchmark program is wrapped in `withRunAttempt`.

The run attempt is deliberately separate from the existing in-process `currentRetryAttemptRef`: in-process retries append `attempt-N` to the salt on purpose, so they are excluded from the predicate and never warn.

## Why?

Orchestrator retries are supposed to be nearly free — the salt is stable across attempts, so completed samples should replay from the response cache. Today a cache regression (TTL expiry, salt drift, routing change) silently turns a retry into a full re-spend with no signal. Requested in Slack: <https://openrouter.slack.com/archives/C07UF9XLTFF/p1786807661570699>

## How to test

Callers opt in by passing `runAttempt`. With a stable `sessionId`, a second attempt that misses the cache emits:

```text
Expected response cache hit on run retry but missed
{ run_attempt: 2, cache_salt: "wf-123", cache_status: "MISS", model: "openai/gpt-4o", cf_ray: ..., generation_id: ... }
```

Nothing is logged on the first attempt, on a `HIT`, when no cache salt exists, or for in-process model retries.

Covered by deterministic, network-free tests in `src/runtime/response-cache.test.ts`, `src/providers/openrouter-model.test.ts`, and `src/providers/responses-client.test.ts` (stubbed `fetch` + spied logger).

## Reviewer focus

- The `runAttempt > 1` threshold assumes 1-based attempt numbering (matches Temporal's `ActivityInfo.attempt`, which the `openrouter-web` caller will pass in a follow-up subtree sync).
- Miss logging sits on the successful-response path only; retryable HTTP failures do not warn.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [ ] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [ ] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/3a1d4c189e2146a49c8b4b711ae32f85
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->