### PR TITLE
feat: support provider ignore lists in benchmarks

### DIFF
--- a/src/benchmarks/benchmark-config.ts
+++ b/src/benchmarks/benchmark-config.ts
@@ -47,6 +47,7 @@ export const InferenceOverrideSchema = z.object({
   timeoutMs: z.number().optional(),
   sort: z.nativeEnum(ProviderSort).optional(),
   providerOnly: z.array(z.string()).optional(),
+  providerIgnore: z.array(z.string()).optional(),
   allowFallbacks: z.boolean().optional(),
   cloudflareVersion: z.string().optional(),
   costQualityTradeoff: z.number().int().min(0).max(10).optional(),

--- a/src/benchmarks/deep-swe/benchmark.ts
+++ b/src/benchmarks/deep-swe/benchmark.ts
@@ -104,6 +104,7 @@ function makeDeepSweLayer(
             timeoutMs: benchmarkConfig.timeoutMs,
             sort: benchmarkConfig.sort,
             providerOnly: benchmarkConfig.providerOnly,
+            providerIgnore: benchmarkConfig.providerIgnore,
             allowFallbacks: benchmarkConfig.allowFallbacks,
             cloudflareVersion: benchmarkConfig.cloudflareVersion,
             costTier: benchmarkConfig.costTier,

--- a/src/benchmarks/gpqa.ts
+++ b/src/benchmarks/gpqa.ts
@@ -136,6 +136,7 @@ export const GPQA_BENCHMARK: Benchmark = defineChatBenchmark({
         timeoutMs: config.timeoutMs,
         sort: config.sort,
         providerOnly: config.providerOnly,
+        providerIgnore: config.providerIgnore,
         allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,

--- a/src/benchmarks/ifstruct/benchmark.ts
+++ b/src/benchmarks/ifstruct/benchmark.ts
@@ -161,6 +161,7 @@ export const IFSTRUCT_BENCHMARK: Benchmark = defineChatBenchmark({
         timeoutMs: config.timeoutMs,
         sort: config.sort,
         providerOnly: config.providerOnly,
+        providerIgnore: config.providerIgnore,
         allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,

--- a/src/benchmarks/mmlu-pro.ts
+++ b/src/benchmarks/mmlu-pro.ts
@@ -166,6 +166,7 @@ const MMLU_PRO_CHAT_BENCHMARK = defineChatBenchmark({
         timeoutMs: config.timeoutMs,
         sort: config.sort,
         providerOnly: config.providerOnly,
+        providerIgnore: config.providerIgnore,
         allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,

--- a/src/benchmarks/mmmu-pro-vision.ts
+++ b/src/benchmarks/mmmu-pro-vision.ts
@@ -168,6 +168,7 @@ export const MMMU_PRO_VISION_BENCHMARK: Benchmark = defineChatBenchmark({
         timeoutMs: config.timeoutMs,
         sort: config.sort,
         providerOnly: config.providerOnly,
+        providerIgnore: config.providerIgnore,
         allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,

--- a/src/benchmarks/search/core/benchmark.test.ts
+++ b/src/benchmarks/search/core/benchmark.test.ts
@@ -29,6 +29,7 @@ describe("searchSolverOptionsFromConfig", () => {
       sort: ProviderSort.Latency,
       providerOrder: ["openai", "azure"],
       providerOnly: ["openai", "azure"],
+      providerIgnore: ["bedrock"],
       allowFallbacks: false,
       cloudflareVersion: "worker-version",
     } as const;
@@ -55,6 +56,7 @@ describe("searchSolverOptionsFromConfig", () => {
       sort: "latency",
       providerOrder: ["openai", "azure"],
       providerOnly: ["openai", "azure"],
+      providerIgnore: ["bedrock"],
       allowFallbacks: false,
       versionOverride: "worker-version",
       retry: { maxRetries: 2, baseDelayMs: 3 },

--- a/src/benchmarks/search/core/benchmark.ts
+++ b/src/benchmarks/search/core/benchmark.ts
@@ -71,6 +71,9 @@ export function searchSolverOptionsFromConfig({
     ...(config.providerOnly !== undefined && {
       providerOnly: config.providerOnly,
     }),
+    ...(config.providerIgnore !== undefined && {
+      providerIgnore: config.providerIgnore,
+    }),
     ...(config.allowFallbacks !== undefined && {
       allowFallbacks: config.allowFallbacks,
     }),

--- a/src/benchmarks/search/core/request.test.ts
+++ b/src/benchmarks/search/core/request.test.ts
@@ -41,6 +41,7 @@ describe("buildSearchRequestBody", () => {
       },
     ]);
     expect(body.maxToolCalls).toBe(25);
+    expect(body.provider).toBeUndefined();
     expect(body.plugins).toBeUndefined();
     expect(body.tools).toEqual([
       {
@@ -201,19 +202,33 @@ describe("buildSearchRequestBody", () => {
       lane: lane({}),
       providerOrder: ["openai", "azure"],
       providerOnly: ["openai", "azure"],
+      providerIgnore: ["bedrock"],
       allowFallbacks: false,
     });
     expect(body.provider).toEqual({
       order: ["openai", "azure"],
       only: ["openai", "azure"],
+      ignore: ["bedrock"],
       allowFallbacks: false,
     });
     expect(JSON.parse(responsesRequestToJSON(body))).toMatchObject({
       provider: {
         order: ["openai", "azure"],
         only: ["openai", "azure"],
+        ignore: ["bedrock"],
         allow_fallbacks: false,
       },
+    });
+  });
+  it("sends the provider object for ignore-only routing", () => {
+    const body = buildSearchRequestBody({
+      ...BASE,
+      lane: lane({}),
+      providerIgnore: ["bedrock"],
+    });
+    expect(body.provider).toEqual({ ignore: ["bedrock"] });
+    expect(JSON.parse(responsesRequestToJSON(body))).toMatchObject({
+      provider: { ignore: ["bedrock"] },
     });
   });
   it("threads search-context and character caps into tool parameters", () => {

--- a/src/benchmarks/search/core/request.ts
+++ b/src/benchmarks/search/core/request.ts
@@ -31,6 +31,7 @@ export interface SearchRequestOptions {
   readonly sort?: ProviderSort;
   readonly providerOrder?: readonly string[];
   readonly providerOnly?: readonly string[];
+  readonly providerIgnore?: readonly string[];
   readonly allowFallbacks?: boolean;
   readonly costQualityTradeoff?: number;
   readonly costTier?: CostTier;
@@ -127,6 +128,7 @@ export function buildSearchRequestBody(
         opts.sort !== undefined ||
         opts.providerOrder !== undefined ||
         opts.providerOnly !== undefined ||
+        opts.providerIgnore !== undefined ||
         opts.allowFallbacks !== undefined
           ? (definedValues({
               sort: opts.sort,
@@ -138,6 +140,10 @@ export function buildSearchRequestBody(
                 opts.providerOnly === undefined
                   ? undefined
                   : [...opts.providerOnly],
+              ignore:
+                opts.providerIgnore === undefined
+                  ? undefined
+                  : [...opts.providerIgnore],
               allowFallbacks: opts.allowFallbacks,
             }) satisfies ProviderPreferences)
           : undefined,

--- a/src/benchmarks/search/core/solver.ts
+++ b/src/benchmarks/search/core/solver.ts
@@ -54,6 +54,7 @@ export interface SearchSolverOptions {
   readonly sort?: ProviderSort;
   readonly providerOrder?: readonly string[];
   readonly providerOnly?: readonly string[];
+  readonly providerIgnore?: readonly string[];
   readonly allowFallbacks?: boolean;
   readonly versionOverride?: string;
   readonly costQualityTradeoff?: number;
@@ -102,6 +103,9 @@ export function searchSolver(
         }),
         ...(opts.providerOnly !== undefined && {
           providerOnly: opts.providerOnly,
+        }),
+        ...(opts.providerIgnore !== undefined && {
+          providerIgnore: opts.providerIgnore,
         }),
         ...(opts.allowFallbacks !== undefined && {
           allowFallbacks: opts.allowFallbacks,

--- a/src/benchmarks/swe-atlas/benchmark.ts
+++ b/src/benchmarks/swe-atlas/benchmark.ts
@@ -113,6 +113,7 @@ function makeSweAtlasLayer(
             timeoutMs: benchmarkConfig.timeoutMs,
             sort: benchmarkConfig.sort,
             providerOnly: benchmarkConfig.providerOnly,
+            providerIgnore: benchmarkConfig.providerIgnore,
             allowFallbacks: benchmarkConfig.allowFallbacks,
             cloudflareVersion: benchmarkConfig.cloudflareVersion,
             costTier: benchmarkConfig.costTier,

--- a/src/benchmarks/tau-bench-airline/benchmark.ts
+++ b/src/benchmarks/tau-bench-airline/benchmark.ts
@@ -105,6 +105,7 @@ function makeAirlineLayer(
       timeoutMs: benchmarkConfig.timeoutMs,
       sort: benchmarkConfig.sort,
       providerOnly: benchmarkConfig.providerOnly,
+      providerIgnore: benchmarkConfig.providerIgnore,
       allowFallbacks: benchmarkConfig.allowFallbacks,
       cloudflareVersion: benchmarkConfig.cloudflareVersion,
       costTier: benchmarkConfig.costTier,

--- a/src/benchmarks/tau3-bench-banking/benchmark.ts
+++ b/src/benchmarks/tau3-bench-banking/benchmark.ts
@@ -59,6 +59,7 @@ function makeBankingLayer(
       timeoutMs: config.timeoutMs,
       sort: config.sort,
       providerOnly: config.providerOnly,
+      providerIgnore: config.providerIgnore,
       allowFallbacks: config.allowFallbacks,
       cloudflareVersion: config.cloudflareVersion,
       costTier: config.costTier,

--- a/src/benchmarks/vgi-bench/benchmark.ts
+++ b/src/benchmarks/vgi-bench/benchmark.ts
@@ -305,6 +305,7 @@ const VGI_BENCH_CHAT_BENCHMARK = defineChatBenchmark({
         timeoutMs: config.timeoutMs,
         sort: config.sort,
         providerOnly: config.providerOnly,
+        providerIgnore: config.providerIgnore,
         allowFallbacks: config.allowFallbacks,
         cloudflareVersion: config.cloudflareVersion,
         costTier: config.costTier,

--- a/src/benchmarks/wandr/benchmark.ts
+++ b/src/benchmarks/wandr/benchmark.ts
@@ -36,6 +36,7 @@ export function wandrInferenceOverride(config: WandrConfig): InferenceOverride {
     timeoutMs: config.timeoutMs,
     sort: config.sort,
     providerOnly: config.providerOnly,
+    providerIgnore: config.providerIgnore,
     allowFallbacks: config.allowFallbacks,
     cloudflareVersion: config.cloudflareVersion,
     costTier: config.costTier,

--- a/src/harness/model.ts
+++ b/src/harness/model.ts
@@ -25,6 +25,7 @@ export interface GenerateConfig {
   readonly timeoutMs?: number;
   readonly sort?: ProviderSort;
   readonly providerOnly?: readonly string[];
+  readonly providerIgnore?: readonly string[];
   readonly allowFallbacks?: boolean;
   readonly cloudflareVersion?: string;
   readonly costQualityTradeoff?: number;

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -126,6 +126,7 @@ describe("openrouter-model request parity", () => {
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
     expect(captured.value?.body["provider"]).toEqual({ sort: "price" });
+    expect(captured.value?.body["provider"]).not.toHaveProperty("ignore");
   });
   it("sends provider.only with fallbacks disabled on pinned runs", async () => {
     const captured = newHolder();
@@ -139,12 +140,14 @@ describe("openrouter-model request parity", () => {
         const model = yield* Model;
         yield* model.generate(MESSAGES, {
           providerOnly: ["google-vertex"],
+          providerIgnore: ["azure"],
           allowFallbacks: false,
         });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
     expect(captured.value?.body["provider"]).toEqual({
       only: ["google-vertex"],
+      ignore: ["azure"],
       allow_fallbacks: false,
     });
   });
@@ -161,6 +164,7 @@ describe("openrouter-model request parity", () => {
         yield* model.generate(MESSAGES, {
           sort: ProviderSort.Price,
           providerOnly: ["google-vertex"],
+          providerIgnore: ["azure"],
           allowFallbacks: false,
         });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
@@ -168,7 +172,27 @@ describe("openrouter-model request parity", () => {
     expect(captured.value?.body["provider"]).toEqual({
       sort: "price",
       only: ["google-vertex"],
+      ignore: ["azure"],
       allow_fallbacks: false,
+    });
+  });
+  it("sends provider.ignore without other provider preferences", async () => {
+    const captured = newHolder();
+    restore = installFetchCapture(captured);
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+    });
+    await runPromiseExit(
+      gen(function* run() {
+        const model = yield* Model;
+        yield* model.generate(MESSAGES, {
+          providerIgnore: ["azure"],
+        });
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    expect(captured.value?.body["provider"]).toEqual({
+      ignore: ["azure"],
     });
   });
   it("records the chat completion generation id", async () => {

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -147,6 +147,9 @@ export function generate(
     ...(genConfig.providerOnly !== undefined && {
       only: [...genConfig.providerOnly],
     }),
+    ...(genConfig.providerIgnore !== undefined && {
+      ignore: [...genConfig.providerIgnore],
+    }),
     ...(genConfig.allowFallbacks !== undefined && {
       allow_fallbacks: genConfig.allowFallbacks,
     }),

--- a/src/providers/responses-model.test.ts
+++ b/src/providers/responses-model.test.ts
@@ -374,6 +374,7 @@ describe("responses-model", () => {
         const model = yield* ResponsesModel;
         return yield* model.generate([], {
           providerOnly: ["google-vertex"],
+          providerIgnore: ["azure"],
           allowFallbacks: false,
         });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
@@ -381,6 +382,7 @@ describe("responses-model", () => {
     assertSuccess(exit);
     expect(captured.value?.body["provider"]).toEqual({
       only: ["google-vertex"],
+      ignore: ["azure"],
       allow_fallbacks: false,
     });
   });

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -150,6 +150,9 @@ export function generate(
     ...(genConfig.providerOnly !== undefined && {
       only: [...genConfig.providerOnly],
     }),
+    ...(genConfig.providerIgnore !== undefined && {
+      ignore: [...genConfig.providerIgnore],
+    }),
     ...(genConfig.allowFallbacks !== undefined && {
       allowFallbacks: genConfig.allowFallbacks,
     }),


### PR DESCRIPTION
## TL;DR

Adds a `providerIgnore` inference field that maps to OpenRouter's `provider.ignore`, so a run can keep default routing while excluding known-broken providers instead of pinning with `provider.only`.

## What changed?

- `providerIgnore?: readonly string[]` on `GenerateConfig` and on `InferenceOverrideSchema` (search configs inherit it through `ModelBenchmarkBaseSchema`, so `SearchBenchmarkOptionsSchema` is deliberately untouched — adding it there would duplicate the key).
- Chat (`openrouter-model`), Responses (`responses-model`) and search (`search/core/request`) request builders emit `ignore` alongside `only`/`order`/`sort`/`allow_fallbacks`. The search builder's "send a provider object at all" condition now includes `providerIgnore`, so an ignore-only config still sends `provider`.
- Threaded through every benchmark that already threads `providerOnly` (gpqa, mmlu-pro, mmmu-pro-vision, ifstruct, wandr, vgi-bench, swe-atlas, deep-swe, tau-bench-airline, tau3-bench-banking) and the search solver options.

Absent the field, request bodies are unchanged.

## Why?

A run that hits a broken provider currently has only one workaround: pin to a healthy provider with `provider.only` + `allow_fallbacks: false`. That changes what is being measured, from the default-routing experience to a provider-pinned one, and concentrates the whole run's traffic on one provider's rate limits. An ignore list keeps default routing minus the broken providers, and is reusable for future runs.

Draco is unchanged: it has its own `ProviderRoutingSchema` and already supports `provider.ignore`.

## How to test

Run any chat benchmark with an ignore list and confirm the served providers exclude it, e.g. add `providerIgnore: ["Parasail"]` to a run config; the emitted request body carries:

```json
{ "provider": { "ignore": ["Parasail"] } }
```

Combined with pinning it preserves the other fields:

```json
{ "provider": { "only": ["DeepInfra"], "ignore": ["Parasail"], "allow_fallbacks": false } }
```

## Benchmark impact

No scoring, dataset, solver or scorer behavior changes. Runs that set `providerIgnore` measure default routing restricted to the remaining providers, which is the intended semantic difference from provider pinning.

## Reviewer focus

- Wire key/casing per surface: chat uses snake_case `allow_fallbacks`, the Responses SDK type is camelCase `allowFallbacks` and serializes to snake_case; `ignore` is the same on both.
- That the ignore-only case sends `provider` on all three request paths.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/d180d520807b461992e10079ec966c96
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->