### PR TITLE
feat: persist completed sample outcomes so interrupted runs resume instead of restarting

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "./parquet": "./src/results/parquet.ts",
     "./parquet-schema": "./src/results/parquet-schema.ts",
     "./progress": "./src/harness/progress.ts",
+    "./sample-result-store": "./src/harness/sample-result-store.ts",
     "./result-store": "./src/results/result-store.ts",
     "./internal/log": "./src/internal/log.ts",
     "./internal/effect-logger": "./src/internal/effect-logger.ts"

--- a/src/harness/run.test.ts
+++ b/src/harness/run.test.ts
@@ -16,6 +16,7 @@ import { fromChunk } from "effect/Stream";
 import {
   noopProgressLayer,
   noopCheckpointLayer,
+  noopSampleResultLayer,
 } from "../../test/helpers/noop-progress-layer";
 import { mcqScorer } from "../benchmarks/scorers/mcq/scorer";
 import { runHarnessPromise } from "../internal/effect-logger";
@@ -27,6 +28,7 @@ import type { ModelService } from "./model";
 import { Model } from "./model";
 import type { CheckpointStore, ProgressReporter } from "./progress";
 import { runBenchmark } from "./run";
+import type { SampleResultStore } from "./sample-result-store";
 import { Scorer } from "./scorer";
 import type { SolverService } from "./solver";
 import { systemMessage, chain, generate, Solver } from "./solver";
@@ -94,14 +96,22 @@ function makeLayers(
     layer: Layer<Model>;
   },
   solverService: ReturnType<typeof chain>
