### PR TITLE
test(terminal-bench): drop the wall-clock duration assertion from the ori zeroed-usage test

### DIFF
--- a/src/benchmarks/terminal-bench/ori-solver.test.ts
+++ b/src/benchmarks/terminal-bench/ori-solver.test.ts
@@ -351,7 +351,6 @@ describe("terminal-bench ori solver", () => {
     }
     expect(usage.inputTokens).toBe(0);
     expect(usage.totalCost).toBe(0);
-    expect(finalState.output?.generationTimeMs).toBeGreaterThanOrEqual(0);
     expect(finalState.completed).toBe(true);
   });
 

--- a/src/benchmarks/terminal-bench/ori-solver.test.ts
+++ b/src/benchmarks/terminal-bench/ori-solver.test.ts
@@ -351,7 +351,7 @@ describe("terminal-bench ori solver", () => {
     }
     expect(usage.inputTokens).toBe(0);
     expect(usage.totalCost).toBe(0);
-    expect(finalState.output?.generationTimeMs).toBe(0);
+    expect(finalState.output?.generationTimeMs).toBeGreaterThanOrEqual(0);
     expect(finalState.completed).toBe(true);
   });
 


### PR DESCRIPTION
## TL;DR

Removes a flaky, redundant duration assertion that made the terminal-bench ori solver zeroed-usage test fail intermittently in CI.

## What changed?

- Deleted `expect(finalState.output?.generationTimeMs).toBe(0)` from `falls back to zeroed usage when the stream carries no result event` in `src/benchmarks/terminal-bench/ori-solver.test.ts`. The remaining assertions in that test are unchanged, so it still pins `inputTokens`, `totalCost`, and completion.

## Why?

The test feeds `"not json at all\n{broken"` as the agent stream. That stream has no `result` event, so `parseClaudeStream` leaves `generationTimeMs` undefined and `runAgentCli` substitutes the elapsed wall-clock time it measured. The fake sandbox normally finishes inside the same millisecond, so the value is 0, but when the run crosses a millisecond boundary it is 1 and the assertion fails with `Expected: 0 / Received: 1`. That is what took out the `unit` job on the openrouter-web vendored copy.

The assertion was also backwards. `oriSolver` coerces a missing duration with `run.generationTimeMs ?? 0`, so deleting the elapsed-time fallback entirely would leave the duration undefined, make it 0, and satisfy `toBe(0)`. The assertion passed on the broken behavior and failed on the correct one.

Relaxing it to `toBeGreaterThanOrEqual(0)` would have been a tautology, since the value is a nonnegative elapsed-time measurement by construction. Duration behavior is already covered twice in the same file, once pinning the parsed duration exactly (`populates generationTimeMs from the reported duration`) and once covering the wall-clock path (`reports a wall-clock generation time since pi emits no duration`), so the assertion added no coverage here.

## How to test

```bash
bun test src/benchmarks/terminal-bench/
```

To see the original flake, restore the `toBe(0)` assertion and run the single test in a loop:

```bash
for i in $(seq 1 8); do
  bun test src/benchmarks/terminal-bench/ori-solver.test.ts \
    -t "falls back to zeroed usage when the stream carries no result event"
done
```

On `main` that failed 4 of 8 runs with `Expected: 0 / Received: 1`.

## Reviewer focus

- Whether dropping the assertion is preferable to keeping a weaker one. The alternative considered was measuring wall clock in the test around the solver call and asserting the reported duration does not exceed it, which would catch a garbage or unit-confused value. That was skipped as unnecessary given the two existing duration tests.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/0c51fd84a1b2412c822487a978e59704
Requested by: @sambarnes
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->