### PR TITLE
feat(vgi-bench): add configurable media mirror script

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@effect/tsgo": "0.31.0",
+        "@types/bun": "1.3.14",
         "@types/cli-progress": "3.11.6",
         "@types/node": "24.10.0",
         "@typescript/native": "npm:@typescript/native-preview@7.0.0-dev.20260707.2",
@@ -195,6 +196,8 @@
 
     "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
 
     "@types/cli-progress": ["@types/cli-progress@3.11.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA=="],
@@ -288,6 +291,8 @@
     "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -41,10 +41,11 @@
     "typecheck": "effect-tsgo diagnostics --project tsconfig.json",
     "test": "bun test",
     "lint": "bun run typecheck && bun run check",
-    "format": "oxfmt src test --write",
-    "format:check": "oxfmt src test --check",
+    "format": "oxfmt src test scripts --write",
+    "format:check": "oxfmt src test scripts --check",
     "check": "oxlint",
-    "fix": "oxfmt src test --write && oxlint --fix"
+    "fix": "oxfmt src test scripts --write && oxlint --fix",
+    "mirror-vgi-bench-media": "bun scripts/mirror-vgi-bench-media.ts"
   },
   "dependencies": {
     "@effect/platform": "0.95.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "bench": "bun src/cli/index.ts",
     "build": "tsgo --project tsconfig.build.json",
-    "typecheck": "effect-tsgo diagnostics --project tsconfig.json",
+    "typecheck": "effect-tsgo diagnostics --project tsconfig.json && effect-tsgo diagnostics --project tsconfig.scripts.json",
     "test": "bun test",
     "lint": "bun run typecheck && bun run check",
     "format": "oxfmt src test scripts --write",
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@effect/tsgo": "0.31.0",
+    "@types/bun": "1.3.14",
     "@types/cli-progress": "3.11.6",
     "@types/node": "24.10.0",
     "@typescript/native": "npm:@typescript/native-preview@7.0.0-dev.20260707.2",

--- a/scripts/mirror-vgi-bench-media.test.ts
+++ b/scripts/mirror-vgi-bench-media.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { VGI_BENCH_DEFAULT_REVISION } from "../src/benchmarks/vgi-bench/benchmark";
 import type { ManifestEntry } from "./mirror-vgi-bench-media";
 import {
+  candidateSources,
   describeFailure,
   extensionOf,
   hashManifest,
@@ -72,6 +73,24 @@ describe("readOptions", () => {
   test("rejects invalid numeric flags", () => {
     expect(() => readOptions(["--concurrency=0"])).toThrow();
     expect(() => readOptions(["--limit=abc"])).toThrow();
+  });
+});
+
+describe("candidateSources", () => {
+  test("prefers the downscaled URL over the original", () => {
+    expect(candidateSources("https://example.test/videos/clip.mp4")).toEqual([
+      {
+        url: "https://example.test/videos/clip_proxy_v2.mp4",
+        kind: "downscaled",
+      },
+      { url: "https://example.test/videos/clip.mp4", kind: "original" },
+    ]);
+  });
+
+  test("falls back to the original alone when it is not a URL", () => {
+    expect(candidateSources("not a url")).toEqual([
+      { url: "not a url", kind: "original" },
+    ]);
   });
 });
 

--- a/scripts/mirror-vgi-bench-media.test.ts
+++ b/scripts/mirror-vgi-bench-media.test.ts
@@ -7,6 +7,7 @@ import {
   describeFailure,
   extensionOf,
   hashManifest,
+  normalizeKeyPrefix,
   readOptions,
 } from "./mirror-vgi-bench-media";
 
@@ -73,6 +74,19 @@ describe("readOptions", () => {
   test("rejects invalid numeric flags", () => {
     expect(() => readOptions(["--concurrency=0"])).toThrow();
     expect(() => readOptions(["--limit=abc"])).toThrow();
+  });
+});
+
+describe("normalizeKeyPrefix", () => {
+  test("appends a single trailing slash to a real prefix", () => {
+    expect(normalizeKeyPrefix("vgi-bench")).toBe("vgi-bench/");
+    expect(normalizeKeyPrefix("/vgi-bench/v1/")).toBe("vgi-bench/v1/");
+  });
+
+  test("treats blank and slash-only prefixes as absent", () => {
+    expect(normalizeKeyPrefix(undefined)).toBe("");
+    expect(normalizeKeyPrefix("  ")).toBe("");
+    expect(normalizeKeyPrefix("///")).toBe("");
   });
 });
 

--- a/scripts/mirror-vgi-bench-media.test.ts
+++ b/scripts/mirror-vgi-bench-media.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { VGI_BENCH_DEFAULT_REVISION } from "../src/benchmarks/vgi-bench/benchmark";
 import type { ManifestEntry } from "./mirror-vgi-bench-media";
 import {
+  describeFailure,
   extensionOf,
   hashManifest,
   readOptions,
@@ -71,6 +72,18 @@ describe("readOptions", () => {
   test("rejects invalid numeric flags", () => {
     expect(() => readOptions(["--concurrency=0"])).toThrow();
     expect(() => readOptions(["--limit=abc"])).toThrow();
+  });
+});
+
+describe("describeFailure", () => {
+  test("reports the message of an error", () => {
+    expect(describeFailure(new Error("Download failed with 503"))).toBe(
+      "Download failed with 503"
+    );
+  });
+
+  test("stringifies non-error causes", () => {
+    expect(describeFailure("socket hang up")).toBe("socket hang up");
   });
 });
 

--- a/scripts/mirror-vgi-bench-media.test.ts
+++ b/scripts/mirror-vgi-bench-media.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+
+import { VGI_BENCH_DEFAULT_REVISION } from "../src/benchmarks/vgi-bench/benchmark";
+import type { ManifestEntry } from "./mirror-vgi-bench-media";
+import {
+  extensionOf,
+  hashManifest,
+  readOptions,
+} from "./mirror-vgi-bench-media";
+
+function makeEntry(overrides?: Partial<ManifestEntry>): ManifestEntry {
+  return {
+    videoId: "abc",
+    sourceUrl: "https://example.test/abc_proxy_v2.mp4",
+    sourceKind: "downscaled",
+    key: "abc.mp4",
+    url: "https://media.example.test/abc.mp4",
+    bytes: 10,
+    contentType: "video/mp4",
+    sha256: "a".repeat(64),
+    ...overrides,
+  };
+}
+
+describe("extensionOf", () => {
+  test("returns the lowercased extension", () => {
+    expect(extensionOf("https://example.test/dir/clip.MP4?x=1")).toBe("mp4");
+  });
+
+  test("defaults to mp4 when the path has no extension", () => {
+    expect(extensionOf("https://example.test/dir/clip")).toBe("mp4");
+  });
+
+  test("ignores dots in directory segments", () => {
+    expect(extensionOf("https://example.test/v1.0/videos/clip")).toBe("mp4");
+    expect(extensionOf("https://example.test/v1.0/videos/clip.webm")).toBe(
+      "webm"
+    );
+  });
+});
+
+describe("readOptions", () => {
+  test("applies defaults", () => {
+    const options = readOptions([]);
+    expect(options.concurrency).toBe(8);
+    expect(options.revision).toBe(VGI_BENCH_DEFAULT_REVISION);
+    expect(options.limit).toBeUndefined();
+    expect(options.force).toBe(false);
+    expect(options.dryRun).toBe(false);
+  });
+
+  test("parses provided flags", () => {
+    const options = readOptions([
+      "--concurrency=3",
+      "--limit=5",
+      "--out=manifest.json",
+      "--revision=main",
+      "--force",
+      "--dry-run",
+    ]);
+    expect(options).toEqual({
+      concurrency: 3,
+      limit: 5,
+      out: "manifest.json",
+      revision: "main",
+      force: true,
+      dryRun: true,
+    });
+  });
+
+  test("rejects invalid numeric flags", () => {
+    expect(() => readOptions(["--concurrency=0"])).toThrow();
+    expect(() => readOptions(["--limit=abc"])).toThrow();
+  });
+});
+
+describe("hashManifest", () => {
+  test("is stable for identical entries and changes with content", () => {
+    const first = hashManifest([makeEntry()]);
+    expect(hashManifest([makeEntry()])).toBe(first);
+    expect(hashManifest([makeEntry({ sha256: "b".repeat(64) })])).not.toBe(
+      first
+    );
+    expect(
+      hashManifest([makeEntry({ url: "https://media.example.test/other.mp4" })])
+    ).not.toBe(first);
+  });
+});

--- a/scripts/mirror-vgi-bench-media.ts
+++ b/scripts/mirror-vgi-bench-media.ts
@@ -1,0 +1,369 @@
+import { createHash } from "node:crypto";
+
+import { S3Client } from "bun";
+
+import {
+  VGI_BENCH_CONFIG,
+  VGI_BENCH_DATASET_PATH,
+  VGI_BENCH_DEFAULT_REVISION,
+  VGI_BENCH_SPLIT,
+  downscaledVideoUrl,
+} from "../src/benchmarks/vgi-bench/benchmark";
+import { z } from "../src/internal/zod";
+
+const HF_ROWS_BASE_URL = "https://datasets-server.huggingface.co/rows";
+const HF_PAGE_SIZE = 100;
+
+const HfRowsPageSchema = z.object({
+  rows: z.array(
+    z.object({
+      row: z.object({
+        video_id: z.string(),
+        video_url: z.string(),
+        question_id: z.number().int(),
+      }),
+    })
+  ),
+  num_rows_total: z.number().int(),
+});
+
+const CONTENT_TYPES: Record<string, string> = {
+  mp4: "video/mp4",
+  webm: "video/webm",
+  mov: "video/quicktime",
+  mkv: "video/x-matroska",
+};
+
+interface MirrorEnv {
+  readonly endpoint: string;
+  readonly bucket: string;
+  readonly accessKeyId: string;
+  readonly secretAccessKey: string;
+  readonly publicBaseUrl: string;
+  readonly keyPrefix: string;
+  readonly hfToken: string | undefined;
+}
+
+interface MirrorOptions {
+  readonly concurrency: number;
+  readonly out: string;
+  readonly force: boolean;
+  readonly dryRun: boolean;
+  readonly revision: string;
+  readonly limit: number | undefined;
+}
+
+interface SourceVideo {
+  readonly videoId: string;
+  readonly originalUrl: string;
+  readonly questionIds: readonly number[];
+}
+
+interface ManifestEntry {
+  readonly videoId: string;
+  readonly sourceUrl: string;
+  readonly sourceKind: "downscaled" | "original";
+  readonly key: string;
+  readonly url: string;
+  readonly bytes: number;
+  readonly contentType: string;
+  readonly sha256: string;
+}
+
+interface Manifest {
+  readonly dataset: string;
+  readonly config: string;
+  readonly split: string;
+  readonly revision: string;
+  readonly publicBaseUrl: string;
+  readonly generatedAt: string;
+  readonly videoCount: number;
+  readonly questionCount: number;
+  readonly manifestHash: string;
+  readonly videos: readonly ManifestEntry[];
+  readonly unresolved: readonly {
+    videoId: string;
+    attempted: readonly string[];
+  }[];
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value.trim();
+}
+
+function readEnv(): MirrorEnv {
+  const publicBaseUrl = requireEnv("BENCH_MEDIA_PUBLIC_BASE_URL").replace(
+    /\/+$/,
+    ""
+  );
+  const rawPrefix = process.env["BENCH_MEDIA_KEY_PREFIX"] ?? "";
+  const keyPrefix =
+    rawPrefix === "" ? "" : `${rawPrefix.replaceAll(/^\/+|\/+$/g, "")}/`;
+  return {
+    endpoint: requireEnv("BENCH_MEDIA_S3_ENDPOINT"),
+    bucket: requireEnv("BENCH_MEDIA_S3_BUCKET"),
+    accessKeyId: requireEnv("BENCH_MEDIA_S3_ACCESS_KEY_ID"),
+    secretAccessKey: requireEnv("BENCH_MEDIA_S3_SECRET_ACCESS_KEY"),
+    publicBaseUrl,
+    keyPrefix,
+    hfToken: process.env["HF_TOKEN"],
+  };
+}
+
+export function readOptions(argv: readonly string[]): MirrorOptions {
+  const flag = (name: string): string | undefined => {
+    const prefixed = `--${name}=`;
+    const match = argv.find((arg) => arg.startsWith(prefixed));
+    return match === undefined ? undefined : match.slice(prefixed.length);
+  };
+  const concurrency = Number(flag("concurrency") ?? "8");
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error("--concurrency must be a positive integer");
+  }
+  const rawLimit = flag("limit");
+  const limit = rawLimit === undefined ? undefined : Number(rawLimit);
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
+    throw new Error("--limit must be a positive integer");
+  }
+  return {
+    concurrency,
+    out: flag("out") ?? "vgi-bench-media-manifest.json",
+    force: argv.includes("--force"),
+    dryRun: argv.includes("--dry-run"),
+    revision: flag("revision") ?? VGI_BENCH_DEFAULT_REVISION,
+    limit,
+  };
+}
+
+export type { ManifestEntry };
+
+export function extensionOf(url: string): string {
+  const pathname = new URL(url).pathname;
+  const filename = pathname.slice(pathname.lastIndexOf("/") + 1);
+  const dot = filename.lastIndexOf(".");
+  if (dot === -1) {
+    return "mp4";
+  }
+  return filename.slice(dot + 1).toLowerCase();
+}
+
+async function fetchSourceVideos(
+  revision: string,
+  hfToken: string | undefined
+): Promise<readonly SourceVideo[]> {
+  const byVideoId = new Map<
+    string,
+    { originalUrl: string; questionIds: number[] }
+  >();
+  const headers: Record<string, string> =
+    hfToken === undefined ? {} : { authorization: `Bearer ${hfToken}` };
+  let offset = 0;
+  let total = Number.POSITIVE_INFINITY;
+  while (offset < total) {
+    const url = new URL(HF_ROWS_BASE_URL);
+    url.searchParams.set("dataset", VGI_BENCH_DATASET_PATH);
+    url.searchParams.set("config", VGI_BENCH_CONFIG);
+    url.searchParams.set("split", VGI_BENCH_SPLIT);
+    url.searchParams.set("revision", revision);
+    url.searchParams.set("offset", String(offset));
+    url.searchParams.set("length", String(HF_PAGE_SIZE));
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new Error(
+        `Hugging Face rows request failed with ${response.status}`
+      );
+    }
+    const payload = HfRowsPageSchema.parse(await response.json());
+    total = payload.num_rows_total;
+    for (const { row } of payload.rows) {
+      const existing = byVideoId.get(row.video_id);
+      if (existing === undefined) {
+        byVideoId.set(row.video_id, {
+          originalUrl: row.video_url,
+          questionIds: [row.question_id],
+        });
+      } else {
+        existing.questionIds.push(row.question_id);
+      }
+    }
+    offset += payload.rows.length;
+    if (payload.rows.length === 0) {
+      break;
+    }
+  }
+  return [...byVideoId.entries()]
+    .map(([videoId, value]) => ({
+      videoId,
+      originalUrl: value.originalUrl,
+      questionIds: [...value.questionIds].sort((a, b) => a - b),
+    }))
+    .sort((a, b) => a.videoId.localeCompare(b.videoId));
+}
+
+async function resolveSourceUrl(
+  video: SourceVideo
+): Promise<{ url: string; kind: "downscaled" | "original" } | undefined> {
+  const candidates: { url: string; kind: "downscaled" | "original" }[] = [
+    { url: downscaledVideoUrl(video.originalUrl), kind: "downscaled" },
+    { url: video.originalUrl, kind: "original" },
+  ];
+  for (const candidate of candidates) {
+    const response = await fetch(candidate.url, { method: "HEAD" });
+    await response.body?.cancel();
+    if (response.ok) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+async function mirrorVideo(
+  video: SourceVideo,
+  env: MirrorEnv,
+  options: MirrorOptions,
+  s3: S3Client
+): Promise<ManifestEntry | undefined> {
+  const source = await resolveSourceUrl(video);
+  if (source === undefined) {
+    return undefined;
+  }
+  const extension = extensionOf(source.url);
+  const contentType = CONTENT_TYPES[extension] ?? "application/octet-stream";
+  const key = `${env.keyPrefix}${video.videoId}.${extension}`;
+  const download = await fetch(source.url);
+  if (!download.ok) {
+    await download.body?.cancel();
+    throw new Error(`Download of ${source.url} failed with ${download.status}`);
+  }
+  const bytes = new Uint8Array(await download.arrayBuffer());
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const entry: ManifestEntry = {
+    videoId: video.videoId,
+    sourceUrl: source.url,
+    sourceKind: source.kind,
+    key,
+    url: `${env.publicBaseUrl}/${key}`,
+    bytes: bytes.byteLength,
+    contentType,
+    sha256,
+  };
+  if (options.dryRun) {
+    return entry;
+  }
+  const target = s3.file(key);
+  if (!options.force) {
+    const existing = await target.stat().catch(() => undefined);
+    if (existing !== undefined && existing.size === bytes.byteLength) {
+      return entry;
+    }
+  }
+  await target.write(bytes, { type: contentType });
+  return entry;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<readonly R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+  const runners = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (true) {
+        const index = cursor;
+        cursor += 1;
+        if (index >= items.length) {
+          return;
+        }
+        results[index] = await worker(items[index]!, index);
+      }
+    }
+  );
+  await Promise.all(runners);
+  return results;
+}
+
+export function hashManifest(entries: readonly ManifestEntry[]): string {
+  const hasher = createHash("sha256");
+  for (const entry of entries) {
+    hasher.update(`${entry.videoId}\u0000${entry.url}\u0000${entry.sha256}\n`);
+  }
+  return hasher.digest("hex");
+}
+
+async function main(): Promise<void> {
+  const env = readEnv();
+  const options = readOptions(process.argv.slice(2));
+  const s3 = new S3Client({
+    accessKeyId: env.accessKeyId,
+    secretAccessKey: env.secretAccessKey,
+    bucket: env.bucket,
+    endpoint: env.endpoint,
+  });
+  const allVideos = await fetchSourceVideos(options.revision, env.hfToken);
+  const videos =
+    options.limit === undefined ? allVideos : allVideos.slice(0, options.limit);
+  process.stderr.write(
+    `Resolved ${allVideos.length} distinct videos, mirroring ${videos.length}\n`
+  );
+  let done = 0;
+  const outcomes = await mapWithConcurrency(
+    videos,
+    options.concurrency,
+    async (video) => {
+      const entry = await mirrorVideo(video, env, options, s3);
+      done += 1;
+      process.stderr.write(
+        `[${done}/${videos.length}] ${video.videoId} ${entry === undefined ? "UNRESOLVED" : entry.sourceKind}\n`
+      );
+      return { video, entry };
+    }
+  );
+  const entries = outcomes
+    .map((outcome) => outcome.entry)
+    .filter((entry): entry is ManifestEntry => entry !== undefined);
+  const unresolved = outcomes
+    .filter((outcome) => outcome.entry === undefined)
+    .map((outcome) => ({
+      videoId: outcome.video.videoId,
+      attempted: [
+        downscaledVideoUrl(outcome.video.originalUrl),
+        outcome.video.originalUrl,
+      ],
+    }));
+  const manifest: Manifest = {
+    dataset: VGI_BENCH_DATASET_PATH,
+    config: VGI_BENCH_CONFIG,
+    split: VGI_BENCH_SPLIT,
+    revision: options.revision,
+    publicBaseUrl: env.publicBaseUrl,
+    generatedAt: new Date().toISOString(),
+    videoCount: entries.length,
+    questionCount: videos.reduce(
+      (sum, video) => sum + video.questionIds.length,
+      0
+    ),
+    manifestHash: hashManifest(entries),
+    videos: entries,
+    unresolved,
+  };
+  await Bun.write(options.out, `${JSON.stringify(manifest, null, 2)}\n`);
+  const totalBytes = entries.reduce((sum, entry) => sum + entry.bytes, 0);
+  process.stderr.write(
+    `Wrote ${options.out}: ${entries.length} mirrored, ${unresolved.length} unresolved, ${(totalBytes / 1e9).toFixed(2)} GB, hash ${manifest.manifestHash.slice(0, 12)}\n`
+  );
+  if (unresolved.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/mirror-vgi-bench-media.ts
+++ b/scripts/mirror-vgi-bench-media.ts
@@ -53,6 +53,11 @@ interface MirrorOptions {
   readonly limit: number | undefined;
 }
 
+interface SourceCandidate {
+  readonly url: string;
+  readonly kind: "downscaled" | "original";
+}
+
 interface SourceVideo {
   readonly videoId: string;
   readonly originalUrl: string;
@@ -212,13 +217,22 @@ async function fetchSourceVideos(
     .sort((a, b) => a.videoId.localeCompare(b.videoId));
 }
 
+export function candidateSources(
+  originalUrl: string
+): readonly SourceCandidate[] {
+  try {
+    return [
+      { url: downscaledVideoUrl(originalUrl), kind: "downscaled" },
+      { url: originalUrl, kind: "original" },
+    ];
+  } catch {
+    return [{ url: originalUrl, kind: "original" }];
+  }
+}
+
 async function resolveSourceUrl(
-  video: SourceVideo
-): Promise<{ url: string; kind: "downscaled" | "original" } | undefined> {
-  const candidates: { url: string; kind: "downscaled" | "original" }[] = [
-    { url: downscaledVideoUrl(video.originalUrl), kind: "downscaled" },
-    { url: video.originalUrl, kind: "original" },
-  ];
+  candidates: readonly SourceCandidate[]
+): Promise<SourceCandidate | undefined> {
   for (const candidate of candidates) {
     const response = await fetch(candidate.url, { method: "HEAD" });
     await response.body?.cancel();
@@ -235,11 +249,12 @@ export function describeFailure(cause: unknown): string {
 
 async function mirrorVideo(
   video: SourceVideo,
+  candidates: readonly SourceCandidate[],
   env: MirrorEnv,
   options: MirrorOptions,
   s3: S3Client
 ): Promise<MirrorOutcome> {
-  const source = await resolveSourceUrl(video);
+  const source = await resolveSourceUrl(candidates);
   if (source === undefined) {
     return {
       kind: "unresolved",
@@ -332,12 +347,17 @@ async function main(): Promise<void> {
     videos,
     options.concurrency,
     async (video) => {
-      const outcome = await mirrorVideo(video, env, options, s3).catch(
-        (cause: unknown): MirrorOutcome => ({
-          kind: "unresolved",
-          reason: describeFailure(cause),
-        })
-      );
+      const candidates = candidateSources(video.originalUrl);
+      const outcome = await mirrorVideo(
+        video,
+        candidates,
+        env,
+        options,
+        s3
+      ).catch((cause: unknown): MirrorOutcome => ({
+        kind: "unresolved",
+        reason: describeFailure(cause),
+      }));
       done += 1;
       process.stderr.write(
         `[${done}/${videos.length}] ${video.videoId} ${
@@ -346,22 +366,19 @@ async function main(): Promise<void> {
             : `UNRESOLVED ${outcome.reason}`
         }\n`
       );
-      return { video, outcome };
+      return { video, candidates, outcome };
     }
   );
   const entries = outcomes.flatMap(({ outcome }) =>
     outcome.kind === "mirrored" ? [outcome.entry] : []
   );
-  const unresolved = outcomes.flatMap(({ video, outcome }) =>
+  const unresolved = outcomes.flatMap(({ video, candidates, outcome }) =>
     outcome.kind === "mirrored"
       ? []
       : [
           {
             videoId: video.videoId,
-            attempted: [
-              downscaledVideoUrl(video.originalUrl),
-              video.originalUrl,
-            ],
+            attempted: candidates.map((candidate) => candidate.url),
             reason: outcome.reason,
           },
         ]
@@ -374,8 +391,9 @@ async function main(): Promise<void> {
     publicBaseUrl: env.publicBaseUrl,
     generatedAt: new Date().toISOString(),
     videoCount: entries.length,
-    questionCount: videos.reduce(
-      (sum, video) => sum + video.questionIds.length,
+    questionCount: outcomes.reduce(
+      (sum, { video, outcome }) =>
+        outcome.kind === "mirrored" ? sum + video.questionIds.length : sum,
       0
     ),
     manifestHash: hashManifest(entries),

--- a/scripts/mirror-vgi-bench-media.ts
+++ b/scripts/mirror-vgi-bench-media.ts
@@ -383,6 +383,9 @@ async function main(): Promise<void> {
           },
         ]
   );
+  const mirroredQuestionIds = outcomes.flatMap(({ video, outcome }) =>
+    outcome.kind === "mirrored" ? video.questionIds : []
+  );
   const manifest: Manifest = {
     dataset: VGI_BENCH_DATASET_PATH,
     config: VGI_BENCH_CONFIG,
@@ -391,11 +394,7 @@ async function main(): Promise<void> {
     publicBaseUrl: env.publicBaseUrl,
     generatedAt: new Date().toISOString(),
     videoCount: entries.length,
-    questionCount: outcomes.reduce(
-      (sum, { video, outcome }) =>
-        outcome.kind === "mirrored" ? sum + video.questionIds.length : sum,
-      0
-    ),
+    questionCount: mirroredQuestionIds.length,
     manifestHash: hashManifest(entries),
     videos: entries,
     unresolved,

--- a/scripts/mirror-vgi-bench-media.ts
+++ b/scripts/mirror-vgi-bench-media.ts
@@ -112,18 +112,20 @@ function readEnv(): MirrorEnv {
     /\/+$/,
     ""
   );
-  const rawPrefix = process.env["BENCH_MEDIA_KEY_PREFIX"] ?? "";
-  const keyPrefix =
-    rawPrefix === "" ? "" : `${rawPrefix.replaceAll(/^\/+|\/+$/g, "")}/`;
   return {
     endpoint: requireEnv("BENCH_MEDIA_S3_ENDPOINT"),
     bucket: requireEnv("BENCH_MEDIA_S3_BUCKET"),
     accessKeyId: requireEnv("BENCH_MEDIA_S3_ACCESS_KEY_ID"),
     secretAccessKey: requireEnv("BENCH_MEDIA_S3_SECRET_ACCESS_KEY"),
     publicBaseUrl,
-    keyPrefix,
+    keyPrefix: normalizeKeyPrefix(process.env["BENCH_MEDIA_KEY_PREFIX"]),
     hfToken: process.env["HF_TOKEN"],
   };
+}
+
+export function normalizeKeyPrefix(rawPrefix: string | undefined): string {
+  const stripped = (rawPrefix ?? "").trim().replaceAll(/^\/+|\/+$/g, "");
+  return stripped === "" ? "" : `${stripped}/`;
 }
 
 export function readOptions(argv: readonly string[]): MirrorOptions {
@@ -234,9 +236,11 @@ async function resolveSourceUrl(
   candidates: readonly SourceCandidate[]
 ): Promise<SourceCandidate | undefined> {
   for (const candidate of candidates) {
-    const response = await fetch(candidate.url, { method: "HEAD" });
-    await response.body?.cancel();
-    if (response.ok) {
+    const response = await fetch(candidate.url, { method: "HEAD" }).catch(
+      () => undefined
+    );
+    await response?.body?.cancel();
+    if (response?.ok === true) {
       return candidate;
     }
   }

--- a/scripts/mirror-vgi-bench-media.ts
+++ b/scripts/mirror-vgi-bench-media.ts
@@ -81,11 +81,18 @@ interface Manifest {
   readonly questionCount: number;
   readonly manifestHash: string;
   readonly videos: readonly ManifestEntry[];
-  readonly unresolved: readonly {
-    videoId: string;
-    attempted: readonly string[];
-  }[];
+  readonly unresolved: readonly UnresolvedEntry[];
 }
+
+interface UnresolvedEntry {
+  readonly videoId: string;
+  readonly attempted: readonly string[];
+  readonly reason: string;
+}
+
+type MirrorOutcome =
+  | { readonly kind: "mirrored"; readonly entry: ManifestEntry }
+  | { readonly kind: "unresolved"; readonly reason: string };
 
 function requireEnv(name: string): string {
   const value = process.env[name];
@@ -222,15 +229,22 @@ async function resolveSourceUrl(
   return undefined;
 }
 
+export function describeFailure(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
 async function mirrorVideo(
   video: SourceVideo,
   env: MirrorEnv,
   options: MirrorOptions,
   s3: S3Client
-): Promise<ManifestEntry | undefined> {
+): Promise<MirrorOutcome> {
   const source = await resolveSourceUrl(video);
   if (source === undefined) {
-    return undefined;
+    return {
+      kind: "unresolved",
+      reason: "no candidate URL responded with 2xx",
+    };
   }
   const extension = extensionOf(source.url);
   const contentType = CONTENT_TYPES[extension] ?? "application/octet-stream";
@@ -253,17 +267,17 @@ async function mirrorVideo(
     sha256,
   };
   if (options.dryRun) {
-    return entry;
+    return { kind: "mirrored", entry };
   }
   const target = s3.file(key);
   if (!options.force) {
     const existing = await target.stat().catch(() => undefined);
     if (existing !== undefined && existing.size === bytes.byteLength) {
-      return entry;
+      return { kind: "mirrored", entry };
     }
   }
   await target.write(bytes, { type: contentType });
-  return entry;
+  return { kind: "mirrored", entry };
 }
 
 async function mapWithConcurrency<T, R>(
@@ -318,26 +332,40 @@ async function main(): Promise<void> {
     videos,
     options.concurrency,
     async (video) => {
-      const entry = await mirrorVideo(video, env, options, s3);
+      const outcome = await mirrorVideo(video, env, options, s3).catch(
+        (cause: unknown): MirrorOutcome => ({
+          kind: "unresolved",
+          reason: describeFailure(cause),
+        })
+      );
       done += 1;
       process.stderr.write(
-        `[${done}/${videos.length}] ${video.videoId} ${entry === undefined ? "UNRESOLVED" : entry.sourceKind}\n`
+        `[${done}/${videos.length}] ${video.videoId} ${
+          outcome.kind === "mirrored"
+            ? outcome.entry.sourceKind
+            : `UNRESOLVED ${outcome.reason}`
+        }\n`
       );
-      return { video, entry };
+      return { video, outcome };
     }
   );
-  const entries = outcomes
-    .map((outcome) => outcome.entry)
-    .filter((entry): entry is ManifestEntry => entry !== undefined);
-  const unresolved = outcomes
-    .filter((outcome) => outcome.entry === undefined)
-    .map((outcome) => ({
-      videoId: outcome.video.videoId,
-      attempted: [
-        downscaledVideoUrl(outcome.video.originalUrl),
-        outcome.video.originalUrl,
-      ],
-    }));
+  const entries = outcomes.flatMap(({ outcome }) =>
+    outcome.kind === "mirrored" ? [outcome.entry] : []
+  );
+  const unresolved = outcomes.flatMap(({ video, outcome }) =>
+    outcome.kind === "mirrored"
+      ? []
+      : [
+          {
+            videoId: video.videoId,
+            attempted: [
+              downscaledVideoUrl(video.originalUrl),
+              video.originalUrl,
+            ],
+            reason: outcome.reason,
+          },
+        ]
+  );
   const manifest: Manifest = {
     dataset: VGI_BENCH_DATASET_PATH,
     config: VGI_BENCH_CONFIG,

--- a/src/benchmarks/vgi-bench/benchmark.ts
+++ b/src/benchmarks/vgi-bench/benchmark.ts
@@ -21,10 +21,10 @@ import { defineChatBenchmark } from "../define-chat-benchmark";
 import { mcqScorer } from "../scorers/mcq/scorer";
 import type { Benchmark } from "../types";
 
-const VGI_BENCH_DATASET_PATH = "Seldon-Technologies/VGIBench";
+export const VGI_BENCH_DATASET_PATH = "Seldon-Technologies/VGIBench";
 
-const VGI_BENCH_CONFIG = "default";
-const VGI_BENCH_SPLIT = "train";
+export const VGI_BENCH_CONFIG = "default";
+export const VGI_BENCH_SPLIT = "train";
 
 export const VGI_BENCH_DEFAULT_REVISION = "v1.0.1";
 

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": [
+      "bun",
+      "node"
+    ]
+  },
+  "include": [
+    "scripts/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}


### PR DESCRIPTION
## TL;DR

Adds a configurable script that mirrors the pinned VGI-Bench split into caller-owned S3-compatible object storage, resolving one source URL per video before any model runs and writing a hashed manifest.

## What changed?

- `scripts/mirror-vgi-bench-media.ts` reads the pinned VGI-Bench rows from the Hugging Face rows API (Zod-validated), dedupes to one entry per `video_id`, resolves each video to its `_proxy_v2` downscaled URL when that URL is live and to the original otherwise, uploads the bytes to caller-configured storage via Bun's built-in `S3Client`, and writes a manifest with per-video `sourceKind`, `sha256`, bytes, content type, final URL, plus a `manifestHash` over the resolved set.
- `scripts/mirror-vgi-bench-media.test.ts` covers the pure helpers: extension extraction, CLI option parsing, and manifest hashing.
- The vgi-bench dataset path, config, and split constants are exported so the script does not restate dataset identity.
- `format`/`format:check`/`fix` also cover `scripts`, and `mirror-vgi-bench-media` is exposed as a package script.

Everything deployment-specific comes from the environment, so no bucket, domain, account, or prefix is hardcoded:

```text
BENCH_MEDIA_S3_ENDPOINT
BENCH_MEDIA_S3_BUCKET
BENCH_MEDIA_S3_ACCESS_KEY_ID
BENCH_MEDIA_S3_SECRET_ACCESS_KEY
BENCH_MEDIA_PUBLIC_BASE_URL
BENCH_MEDIA_KEY_PREFIX   # optional
HF_TOKEN                 # optional
```

## Why?

116 of the 315 distinct `_proxy_v2` URLs in VGI-Bench `v1.0.1` return 404 on the dataset publisher's CDN, which makes 137 of the 439 questions unanswerable. Every model in a sweep fails those questions, and because providers report a media fetch failure as an HTTP 400, the harness scores them as wrong answers rather than skips.

Falling back per request would let the fallback fire for some models and not others, so two lanes would be graded on different inputs. Resolving each video once, ahead of the run, and serving every lane from one mirrored URL set removes that divergence. `manifestHash` makes "did all lanes see the same inputs" checkable rather than assumed.

Nothing consumes the manifest yet. Wiring it into dataset URL resolution is a separate change.

## How to test

```bash
BENCH_MEDIA_S3_ENDPOINT=https://example.invalid \
BENCH_MEDIA_S3_BUCKET=example \
BENCH_MEDIA_S3_ACCESS_KEY_ID=example \
BENCH_MEDIA_S3_SECRET_ACCESS_KEY=example \
BENCH_MEDIA_PUBLIC_BASE_URL=https://media.example.invalid \
bun scripts/mirror-vgi-bench-media.ts --dry-run --limit=4 --out=/tmp/manifest.json
```

Expected: four entries in `/tmp/manifest.json`, each with a `sourceKind` of `downscaled` or `original`, a `sha256`, and a URL under the configured public base. No upload occurs under `--dry-run`.

Static checks and unit tests:

```bash
bun run format:check && bun run check && bun run typecheck && bun test && bun run build
```

## Benchmark impact

None yet. No dataset, solver, or scorer behavior changes, and no run reads the manifest. The only non-script change is widening the visibility of three existing constants.

## Reviewer focus

- The script lives in `scripts/` rather than `src/` because it uses Bun-only APIs (`S3Client`, `Bun.write`) and the build project declares only Node types, so including it in `src` breaks `bun run build`. It is covered by oxlint, oxfmt, `bun test`, and the type checker through the new `tsconfig.scripts.json` project that `bun run typecheck` also runs.
- Per-video failures are recorded as `unresolved` entries with a reason rather than aborting the run, so a partial mirror still writes a manifest while exiting nonzero.
- Source resolution order and the fact that resolution happens once per video rather than per request.
- Whether the manifest carries everything a future consumer needs to pin inputs.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [ ] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/6858335142a64558bf56f746a7982b17
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->