### PR TITLE
fix(response-cache): send cache salt as header

### DIFF
--- a/src/benchmarks/tau-bench-airline/user-simulator.test.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.test.ts
@@ -12,6 +12,7 @@ import {
   getCollectedGenerationIds,
   resetGenerationIds,
 } from "../../runtime/generation-ids";
+import { setCurrentEpoch } from "../../runtime/response-cache";
 import { UserSimulator } from "./user-simulator";
 describe("UserSimulator", () => {
   it.serial(
@@ -43,6 +44,34 @@ describe("UserSimulator", () => {
       }
     }
   );
+  it.serial("sends the cache salt as a header, not a body field", async () => {
+    const requests: CapturedRequest[] = [];
+    const restore = installFetchSequence(
+      [{ id: "tau-user-gen-1", choices: [{ message: { content: "Hello" } }] }],
+      requests
+    );
+    try {
+      const simulator = new UserSimulator({
+        apiKey: "sk-test",
+        model: "openai/gpt-4o-mini",
+        baseUrl: "https://example.test",
+        sessionId: "wf-123",
+      });
+      simulator.reset("scenario", "Hi");
+      await runPromise(
+        setCurrentEpoch(2).pipe(
+          flatMap(() => simulator.generateInitial()),
+          provide(FetchHttpClient.layer)
+        )
+      );
+      expect(requests[0]?.headers["x-openrouter-cache-salt"]).toBe(
+        "wf-123:epoch-2"
+      );
+      expect(requests[0]?.body["cache_salt"]).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
   it.serial(
     "replays opaque reasoning_details and omits absent details",
     async () => {

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -29,7 +29,7 @@ import {
   getCurrentEpoch,
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
-  RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SALT_HEADER,
   RESPONSE_CACHE_SOURCE_ID_HEADER,
   RESPONSE_CACHE_STATUS_HEADER,
   RESPONSE_CACHE_STATUS_HIT,
@@ -162,6 +162,9 @@ export class UserSimulator {
           "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
           "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
           [RESPONSE_CACHE_HEADER]: "true",
+          ...(cacheSalt !== undefined && {
+            [RESPONSE_CACHE_SALT_HEADER]: cacheSalt,
+          }),
           [RESPONSE_CACHE_TTL_HEADER]: `${RESPONSE_CACHE_TTL_SECONDS}`,
           ...(config.sessionId !== undefined && {
             "x-session-id": config.sessionId,
@@ -171,9 +174,6 @@ export class UserSimulator {
           model,
           messages,
           temperature: 0,
-          ...(cacheSalt !== undefined && {
-            [RESPONSE_CACHE_SALT_FIELD]: cacheSalt,
-          }),
         })
       );
       const client = yield* HttpClient.HttpClient;

--- a/src/benchmarks/tau3-bench-banking/user-simulator.test.ts
+++ b/src/benchmarks/tau3-bench-banking/user-simulator.test.ts
@@ -147,15 +147,17 @@ describe("UserSimulator", () => {
       await runSim(sim.generateInitial());
       expect(authorization).toBe(`Bearer ${TEST_API_KEY}`);
     });
-    it("sends the response-cache headers and an epoch-scoped cache_salt", async () => {
+    it("sends the response-cache headers and an epoch-scoped salt", async () => {
       const sim = new UserSimulator(createTestConfig());
       sim.reset("Help", "Hi");
       let cacheHeader: string | null = null;
+      let saltHeader: string | null = null;
       let ttlHeader: string | null = null;
       let capturedBody: unknown;
       global.fetch = async (input, init) => {
         const request = new Request(input, init);
         cacheHeader = request.headers.get("x-openrouter-cache");
+        saltHeader = request.headers.get("x-openrouter-cache-salt");
         ttlHeader = request.headers.get("x-openrouter-cache-ttl");
         capturedBody = await request.clone().json();
         return new Response(
@@ -169,9 +171,10 @@ describe("UserSimulator", () => {
         setCurrentEpoch(2).pipe(flatMap(() => sim.generateInitial()))
       );
       expect(cacheHeader).toBe("true");
+      expect(saltHeader).toBe(`${TEST_SESSION}:epoch-2`);
       expect(ttlHeader).toBe("7200");
       assert(isRecord(capturedBody));
-      expect(capturedBody["cache_salt"]).toBe(`${TEST_SESSION}:epoch-2`);
+      expect(capturedBody["cache_salt"]).toBeUndefined();
     });
   });
   describe("step", () => {

--- a/src/benchmarks/tau3-bench-banking/user-simulator.ts
+++ b/src/benchmarks/tau3-bench-banking/user-simulator.ts
@@ -25,7 +25,7 @@ import {
   getCurrentEpoch,
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
-  RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SALT_HEADER,
   RESPONSE_CACHE_TTL_HEADER,
   RESPONSE_CACHE_TTL_SECONDS,
 } from "../../runtime/response-cache";
@@ -174,9 +174,6 @@ export class UserSimulator {
         ...(this.config.userReasoningEffort !== undefined && {
           reasoning_effort: this.config.userReasoningEffort,
         }),
-        ...(cacheSalt !== undefined && {
-          [RESPONSE_CACHE_SALT_FIELD]: cacheSalt,
-        }),
       };
       if (this.availableTools.length > 0) {
         requestBody.tools = [...this.availableTools];
@@ -190,6 +187,9 @@ export class UserSimulator {
           "HTTP-Referer": BENCH_HARNESS_APP_REFERRER,
           "X-OpenRouter-Title": BENCH_HARNESS_APP_TITLE,
           [RESPONSE_CACHE_HEADER]: "true",
+          ...(cacheSalt !== undefined && {
+            [RESPONSE_CACHE_SALT_HEADER]: cacheSalt,
+          }),
           [RESPONSE_CACHE_TTL_HEADER]: `${RESPONSE_CACHE_TTL_SECONDS}`,
           ...(this.config.sessionId !== undefined && {
             "x-session-id": this.config.sessionId,

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -477,7 +477,7 @@ describe("openrouter-model response caching", () => {
     );
     expect(captured.value?.headers["x-openrouter-cache"]).toBe("true");
   });
-  it("sends a session- and epoch-scoped cache_salt body field", async () => {
+  it("sends a session- and epoch-scoped cache salt header", async () => {
     const captured = newHolder();
     restore = installFetchCapture(captured);
     const layer = makeOpenRouterModelLayer({
@@ -492,9 +492,12 @@ describe("openrouter-model response caching", () => {
         yield* model.generate(MESSAGES, {});
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
-    expect(captured.value?.body["cache_salt"]).toBe("wf-123:epoch-1");
+    expect(captured.value?.headers["x-openrouter-cache-salt"]).toBe(
+      "wf-123:epoch-1"
+    );
+    expect(captured.value?.body["cache_salt"]).toBeUndefined();
   });
-  it("varies the cache_salt across epochs", async () => {
+  it("varies the cache salt header across epochs", async () => {
     const captured = newHolder();
     restore = installFetchCapture(captured);
     const layer = makeOpenRouterModelLayer({
@@ -508,22 +511,21 @@ describe("openrouter-model response caching", () => {
         const model = yield* Model;
         yield* setCurrentEpoch(0);
         yield* model.generate(MESSAGES, {});
-        salts.push(captured.value?.body["cache_salt"]);
+        salts.push(captured.value?.headers["x-openrouter-cache-salt"]);
         yield* setCurrentEpoch(1);
         yield* model.generate(MESSAGES, {});
-        salts.push(captured.value?.body["cache_salt"]);
+        salts.push(captured.value?.headers["x-openrouter-cache-salt"]);
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
     expect(salts).toEqual(["wf-123:epoch-0", "wf-123:epoch-1"]);
   });
-  it("appends the retry attempt to cache_salt on in-process retries", async () => {
+  it("appends the retry attempt to the cache salt header on in-process retries", async () => {
     const salts: unknown[] = [];
     const original = globalThis.fetch;
     let callCount = 0;
     const stub: typeof fetch = async (input, init) => {
       const req = input instanceof Request ? input : new Request(input, init);
-      const rawBody = await req.clone().text();
-      salts.push(parseJsonObject(rawBody)["cache_salt"]);
+      salts.push(req.headers.get("x-openrouter-cache-salt"));
       callCount += 1;
       if (callCount === 1) {
         return new Response(JSON.stringify({ error: { message: "slow" } }), {
@@ -555,7 +557,7 @@ describe("openrouter-model response caching", () => {
     );
     expect(salts).toEqual(["wf-123:epoch-1", "wf-123:epoch-1:attempt-1"]);
   });
-  it("omits cache_salt when session id and epoch are unset", async () => {
+  it("omits the cache salt header when session id and epoch are unset", async () => {
     const captured = newHolder();
     restore = installFetchCapture(captured);
     const layer = makeOpenRouterModelLayer({
@@ -568,6 +570,7 @@ describe("openrouter-model response caching", () => {
         yield* model.generate(MESSAGES, {});
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
+    expect(captured.value?.headers["x-openrouter-cache-salt"]).toBeUndefined();
     expect(captured.value?.body["cache_salt"]).toBeUndefined();
   });
 });

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -40,7 +40,7 @@ import {
   getCurrentEpoch,
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
-  RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SALT_HEADER,
   RESPONSE_CACHE_SOURCE_ID_HEADER,
   RESPONSE_CACHE_STATUS_HEADER,
   RESPONSE_CACHE_STATUS_HIT,
@@ -189,15 +189,17 @@ export function generate(
       ...(wireAutoRouterPlugin !== undefined && {
         plugins: [wireAutoRouterPlugin],
       }),
-      ...(cacheSalt !== undefined && {
-        [RESPONSE_CACHE_SALT_FIELD]: cacheSalt,
-      }),
       ...genConfig.extraBody,
     };
     const request = HttpClientRequest.post(
       `${opts.baseUrl}/chat/completions`
     ).pipe(
-      HttpClientRequest.setHeaders(headers),
+      HttpClientRequest.setHeaders({
+        ...headers,
+        ...(cacheSalt !== undefined && {
+          [RESPONSE_CACHE_SALT_HEADER]: cacheSalt,
+        }),
+      }),
       HttpClientRequest.bodyUnsafeJson(body)
     );
     const response = yield* hasTimeout

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -548,7 +548,7 @@ describe("makeResponsesLayer", () => {
       globalThis.fetch = originalFetch;
     }
   });
-  it("sends the response-cache header and an epoch-scoped cache_salt", async () => {
+  it("sends response-cache headers with an epoch-scoped salt", async () => {
     const originalFetch = globalThis.fetch;
     const stream = await readStreamFixture();
     const capturedBodies: unknown[] = [];
@@ -583,10 +583,13 @@ describe("makeResponsesLayer", () => {
         )
       );
       expect(capturedHeaders?.get("x-openrouter-cache")).toBe("true");
+      expect(capturedHeaders?.get("x-openrouter-cache-salt")).toBe(
+        "wf-123:epoch-2"
+      );
       expect(capturedBodies[0]).toMatchObject({
-        cache_salt: "wf-123:epoch-2",
         top_k: 5,
       });
+      expect(capturedBodies[0]).not.toHaveProperty("cache_salt");
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/src/providers/responses-client.ts
+++ b/src/providers/responses-client.ts
@@ -34,7 +34,7 @@ import {
   getCurrentEpoch,
   getCurrentRetryAttempt,
   RESPONSE_CACHE_HEADER,
-  RESPONSE_CACHE_SALT_FIELD,
+  RESPONSE_CACHE_SALT_HEADER,
   RESPONSE_CACHE_SOURCE_ID_HEADER,
   RESPONSE_CACHE_STATUS_HEADER,
   RESPONSE_CACHE_STATUS_HIT,
@@ -154,14 +154,14 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
   const send = (
     body: ResponsesRequest,
     options: ResponsesSendOptions,
-    effectiveExtraBody: Readonly<Record<string, unknown>> | undefined
+    cacheSalt: string | undefined
   ): Effect<ResponsesResult, ResponsesError> => {
     let identifiers: ModelErrorIdentifiers = {};
     let isCacheHit = false;
     let cacheSourceId: string | undefined;
     const httpClient = new HTTPClient({
       fetcher: async (input, init) => {
-        const request = await mergeExtraBody(input, init, effectiveExtraBody);
+        const request = await mergeExtraBody(input, init, options.extraBody);
         const response = await fetch(request);
         identifiers = modelErrorIdentifiersFromFetchHeaders(response.headers);
         isCacheHit =
@@ -193,6 +193,9 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
       }),
       [RESPONSE_CACHE_HEADER]: "true",
       [RESPONSE_CACHE_TTL_HEADER]: `${RESPONSE_CACHE_TTL_SECONDS}`,
+      ...(cacheSalt !== undefined && {
+        [RESPONSE_CACHE_SALT_HEADER]: cacheSalt,
+      }),
     };
     return tryPromise({
       try: async (signal) => {
@@ -200,7 +203,7 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
         const requestBody = {
           ...body,
           ...(body.cacheControl === undefined &&
-            effectiveExtraBody?.["cache_control"] === undefined && {
+            options.extraBody?.["cache_control"] === undefined && {
               cacheControl: { type: "ephemeral" as const },
             }),
           stream: true,
@@ -268,14 +271,7 @@ export function makeResponsesLayer(config: ResponsesConfig): Layer<Responses> {
           retryAttempt,
           callSalt
         );
-        const effectiveExtraBody =
-          cacheSalt === undefined
-            ? options.extraBody
-            : {
-                [RESPONSE_CACHE_SALT_FIELD]: cacheSalt,
-                ...options.extraBody,
-              };
-        return send(body, options, effectiveExtraBody);
+        return send(body, options, cacheSalt);
       })
     );
   };

--- a/src/runtime/response-cache.ts
+++ b/src/runtime/response-cache.ts
@@ -15,7 +15,7 @@ export const RESPONSE_CACHE_STATUS_HIT = "HIT";
 
 export const RESPONSE_CACHE_SOURCE_ID_HEADER = "x-openrouter-cache-source-id";
 
-export const RESPONSE_CACHE_SALT_FIELD = "cache_salt";
+export const RESPONSE_CACHE_SALT_HEADER = "x-openrouter-cache-salt";
 
 export const currentEpochRef: FiberRef<number | undefined> = unsafeMake<
   number | undefined


### PR DESCRIPTION
## Body salts can reach Responses providers

Per-epoch response-cache salts were injected as an undocumented `cache_salt` JSON field. OpenRouter's Responses runtime preserves unknown root fields for provider compatibility, so matching adapters can forward that private field upstream. Three Parallel WideSearch runs consequently returned `400 Unknown parameter: 'cache_salt'` for 271 of 295 landed rows.

## TL;DR

Send the existing session/epoch/retry salt through `x-openrouter-cache-salt` instead of the request body. Salt construction and retry partitioning remain unchanged, while chat, Responses, and user-simulator payloads no longer contain `cache_salt`.

## What Changed?

- Replaced the body-field constant with `RESPONSE_CACHE_SALT_HEADER`.
- Moved salts to headers in the Chat Completions and Responses clients.
- Moved salts to headers in the tau-bench airline and tau3-banking user simulators.
- Preserved session, epoch, call, and retry-attempt salt composition.
- Kept generic Responses `extraBody` support independent from cache salting.
- Updated request-capture tests to assert the header value and prove `cache_salt` is absent from JSON bodies.

## Sequencing And Rollout

Depends on OpenRouterTeam/openrouter-web#34276. Deploy the cfw-api header consumer before deploying a benchmark worker built from this PR; otherwise the new header would temporarily be ignored and epochs would share cache keys.

No body-field compatibility path is retained or introduced.

## How To Test

Validated after push:

- Focused provider and user-simulator suite: 95 passed.
- Full suite: 1,254 passed across 117 files.
- `bun run format:check`: passed.
- `bun run check`: passed with existing warnings only.
- `bun run typecheck`: passed with one existing informational Effect diagnostic.
- `bun run build`: passed.

After both deployments, rerun the one-sample Parallel WideSearch Temporal smoke. The request should contain `x-openrouter-cache-salt`, omit body `cache_salt`, and complete without the provider `unknown_parameter` error.

## Reviewer Focus

- Confirm every salt sender moved to the header.
- Confirm retry attempts still receive distinct salt values.
- Confirm Responses `extraBody` behavior remains unchanged except that cache salting no longer uses it.