-): Layer<Dataset | Solver | Scorer | ProgressReporter | CheckpointStore> {
+): Layer<
+  | Dataset
+  | Solver
+  | Scorer
+  | ProgressReporter
+  | CheckpointStore
+  | SampleResultStore
+> {
   return mergeAll(
     fakeDatasetLayer(SAMPLES),
     layerSucceed(Solver, Solver.of(solverService)),
     layerSucceed(Scorer, Scorer.of(mcqScorer)),
     model.layer,
     noopProgressLayer,
-    noopCheckpointLayer
+    noopCheckpointLayer,
+    noopSampleResultLayer
   );
 }
 describe("runBenchmark", () => {
@@ -130,7 +140,8 @@ describe("runBenchmark", () => {
       layerSucceed(Solver, Solver.of(solver)),
       layerSucceed(Scorer, Scorer.of(mcqScorer)),
       noopProgressLayer,
-      noopCheckpointLayer
+      noopCheckpointLayer,
+      noopSampleResultLayer
     );
     await runHarnessPromise(
       runBenchmark({
@@ -184,7 +195,8 @@ describe("runBenchmark", () => {
       layerSucceed(Scorer, Scorer.of(mcqScorer)),
       model.layer,
       noopProgressLayer,
-      noopCheckpointLayer
+      noopCheckpointLayer,
+      noopSampleResultLayer
     );
     const result = await runPromise(
       runBenchmark({ epochs: 1, maxConcurrency: 1 }).pipe(provide(layers))
@@ -225,7 +237,8 @@ describe("runBenchmark", () => {
       layerSucceed(Solver, Solver.of(solver)),
       layerSucceed(Scorer, Scorer.of(mcqScorer)),
       noopProgressLayer,
-      noopCheckpointLayer
+      noopCheckpointLayer,
+      noopSampleResultLayer
     );
     const result = await runPromise(
       runBenchmark({ epochs: 1, maxConcurrency: 1 }).pipe(provide(layers))
@@ -252,7 +265,8 @@ describe("runBenchmark", () => {
       layerSucceed(Solver, Solver.of(solver)),
       layerSucceed(Scorer, Scorer.of(mcqScorer)),
       noopProgressLayer,
-      noopCheckpointLayer
+      noopCheckpointLayer,
+      noopSampleResultLayer
     );
     const result = await runPromise(
       runBenchmark({ epochs: 1, maxConcurrency: 1 }).pipe(provide(layers))
@@ -268,7 +282,8 @@ describe("runBenchmark", () => {
       layerSucceed(Scorer, Scorer.of(mcqScorer)),
       model.layer,
       noopProgressLayer,
-      noopCheckpointLayer
+      noopCheckpointLayer,
+      noopSampleResultLayer
     );
     const result = await runPromise(
       runBenchmark({
@@ -307,7 +322,8 @@ describe("runBenchmark", () => {
       layerSucceed(Scorer, Scorer.of(mcqScorer)),
       model.layer,
       noopProgressLayer,
-      noopCheckpointLayer
+      noopCheckpointLayer,
+      noopSampleResultLayer
     );
     const result = await runPromise(
       runBenchmark({ epochs: 1, maxConcurrency: 2 }).pipe(provide(layers))
@@ -346,7 +362,8 @@ describe("runBenchmark", () => {
       layerSucceed(Scorer, Scorer.of(mcqScorer)),
       model.layer,
       noopProgressLayer,
-      noopCheckpointLayer
+      noopCheckpointLayer,
+      noopSampleResultLayer
     );
     const result = await runPromise(
       runBenchmark({ epochs: 1, maxConcurrency: 2 }).pipe(provide(layers))
@@ -389,7 +406,8 @@ describe("runBenchmark", () => {
       layerSucceed(Scorer, Scorer.of(mcqScorer)),
       model.layer,
       noopProgressLayer,
-      noopCheckpointLayer
+      noopCheckpointLayer,
+      noopSampleResultLayer
     );
     const result = await runPromise(
       runBenchmark({ epochs: 1, maxConcurrency: 2 }).pipe(provide(layers))

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -6,6 +6,8 @@ import {
   gen as effectGen,
   map as effectMap,
   annotateLogs,
+  orElseSucceed,
+  tryPromise,
   withLogSpan,
   succeed as effectSucceed,
 } from "effect/Effect";
@@ -42,6 +44,7 @@ import { Dataset } from "./dataset";
 import type { AggregateMetrics, SampleScore } from "./metric";
 import { aggregateScores } from "./metric";
 import { CheckpointStore, ProgressReporter } from "./progress";
+import { SampleResultStore, sampleResultKey } from "./sample-result-store";
 import { Scorer } from "./scorer";
 import { Solver } from "./solver";
 
@@ -109,12 +112,12 @@ function evalWithProgress(
   evaluate: Effect<
     EvalOutcome,
     ModelError | SolverError,
-    Solver | Scorer | ProgressReporter | CheckpointStore
+    Solver | Scorer | ProgressReporter | CheckpointStore | SampleResultStore
   >
 ): Effect<
   EvalOutcome,
   ModelError | SolverError,
-  Solver | Scorer | ProgressReporter | CheckpointStore
+  Solver | Scorer | ProgressReporter | CheckpointStore | SampleResultStore
 > {
   const { sample, epoch, sampleIndex } = sampleEpoch;
   return effectGen(function* () {
@@ -188,6 +191,31 @@ function applyReplayedUsage(
 interface EvaluateOneOpts {
   readonly sampleEpoch: SampleEpoch;
   readonly degradeSolverErrors: boolean;
+}
+
+function evaluateOneResumable(
+  opts: EvaluateOneOpts
+): Effect<
+  EvalOutcome,
+  ModelError | SolverError,
+  Solver | Scorer | ProgressReporter | CheckpointStore | SampleResultStore
+> {
+  const { sample, epoch } = opts.sampleEpoch;
+  const key = sampleResultKey(sample.id, epoch);
+  return effectGen(function* () {
+    const store = yield* SampleResultStore;
+    const persisted = yield* tryPromise(() => store.read(key)).pipe(
+      orElseSucceed(() => null)
+    );
+    if (persisted !== null) {
+      return persisted;
+    }
+    const outcome = yield* evaluateOne(opts);
+    yield* tryPromise(() => store.write(key, outcome)).pipe(
+      orElseSucceed(() => undefined)
+    );
+    return outcome;
+  });
 }
 
 function evaluateOne(
@@ -330,7 +358,12 @@ export function runBenchmark(
 ): Effect<
   RunResult,
   ModelError | SolverError | DatasetError,
-  Dataset | Solver | Scorer | ProgressReporter | CheckpointStore
+  | Dataset
+  | Solver
+  | Scorer
+  | ProgressReporter
+  | CheckpointStore
+  | SampleResultStore
 > {
   return Dataset.pipe(
     effectFlatMap((dataset) => {
@@ -348,7 +381,7 @@ export function runBenchmark(
           (se) =>
             evalWithProgress(
               se,
-              evaluateOne({
+              evaluateOneResumable({
                 sampleEpoch: se,
                 degradeSolverErrors: config.degradeSolverErrors ?? false,
               }).pipe(

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -20,8 +20,10 @@ import {
   zipWithIndex as streamZipWithIndex,
 } from "effect/Stream";
 
+import { Either } from "../internal/either";
 import { unknownErrorToString } from "../internal/errors";
 import { wLog } from "../internal/log";
+import { firstZodIssueMessage, parseSchema } from "../internal/zod";
 import { resetGenerationIds } from "../runtime/generation-ids";
 import type { ReplayedUsage } from "../runtime/generation-resolver";
 import { resolveCollectedGenerations } from "../runtime/generation-resolver";
@@ -46,7 +48,11 @@ import { Dataset } from "./dataset";
 import type { AggregateMetrics, SampleScore } from "./metric";
 import { aggregateScores } from "./metric";
 import { CheckpointStore, ProgressReporter } from "./progress";
-import { SampleResultStore, sampleResultKey } from "./sample-result-store";
+import {
+  PersistedSampleOutcomeSchema,
+  SampleResultStore,
+  sampleResultKey,
+} from "./sample-result-store";
 import { Scorer } from "./scorer";
 import { Solver } from "./solver";
 
@@ -207,7 +213,7 @@ function evaluateOneResumable(
   const key = sampleResultKey(sample.id, epoch);
   return effectGen(function* () {
     const store = yield* SampleResultStore;
-    const persisted = yield* tryPromise({
+    const raw = yield* tryPromise({
       try: () => store.read(key),
       catch: unknownErrorToString,
     }).pipe(
@@ -219,8 +225,15 @@ function evaluateOneResumable(
         return effectSucceed(null);
       })
     );
-    if (persisted !== null) {
-      return persisted;
+    if (raw !== null && raw !== undefined) {
+      const persisted = parseSchema(PersistedSampleOutcomeSchema, raw);
+      if (Either.isRight(persisted)) {
+        return persisted.right;
+      }
+      wLog("Persisted sample outcome failed validation; re-evaluating", {
+        sample_result_key: key,
+        error: firstZodIssueMessage(persisted.left),
+      });
     }
     const outcome = yield* evaluateOne(opts);
     if (outcome.isDegraded === true) {

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -228,12 +228,21 @@ function evaluateOneResumable(
     if (raw !== null && raw !== undefined) {
       const persisted = parseSchema(PersistedSampleOutcomeSchema, raw);
       if (Either.isRight(persisted)) {
-        return persisted.right;
+        const { sampleId, epoch: persistedEpoch } = persisted.right.sampleScore;
+        if (sampleId === sample.id && persistedEpoch === epoch) {
+          return persisted.right;
+        }
+        wLog("Persisted sample outcome identity mismatch; re-evaluating", {
+          sample_result_key: key,
+          persisted_sample_id: sampleId,
+          persisted_epoch: persistedEpoch,
+        });
+      } else {
+        wLog("Persisted sample outcome failed validation; re-evaluating", {
+          sample_result_key: key,
+          error: firstZodIssueMessage(persisted.left),
+        });
       }
-      wLog("Persisted sample outcome failed validation; re-evaluating", {
-        sample_result_key: key,
-        error: firstZodIssueMessage(persisted.left),
-      });
     }
     const outcome = yield* evaluateOne(opts);
     if (outcome.isDegraded === true) {

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -1,12 +1,12 @@
 import type { Effect } from "effect/Effect";
 import {
+  catchAll,
   catchTags,
   fail as effectFail,
   flatMap as effectFlatMap,
   gen as effectGen,
   map as effectMap,
   annotateLogs,
-  orElseSucceed,
   tryPromise,
   withLogSpan,
   succeed as effectSucceed,
@@ -20,6 +20,8 @@ import {
   zipWithIndex as streamZipWithIndex,
 } from "effect/Stream";
 
+import { unknownErrorToString } from "../internal/errors";
+import { wLog } from "../internal/log";
 import { resetGenerationIds } from "../runtime/generation-ids";
 import type { ReplayedUsage } from "../runtime/generation-resolver";
 import { resolveCollectedGenerations } from "../runtime/generation-resolver";
@@ -205,14 +207,26 @@ function evaluateOneResumable(
   return effectGen(function* () {
     const store = yield* SampleResultStore;
     const persisted = yield* tryPromise(() => store.read(key)).pipe(
-      orElseSucceed(() => null)
+      catchAll((error) => {
+        wLog("Failed to read persisted sample outcome; re-evaluating", {
+          sample_result_key: key,
+          error: unknownErrorToString(error),
+        });
+        return effectSucceed(null);
+      })
     );
     if (persisted !== null) {
       return persisted;
     }
     const outcome = yield* evaluateOne(opts);
     yield* tryPromise(() => store.write(key, outcome)).pipe(
-      orElseSucceed(() => undefined)
+      catchAll((error) => {
+        wLog("Failed to persist sample outcome; a resumed run will re-run it", {
+          sample_result_key: key,
+          error: unknownErrorToString(error),
+        });
+        return effectSucceed(undefined);
+      })
     );
     return outcome;
   });

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -82,6 +82,7 @@ type EvalOutcome = {
   sampleScore: SampleScore;
   usage?: ModelUsage;
   generationTimeMs?: number;
+  isDegraded?: boolean;
 };
 
 function sampleEpochStream(
@@ -206,11 +207,14 @@ function evaluateOneResumable(
   const key = sampleResultKey(sample.id, epoch);
   return effectGen(function* () {
     const store = yield* SampleResultStore;
-    const persisted = yield* tryPromise(() => store.read(key)).pipe(
+    const persisted = yield* tryPromise({
+      try: () => store.read(key),
+      catch: unknownErrorToString,
+    }).pipe(
       catchAll((error) => {
         wLog("Failed to read persisted sample outcome; re-evaluating", {
           sample_result_key: key,
-          error: unknownErrorToString(error),
+          error,
         });
         return effectSucceed(null);
       })
@@ -219,11 +223,17 @@ function evaluateOneResumable(
       return persisted;
     }
     const outcome = yield* evaluateOne(opts);
-    yield* tryPromise(() => store.write(key, outcome)).pipe(
+    if (outcome.isDegraded === true) {
+      return outcome;
+    }
+    yield* tryPromise({
+      try: () => store.write(key, outcome),
+      catch: unknownErrorToString,
+    }).pipe(
       catchAll((error) => {
         wLog("Failed to persist sample outcome; a resumed run will re-run it", {
           sample_result_key: key,
-          error: unknownErrorToString(error),
+          error,
         });
         return effectSucceed(undefined);
       })
@@ -355,6 +365,7 @@ function errorOutcome(opts: ErrorOutcomeOpts): EvalOutcome {
       input: sample.input,
       target: sample.target.text,
     },
+    isDegraded: true,
   };
 }
 

--- a/src/harness/sample-result-resume.test.ts
+++ b/src/harness/sample-result-resume.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, spyOn } from "bun:test";
 
 import { fromIterable } from "effect/Chunk";
 import {
+  fail as effectFail,
   flatMap as effectFlatMap,
   runPromise,
   succeed as effectSucceed,
@@ -18,7 +19,7 @@ import {
 import { mcqScorer } from "../benchmarks/scorers/mcq/scorer";
 import { recordGenerationId } from "../runtime/generation-ids";
 import type { Sample } from "./core";
-import { MessageRole } from "./core";
+import { MessageRole, ModelError, ScoreValue } from "./core";
 import { Dataset } from "./dataset";
 import type { ModelService } from "./model";
 import type { RunResult } from "./run";
@@ -122,10 +123,14 @@ function throwingStore(): SampleResultStoreService {
 }
 
 async function runWithStore(
-  store: SampleResultStoreService
+  store: SampleResultStoreService,
+  overrides?: {
+    readonly model?: ModelService;
+    readonly scorer?: ScorerService;
+  }
 ): Promise<{ result: RunResult; counters: Counters }> {
   const counters: Counters = { solver: 0, scorer: 0 };
-  const model = fakeModel();
+  const model = overrides?.model ?? fakeModel();
   const innerSolver = chain(
     systemMessage("You are a helpful assistant."),
     generate(model, { temperature: 0.5 })
@@ -134,9 +139,10 @@ async function runWithStore(
     counters.solver += 1;
     return innerSolver(state);
   });
+  const baseScorer = overrides?.scorer ?? mcqScorer;
   const countingScorer: ScorerService = (state, target) => {
     counters.scorer += 1;
-    return mcqScorer(state, target);
+    return baseScorer(state, target);
   };
   const layers = mergeAll(
     fakeDatasetLayer(SAMPLES),
@@ -223,7 +229,9 @@ describe("sample-result resume", () => {
       expect(result.sampleScores.length).toBe(6);
       expect(summarize(result)).toEqual(run1Summary);
       expect(result.metrics.accuracy).toBeCloseTo(run1Metrics.accuracy, 5);
-      const warned = warn.mock.calls.map((call) => String(call[0]));
+      const warned = warn.mock.calls.map((call) =>
+        call.map((arg) => JSON.stringify(arg)).join(" ")
+      );
       expect(
         warned.some((line) =>
           line.includes("Failed to read persisted sample outcome")
@@ -232,8 +240,79 @@ describe("sample-result resume", () => {
       expect(
         warned.some((line) => line.includes("Failed to persist sample outcome"))
       ).toBe(true);
+      expect(warned.some((line) => line.includes("read exploded"))).toBe(true);
+      expect(warned.some((line) => line.includes("write exploded"))).toBe(true);
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it("T5: degraded error outcomes are not persisted and are re-evaluated on resume", async () => {
+    const failingModel: ModelService = {
+      generate: (messages) => {
+        const userMsg =
+          messages.find((m) => m.role === MessageRole.User)?.content ?? "";
+        if (userMsg.includes("Q1")) {
+          return effectFail(
+            new ModelError({ message: "OpenRouter HTTP 429", status: 429 })
+          );
+        }
+        return effectSucceed({
+          completion: "Answer: B",
+          message: { role: MessageRole.Assistant, content: "Answer: B" },
+          generationTimeMs: 100,
+        });
+      },
+    };
+    const store = makeInMemoryStore();
+    const run1 = await runWithStore(store, { model: failingModel });
+    const skippedRun1 = run1.result.sampleScores.filter(
+      (s) => s.sampleId === "s1"
+    );
+    expect(skippedRun1.every((s) => s.score.value === ScoreValue.Skipped)).toBe(
+      true
+    );
+    expect([...store.map.keys()].sort()).toEqual([
+      "s2/0",
+      "s2/1",
+      "s3/0",
+      "s3/1",
+    ]);
+
+    const run2 = await runWithStore(store);
+    expect(run2.counters.solver).toBe(2);
+    expect(run2.counters.scorer).toBe(2);
+    const s1Run2 = run2.result.sampleScores.filter((s) => s.sampleId === "s1");
+    expect(s1Run2.every((s) => s.score.value === ScoreValue.Correct)).toBe(
+      true
+    );
+    expect([...store.map.keys()].sort()).toEqual(ALL_KEYS);
+  });
+
+  it("T6: scorer trajectory survives persistence and resume", async () => {
+    const trajectoryScorer: ScorerService = (state, target) =>
+      mcqScorer(state, target).pipe(
+        effectFlatMap((score) =>
+          effectSucceed({
+            ...score,
+            trajectory: {
+              kind: "verifier_log" as const,
+              log: "pytest: 12 passed",
+            },
+          })
+        )
+      );
+    const store = makeInMemoryStore();
+    await runWithStore(store, { scorer: trajectoryScorer });
+
+    const resumed = await runWithStore(store);
+    expect(resumed.counters.solver).toBe(0);
+    expect(
+      resumed.result.sampleScores.every(
+        (s) =>
+          s.score.trajectory?.kind === "verifier_log" &&
+          s.score.trajectory.log === "pytest: 12 passed"
+      )
+    ).toBe(true);
   });
 });

--- a/src/harness/sample-result-resume.test.ts
+++ b/src/harness/sample-result-resume.test.ts
@@ -98,11 +98,7 @@ function makeInMemoryStore(seed?: Map<string, string>): InMemoryStore {
     writtenKeys,
     read: async (key) => {
       const raw = map.get(key);
-      if (raw === undefined) {
-        return null;
-      }
-      const parsed = PersistedSampleOutcomeSchema.safeParse(JSON.parse(raw));
-      return parsed.success ? parsed.data : null;
+      return raw === undefined ? null : JSON.parse(raw);
     },
     write: async (key, data) => {
       writtenKeys.push(key);
@@ -287,6 +283,44 @@ describe("sample-result resume", () => {
       true
     );
     expect([...store.map.keys()].sort()).toEqual(ALL_KEYS);
+  });
+
+  it("T7: unparseable persisted record is logged and re-evaluated", async () => {
+    const seeded = new Map(run1Store.map);
+    const corruptRaw = seeded.get("s1/0");
+    if (corruptRaw === undefined) {
+      throw new Error("expected s1/0 in run1 store");
+    }
+    const corrupt: unknown = JSON.parse(corruptRaw);
+    if (typeof corrupt !== "object" || corrupt === null) {
+      throw new Error("expected persisted record to be an object");
+    }
+    seeded.set(
+      "s1/0",
+      JSON.stringify({ ...corrupt, usage: { inputTokens: 10.5 } })
+    );
+    const store = makeInMemoryStore(seeded);
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { result, counters } = await runWithStore(store);
+      expect(counters.solver).toBe(1);
+      expect(counters.scorer).toBe(1);
+      expect(summarize(result)).toEqual(run1Summary);
+      expect(store.writtenKeys).toEqual(["s1/0"]);
+      const warned = warn.mock.calls.map((call) =>
+        call.map((arg) => JSON.stringify(arg)).join(" ")
+      );
+      expect(
+        warned.some(
+          (line) =>
+            line.includes("Persisted sample outcome failed validation") &&
+            line.includes("s1/0") &&
+            line.includes("inputTokens")
+        )
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("T6: scorer trajectory survives persistence and resume", async () => {

--- a/src/harness/sample-result-resume.test.ts
+++ b/src/harness/sample-result-resume.test.ts
@@ -323,6 +323,36 @@ describe("sample-result resume", () => {
     }
   });
 
+  it("T8: persisted record with mismatched identity is logged and re-evaluated", async () => {
+    const backing = makeInMemoryStore(run1Store.map);
+    const misMappingStore: SampleResultStoreService = {
+      read: (key) => backing.read(`s1/${key.split("/")[1]}`),
+      write: backing.write,
+    };
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { result, counters } = await runWithStore(misMappingStore);
+      expect(counters.solver).toBe(4);
+      expect(counters.scorer).toBe(4);
+      expect(summarize(result)).toEqual(run1Summary);
+      expect(result.metrics.totalQuestions).toBe(run1Metrics.total);
+      expect(result.metrics.accuracy).toBeCloseTo(run1Metrics.accuracy, 5);
+      const warned = warn.mock.calls.map((call) =>
+        call.map((arg) => JSON.stringify(arg)).join(" ")
+      );
+      expect(
+        warned.some(
+          (line) =>
+            line.includes("Persisted sample outcome identity mismatch") &&
+            line.includes("s2/0") &&
+            line.includes("s1")
+        )
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("T6: scorer trajectory survives persistence and resume", async () => {
     const trajectoryScorer: ScorerService = (state, target) =>
       mcqScorer(state, target).pipe(

--- a/src/harness/sample-result-resume.test.ts
+++ b/src/harness/sample-result-resume.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "bun:test";
+
+import { fromIterable } from "effect/Chunk";
+import {
+  flatMap as effectFlatMap,
+  runPromise,
+  succeed as effectSucceed,
+  provide,
+} from "effect/Effect";
+import type { Layer } from "effect/Layer";
+import { mergeAll, succeed as layerSucceed } from "effect/Layer";
+import { fromChunk } from "effect/Stream";
+
+import {
+  noopProgressLayer,
+  noopCheckpointLayer,
+} from "../../test/helpers/noop-progress-layer";
+import { mcqScorer } from "../benchmarks/scorers/mcq/scorer";
+import { recordGenerationId } from "../runtime/generation-ids";
+import type { Sample } from "./core";
+import { MessageRole } from "./core";
+import { Dataset } from "./dataset";
+import type { ModelService } from "./model";
+import type { RunResult } from "./run";
+import { runBenchmark } from "./run";
+import type { SampleResultStoreService } from "./sample-result-store";
+import {
+  PersistedSampleOutcomeSchema,
+  SampleResultStore,
+} from "./sample-result-store";
+import { Scorer } from "./scorer";
+import type { ScorerService } from "./scorer";
+import { systemMessage, chain, generate, Solver } from "./solver";
+
+const SAMPLES: readonly Sample[] = [
+  { id: "s1", input: "Q1 target B", target: { text: "B" } },
+  { id: "s2", input: "Q2 target B", target: { text: "B" } },
+  { id: "s3", input: "Q3 target B", target: { text: "B" } },
+];
+const EPOCHS = 2;
+const ALL_KEYS = ["s1/0", "s1/1", "s2/0", "s2/1", "s3/0", "s3/1"];
+
+function fakeDatasetLayer(samples: readonly Sample[]): Layer<Dataset> {
+  return layerSucceed(
+    Dataset,
+    Dataset.of({
+      stream: (opts) => {
+        const start = opts?.start ?? 0;
+        const end = opts?.end ?? samples.length;
+        return fromChunk(fromIterable(samples.slice(start, end)));
+      },
+      size: effectSucceed(samples.length),
+    })
+  );
+}
+
+function fakeModel(): ModelService {
+  return {
+    generate: (messages) => {
+      const userMsg =
+        messages.find((m) => m.role === MessageRole.User)?.content ?? "";
+      const completion = userMsg.includes("Q2") ? "Answer: A" : "Answer: B";
+      return recordGenerationId(`fake-${userMsg}`).pipe(
+        effectFlatMap(() =>
+          effectSucceed({
+            completion,
+            message: { role: MessageRole.Assistant, content: completion },
+            usage: {
+              inputTokens: 10,
+              outputTokens: 5,
+              totalTokens: 15,
+              totalCost: 0.001,
+            },
+            generationTimeMs: 100,
+          })
+        )
+      );
+    },
+  };
+}
+
+interface Counters {
+  solver: number;
+  scorer: number;
+}
+
+interface InMemoryStore extends SampleResultStoreService {
+  readonly map: Map<string, string>;
+  readonly writtenKeys: string[];
+}
+
+function makeInMemoryStore(seed?: Map<string, string>): InMemoryStore {
+  const map = new Map(seed ?? []);
+  const writtenKeys: string[] = [];
+  return {
+    map,
+    writtenKeys,
+    read: async (key) => {
+      const raw = map.get(key);
+      if (raw === undefined) {
+        return null;
+      }
+      const parsed = PersistedSampleOutcomeSchema.safeParse(JSON.parse(raw));
+      return parsed.success ? parsed.data : null;
+    },
+    write: async (key, data) => {
+      writtenKeys.push(key);
+      map.set(key, JSON.stringify(data));
+    },
+  };
+}
+
+function throwingStore(): SampleResultStoreService {
+  return {
+    read: async () => {
+      throw new Error("read exploded");
+    },
+    write: async () => {
+      throw new Error("write exploded");
+    },
+  };
+}
+
+async function runWithStore(
+  store: SampleResultStoreService
+): Promise<{ result: RunResult; counters: Counters }> {
+  const counters: Counters = { solver: 0, scorer: 0 };
+  const model = fakeModel();
+  const innerSolver = chain(
+    systemMessage("You are a helpful assistant."),
+    generate(model, { temperature: 0.5 })
+  );
+  const countingSolver = Solver.of((state) => {
+    counters.solver += 1;
+    return innerSolver(state);
+  });
+  const countingScorer: ScorerService = (state, target) => {
+    counters.scorer += 1;
+    return mcqScorer(state, target);
+  };
+  const layers = mergeAll(
+    fakeDatasetLayer(SAMPLES),
+    layerSucceed(Solver, countingSolver),
+    layerSucceed(Scorer, Scorer.of(countingScorer)),
+    noopProgressLayer,
+    noopCheckpointLayer,
+    layerSucceed(SampleResultStore, store)
+  );
+  const result = await runPromise(
+    runBenchmark({ epochs: EPOCHS, maxConcurrency: 2 }).pipe(provide(layers))
+  );
+  return { result, counters };
+}
+
+function summarize(result: RunResult): { key: string; value: string }[] {
+  return result.sampleScores
+    .map((s) => ({ key: `${s.sampleId}/${s.epoch}`, value: s.score.value }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+let run1Store: InMemoryStore;
+let run1Summary: { key: string; value: string }[];
+let run1Metrics: { accuracy: number; total: number; correct: number };
+
+describe("sample-result resume", () => {
+  it("T1: fresh run evaluates all 6 and persists all 6 keys", async () => {
+    run1Store = makeInMemoryStore();
+    const { result, counters } = await runWithStore(run1Store);
+    expect(result.sampleScores.length).toBe(6);
+    expect(counters.solver).toBe(6);
+    expect(counters.scorer).toBe(6);
+    expect([...run1Store.map.keys()].sort()).toEqual(ALL_KEYS);
+    for (const raw of run1Store.map.values()) {
+      const parsed = PersistedSampleOutcomeSchema.safeParse(JSON.parse(raw));
+      expect(parsed.success).toBe(true);
+    }
+    run1Summary = summarize(result);
+    run1Metrics = {
+      accuracy: result.metrics.accuracy,
+      total: result.metrics.totalQuestions,
+      correct: result.metrics.correctAnswers,
+    };
+    expect(run1Metrics.total).toBe(3);
+    expect(run1Metrics.accuracy).toBeCloseTo(2 / 3, 5);
+  });
+
+  it("T2: full resume — solver/scorer never invoked, identical outcome", async () => {
+    const store = makeInMemoryStore(run1Store.map);
+    const { result, counters } = await runWithStore(store);
+    expect(counters.solver).toBe(0);
+    expect(counters.scorer).toBe(0);
+    expect(summarize(result)).toEqual(run1Summary);
+    expect(result.metrics.accuracy).toBeCloseTo(run1Metrics.accuracy, 5);
+    expect(result.metrics.totalQuestions).toBe(run1Metrics.total);
+    expect(result.metrics.correctAnswers).toBe(run1Metrics.correct);
+    expect(store.writtenKeys).toEqual([]);
+  });
+
+  it("T3: partial resume — only the 4 missing keys are evaluated", async () => {
+    const seeded = new Map(
+      [...run1Store.map.entries()].filter(([k]) => ["s1/0", "s2/1"].includes(k))
+    );
+    const store = makeInMemoryStore(seeded);
+    const { result, counters } = await runWithStore(store);
+    expect(counters.solver).toBe(4);
+    expect(counters.scorer).toBe(4);
+    expect([...store.writtenKeys].sort()).toEqual([
+      "s1/1",
+      "s2/0",
+      "s3/0",
+      "s3/1",
+    ]);
+    expect(summarize(result)).toEqual(run1Summary);
+    expect(result.metrics.accuracy).toBeCloseTo(run1Metrics.accuracy, 5);
+  });
+
+  it("T4: store whose read/write throw — run completes, all evaluated", async () => {
+    const { result, counters } = await runWithStore(throwingStore());
+    expect(counters.solver).toBe(6);
+    expect(counters.scorer).toBe(6);
+    expect(result.sampleScores.length).toBe(6);
+    expect(summarize(result)).toEqual(run1Summary);
+    expect(result.metrics.accuracy).toBeCloseTo(run1Metrics.accuracy, 5);
+  });
+});

--- a/src/harness/sample-result-resume.test.ts
+++ b/src/harness/sample-result-resume.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 
 import { fromIterable } from "effect/Chunk";
 import {
@@ -214,12 +214,26 @@ describe("sample-result resume", () => {
     expect(result.metrics.accuracy).toBeCloseTo(run1Metrics.accuracy, 5);
   });
 
-  it("T4: store whose read/write throw — run completes, all evaluated", async () => {
-    const { result, counters } = await runWithStore(throwingStore());
-    expect(counters.solver).toBe(6);
-    expect(counters.scorer).toBe(6);
-    expect(result.sampleScores.length).toBe(6);
-    expect(summarize(result)).toEqual(run1Summary);
-    expect(result.metrics.accuracy).toBeCloseTo(run1Metrics.accuracy, 5);
+  it("T4: store whose read/write throw — run completes, all evaluated, failures logged", async () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { result, counters } = await runWithStore(throwingStore());
+      expect(counters.solver).toBe(6);
+      expect(counters.scorer).toBe(6);
+      expect(result.sampleScores.length).toBe(6);
+      expect(summarize(result)).toEqual(run1Summary);
+      expect(result.metrics.accuracy).toBeCloseTo(run1Metrics.accuracy, 5);
+      const warned = warn.mock.calls.map((call) => String(call[0]));
+      expect(
+        warned.some((line) =>
+          line.includes("Failed to read persisted sample outcome")
+        )
+      ).toBe(true);
+      expect(
+        warned.some((line) => line.includes("Failed to persist sample outcome"))
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/src/harness/sample-result-store.test.ts
+++ b/src/harness/sample-result-store.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+
+import { ScoreValue } from "./core";
+import type {
+  PersistedSampleOutcome,
+  SampleResultStoreService,
+} from "./sample-result-store";
+import {
+  namespacedSampleResultStore,
+  sampleResultKey,
+} from "./sample-result-store";
+
+const OUTCOME: PersistedSampleOutcome = {
+  sampleScore: {
+    sampleId: "s1",
+    epoch: 0,
+    score: { value: ScoreValue.Correct, answer: "B", explanation: "" },
+  },
+};
+
+describe("namespacedSampleResultStore", () => {
+  it("prefixes reads and writes so different sessions do not collide", async () => {
+    const map = new Map<string, PersistedSampleOutcome>();
+    const backing: SampleResultStoreService = {
+      read: async (key) => map.get(key) ?? null,
+      write: async (key, data) => {
+        map.set(key, data);
+      },
+    };
+    const sessionA = namespacedSampleResultStore("session-a", backing);
+    const sessionB = namespacedSampleResultStore("session-b", backing);
+    const key = sampleResultKey("s1", 0);
+
+    await sessionA.write(key, OUTCOME);
+
+    expect([...map.keys()]).toEqual(["session-a/s1/0"]);
+    expect(await sessionA.read(key)).toEqual(OUTCOME);
+    expect(await sessionB.read(key)).toBeNull();
+  });
+});

--- a/src/harness/sample-result-store.ts
+++ b/src/harness/sample-result-store.ts
@@ -67,16 +67,16 @@ const SampleScoreSchema = z.object({
 } satisfies ZodShape<SampleScore>);
 
 const ServerToolUseCountsSchema = z.object({
-  webSearchRequests: z.number().optional(),
-  toolCallsRequested: z.number().optional(),
-  toolCallsExecuted: z.number().optional(),
+  webSearchRequests: zInt().optional(),
+  toolCallsRequested: zInt().optional(),
+  toolCallsExecuted: zInt().optional(),
 } satisfies ZodShape<ServerToolUseCounts>);
 
 const ModelUsageSchema = z.object({
-  inputTokens: z.number().optional(),
-  outputTokens: z.number().optional(),
-  totalTokens: z.number().optional(),
-  reasoningTokens: z.number().optional(),
+  inputTokens: zInt().optional(),
+  outputTokens: zInt().optional(),
+  totalTokens: zInt().optional(),
+  reasoningTokens: zInt().optional(),
   totalCost: z.number().optional(),
   serverToolUse: ServerToolUseCountsSchema.optional(),
 } satisfies ZodShape<ModelUsage>);

--- a/src/harness/sample-result-store.ts
+++ b/src/harness/sample-result-store.ts
@@ -92,8 +92,11 @@ export function sampleResultKey(sampleId: string, epoch: number): string {
 }
 
 export interface SampleResultStoreService {
-  readonly read: (key: string) => Promise<unknown>;
-  readonly write: (key: string, data: PersistedSampleOutcome) => Promise<void>;
+  readonly read: (runRelativeKey: string) => Promise<unknown>;
+  readonly write: (
+    runRelativeKey: string,
+    data: PersistedSampleOutcome
+  ) => Promise<void>;
 }
 
 export class SampleResultStore extends Tag(
@@ -106,11 +109,12 @@ export const NOOP_SAMPLE_RESULT_STORE: SampleResultStoreService = {
 };
 
 export function namespacedSampleResultStore(
-  prefix: string,
+  sessionId: string,
   store: SampleResultStoreService
 ): SampleResultStoreService {
   return {
-    read: (key) => store.read(`${prefix}/${key}`),
-    write: (key, data) => store.write(`${prefix}/${key}`, data),
+    read: (runRelativeKey) => store.read(`${sessionId}/${runRelativeKey}`),
+    write: (runRelativeKey, data) =>
+      store.write(`${sessionId}/${runRelativeKey}`, data),
   };
 }

--- a/src/harness/sample-result-store.ts
+++ b/src/harness/sample-result-store.ts
@@ -1,0 +1,69 @@
+import { Tag } from "effect/Context";
+
+import { z } from "../internal/zod";
+import { ChatMessageSchema, ScoreValue } from "./core";
+
+export const PersistedSampleOutcomeSchema = z.object({
+  sampleScore: z.object({
+    sampleId: z.string(),
+    epoch: z.number(),
+    score: z.object({
+      value: z.enum([
+        ScoreValue.Correct,
+        ScoreValue.Incorrect,
+        ScoreValue.Skipped,
+      ]),
+      answer: z.string().nullable(),
+      explanation: z.string(),
+    }),
+    messages: z.array(ChatMessageSchema).readonly().optional(),
+    responseItems: z
+      .array(z.record(z.string(), z.unknown()).readonly())
+      .readonly()
+      .optional(),
+    requestBody: z.record(z.string(), z.unknown()).readonly().optional(),
+    generationIds: z.array(z.string()).readonly().optional(),
+    metadata: z.record(z.string(), z.unknown()).readonly().optional(),
+    input: z.string().optional(),
+    target: z.string().optional(),
+  }),
+  usage: z
+    .object({
+      inputTokens: z.number().optional(),
+      outputTokens: z.number().optional(),
+      totalTokens: z.number().optional(),
+      reasoningTokens: z.number().optional(),
+      totalCost: z.number().optional(),
+      serverToolUse: z
+        .object({
+          webSearchRequests: z.number().optional(),
+          toolCallsRequested: z.number().optional(),
+          toolCallsExecuted: z.number().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  generationTimeMs: z.number().optional(),
+});
+
+export type PersistedSampleOutcome = z.infer<
+  typeof PersistedSampleOutcomeSchema
+>;
+
+export function sampleResultKey(sampleId: string, epoch: number): string {
+  return `${sampleId}/${epoch}`;
+}
+
+export interface SampleResultStoreService {
+  readonly read: (key: string) => Promise<PersistedSampleOutcome | null>;
+  readonly write: (key: string, data: PersistedSampleOutcome) => Promise<void>;
+}
+
+export class SampleResultStore extends Tag(
+  "@openrouter/bench-harness/sample-result-store"
+)<SampleResultStore, SampleResultStoreService>() {}
+
+export const NOOP_SAMPLE_RESULT_STORE: SampleResultStoreService = {
+  read: async () => null,
+  write: async () => {},
+};

--- a/src/harness/sample-result-store.ts
+++ b/src/harness/sample-result-store.ts
@@ -1,7 +1,7 @@
 import { Tag } from "effect/Context";
 
 import type { ZodShape } from "../internal/zod";
-import { z } from "../internal/zod";
+import { z, zInt } from "../internal/zod";
 import type {
   ModelUsage,
   ResponseItem,
@@ -55,7 +55,7 @@ const ResponseItemSchema: z.ZodType<ResponseItem> = z
 
 const SampleScoreSchema = z.object({
   sampleId: z.string(),
-  epoch: z.number(),
+  epoch: zInt(),
   score: ScoreSchema,
   messages: z.array(ChatMessageSchema).readonly().optional(),
   responseItems: z.array(ResponseItemSchema).readonly().optional(),

--- a/src/harness/sample-result-store.ts
+++ b/src/harness/sample-result-store.ts
@@ -104,3 +104,13 @@ export const NOOP_SAMPLE_RESULT_STORE: SampleResultStoreService = {
   read: async () => null,
   write: async () => {},
 };
+
+export function namespacedSampleResultStore(
+  prefix: string,
+  store: SampleResultStoreService
+): SampleResultStoreService {
+  return {
+    read: (key) => store.read(`${prefix}/${key}`),
+    write: (key, data) => store.write(`${prefix}/${key}`, data),
+  };
+}

--- a/src/harness/sample-result-store.ts
+++ b/src/harness/sample-result-store.ts
@@ -1,54 +1,91 @@
 import { Tag } from "effect/Context";
 
+import type { ZodShape } from "../internal/zod";
 import { z } from "../internal/zod";
+import type {
+  ModelUsage,
+  ResponseItem,
+  Score,
+  ScorerTrajectory,
+  ServerToolUseCounts,
+} from "./core";
 import { ChatMessageSchema, ScoreValue } from "./core";
+import type { SampleScore } from "./metric";
+
+export interface PersistedSampleOutcome {
+  readonly sampleScore: SampleScore;
+  readonly usage?: ModelUsage;
+  readonly generationTimeMs?: number;
+}
+
+const ScoreValueSchema = z.enum([
+  ScoreValue.Correct,
+  ScoreValue.Incorrect,
+  ScoreValue.Skipped,
+]);
+
+type VerifierLogTrajectory = Extract<
+  ScorerTrajectory,
+  { kind: "verifier_log" }
+>;
+type JudgeRunsTrajectory = Extract<ScorerTrajectory, { kind: "judge_runs" }>;
+
+const ScorerTrajectorySchema: z.ZodType<ScorerTrajectory> =
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("verifier_log"),
+      log: z.string(),
+    } satisfies ZodShape<VerifierLogTrajectory>),
+    z.object({
+      kind: z.literal("judge_runs"),
+      runs: z.array(z.unknown()).readonly(),
+    } satisfies ZodShape<JudgeRunsTrajectory>),
+  ]);
+
+const ScoreSchema = z.object({
+  value: ScoreValueSchema,
+  answer: z.string().nullable(),
+  explanation: z.string(),
+  trajectory: ScorerTrajectorySchema.optional(),
+} satisfies ZodShape<Score>);
+
+const ResponseItemSchema: z.ZodType<ResponseItem> = z
+  .record(z.string(), z.unknown())
+  .readonly();
+
+const SampleScoreSchema = z.object({
+  sampleId: z.string(),
+  epoch: z.number(),
+  score: ScoreSchema,
+  messages: z.array(ChatMessageSchema).readonly().optional(),
+  responseItems: z.array(ResponseItemSchema).readonly().optional(),
+  requestBody: z.record(z.string(), z.unknown()).readonly().optional(),
+  generationIds: z.array(z.string()).readonly().optional(),
+  metadata: z.record(z.string(), z.unknown()).readonly().optional(),
+  input: z.string().optional(),
+  target: z.string().optional(),
+} satisfies ZodShape<SampleScore>);
+
+const ServerToolUseCountsSchema = z.object({
+  webSearchRequests: z.number().optional(),
+  toolCallsRequested: z.number().optional(),
+  toolCallsExecuted: z.number().optional(),
+} satisfies ZodShape<ServerToolUseCounts>);
+
+const ModelUsageSchema = z.object({
+  inputTokens: z.number().optional(),
+  outputTokens: z.number().optional(),
+  totalTokens: z.number().optional(),
+  reasoningTokens: z.number().optional(),
+  totalCost: z.number().optional(),
+  serverToolUse: ServerToolUseCountsSchema.optional(),
+} satisfies ZodShape<ModelUsage>);
 
 export const PersistedSampleOutcomeSchema = z.object({
-  sampleScore: z.object({
-    sampleId: z.string(),
-    epoch: z.number(),
-    score: z.object({
-      value: z.enum([
-        ScoreValue.Correct,
-        ScoreValue.Incorrect,
-        ScoreValue.Skipped,
-      ]),
-      answer: z.string().nullable(),
-      explanation: z.string(),
-    }),
-    messages: z.array(ChatMessageSchema).readonly().optional(),
-    responseItems: z
-      .array(z.record(z.string(), z.unknown()).readonly())
-      .readonly()
-      .optional(),
-    requestBody: z.record(z.string(), z.unknown()).readonly().optional(),
-    generationIds: z.array(z.string()).readonly().optional(),
-    metadata: z.record(z.string(), z.unknown()).readonly().optional(),
-    input: z.string().optional(),
-    target: z.string().optional(),
-  }),
-  usage: z
-    .object({
-      inputTokens: z.number().optional(),
-      outputTokens: z.number().optional(),
-      totalTokens: z.number().optional(),
-      reasoningTokens: z.number().optional(),
-      totalCost: z.number().optional(),
-      serverToolUse: z
-        .object({
-          webSearchRequests: z.number().optional(),
-          toolCallsRequested: z.number().optional(),
-          toolCallsExecuted: z.number().optional(),
-        })
-        .optional(),
-    })
-    .optional(),
+  sampleScore: SampleScoreSchema,
+  usage: ModelUsageSchema.optional(),
   generationTimeMs: z.number().optional(),
-});
-
-export type PersistedSampleOutcome = z.infer<
-  typeof PersistedSampleOutcomeSchema
->;
+} satisfies ZodShape<PersistedSampleOutcome>);
 
 export function sampleResultKey(sampleId: string, epoch: number): string {
   return `${sampleId}/${epoch}`;

--- a/src/harness/sample-result-store.ts
+++ b/src/harness/sample-result-store.ts
@@ -92,7 +92,7 @@ export function sampleResultKey(sampleId: string, epoch: number): string {
 }
 
 export interface SampleResultStoreService {
-  readonly read: (key: string) => Promise<PersistedSampleOutcome | null>;
+  readonly read: (key: string) => Promise<unknown>;
   readonly write: (key: string, data: PersistedSampleOutcome) => Promise<void>;
 }
 

--- a/src/internal/zod.ts
+++ b/src/internal/zod.ts
@@ -5,7 +5,7 @@ import { Either } from "./either";
 export { z };
 
 export type ZodShape<T> = {
-  [key in keyof T]: ZodType<T[key]>;
+  [key in keyof Required<T>]: ZodType<T[key]>;
 };
 
 export function parseSchema<Input, Output>(

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -35,6 +35,7 @@ import type { RunResult, RunConfig } from "../harness/run";
 import { runBenchmark } from "../harness/run";
 import type { SampleResultStoreService } from "../harness/sample-result-store";
 import {
+  namespacedSampleResultStore,
   NOOP_SAMPLE_RESULT_STORE,
   SampleResultStore,
 } from "../harness/sample-result-store";
@@ -96,7 +97,9 @@ export function runBenchmarkById(
   );
   const sampleResultLayer = layerSucceed(
     SampleResultStore,
-    input.sampleResultStore ?? NOOP_SAMPLE_RESULT_STORE
+    input.sampleResultStore === undefined
+      ? NOOP_SAMPLE_RESULT_STORE
+      : namespacedSampleResultStore(input.sessionId, input.sampleResultStore)
   );
   const model = modelFromConfig(input.benchmarkConfig);
   const runConfig: RunConfig = {

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -22,6 +22,11 @@ import {
 } from "../harness/progress";
 import type { RunResult, RunConfig } from "../harness/run";
 import { runBenchmark } from "../harness/run";
+import type { SampleResultStoreService } from "../harness/sample-result-store";
+import {
+  NOOP_SAMPLE_RESULT_STORE,
+  SampleResultStore,
+} from "../harness/sample-result-store";
 import { runHarnessPromise } from "../internal/effect-logger";
 import type { AsyncEither } from "../internal/either";
 import { Either } from "../internal/either";
@@ -50,6 +55,7 @@ export interface RunBenchmarkInput {
   readonly datasetRetry?: RetryConfig;
   readonly progressReporter?: ProgressReporterService;
   readonly checkpointStore?: CheckpointStoreService;
+  readonly sampleResultStore?: SampleResultStoreService;
   readonly abortSignal?: AbortSignal;
   readonly resultStore?: ResultStoreService;
   readonly maxOutputTokensCeiling?: number;
@@ -91,6 +97,10 @@ export function runBenchmarkById(
     CheckpointStore,
     input.checkpointStore ?? NOOP_CHECKPOINT_STORE
   );
+  const sampleResultLayer = layerSucceed(
+    SampleResultStore,
+    input.sampleResultStore ?? NOOP_SAMPLE_RESULT_STORE
+  );
   const model = modelFromConfig(input.benchmarkConfig);
   const runConfig: RunConfig = {
     epochs: input.epochs,
@@ -122,6 +132,7 @@ export function runBenchmarkById(
     fullBenchmarkLayer,
     progressLayer,
     checkpointLayer,
+    sampleResultLayer,
     resolverLayer
   );
   const runOpts =

--- a/test/helpers/noop-progress-layer.ts
+++ b/test/helpers/noop-progress-layer.ts
@@ -6,6 +6,10 @@ import {
   NOOP_PROGRESS_REPORTER,
   ProgressReporter,
 } from "../../src/harness/progress";
+import {
+  NOOP_SAMPLE_RESULT_STORE,
+  SampleResultStore,
+} from "../../src/harness/sample-result-store";
 
 export const noopProgressLayer = layerSucceed(
   ProgressReporter,
@@ -15,4 +19,9 @@ export const noopProgressLayer = layerSucceed(
 export const noopCheckpointLayer = layerSucceed(
   CheckpointStore,
   NOOP_CHECKPOINT_STORE
+);
+
+export const noopSampleResultLayer = layerSucceed(
+  SampleResultStore,
+  NOOP_SAMPLE_RESULT_STORE
 );


### PR DESCRIPTION
## TL;DR

Adds a `SampleResultStore` Effect service to the shared harness: completed per-sample outcomes are persisted (keyed by `sampleId/epoch`) and replayed on a re-run, so an interrupted run (e.g. a Temporal Activity retry after a worker kill) only re-executes samples that were actually in flight.

## What changed?

- New `src/harness/sample-result-store.ts`: `PersistedSampleOutcomeSchema` (Zod), `SampleResultStore` Tag, `SampleResultStoreService` interface, `sampleResultKey(sampleId, epoch)`, and `NOOP_SAMPLE_RESULT_STORE`.
- `src/harness/run.ts`: the sample/epoch stream now goes through `evaluateOneResumable` — read persisted outcome → return it if present, else `evaluateOne` then best-effort `write`. Read failure = cache miss; write failure never fails the run — but both are now logged via `wLog` (`Failed to read persisted sample outcome…` / `Failed to persist sample outcome…`) instead of being silently swallowed.
- `src/runner/run-by-id.ts`: `RunBenchmarkInput` gains optional `sampleResultStore`; the layer defaults to the noop store.
- `package.json`: exports `./sample-result-store`.
- Test helpers/layers updated with `noopSampleResultLayer`; branch merged up to current `main` (post `run-by-id` refactor).

## Why?

In the openrouter-web monorepo (which vendors this repo as a subtree), Temporal Cloud's Worker Controller scale-in kills Cloud Run workers mid-Activity; heartbeat-timeout retries currently restart every sample from scratch. Wiring a GCS-backed store happens downstream: OpenRouterTeam/openrouter-web#35767.

This write-through design was chosen over abort-time aggregate flushing (#52, now closed) after an empirical head-to-head: on hard SIGKILL, write-through preserved 8/13 completed samples vs 0 for the abort-flush approach; clean aborts and repeated interruptions were parity with exact-baseline aggregates. See the comparison summary on #52.

Scope guarding (epochs/range) is intentionally not needed here: outcomes are keyed per `sampleId/epoch` and the store instance is provided per run/session downstream, so a persisted outcome is only ever reused for the identical sample-epoch.

## How to test

- `bun test src/harness/run.test.ts src/harness/sample-result-resume.test.ts` — fresh run, full resume (0 solver/scorer calls), partial resume (only missing keys evaluated), and throwing-store behavior (run completes, all evaluated, failures logged).
- Downstream: provide a `SampleResultStoreService` in `runBenchmarkById`, run once, interrupt, run again with the same store — completed samples return without invoking solver/scorer.

## Benchmark impact

No score changes with the default noop store. With a persistent store, replayed samples reuse their recorded score/usage instead of re-evaluating, which is the intended behavior for Activity retries.

## Reviewer focus

- `PersistedSampleOutcomeSchema` vs `EvalOutcome` compatibility (usage/generation-id accounting on replay).
- Best-effort semantics (`catchAll` + `wLog`) around read/write.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [ ] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed

Link to Devin session: https://openrouter.devinenterprise.com/sessions/4899435489c14bba8242921472c31807
Requested by: @jamespsterling