### PR TITLE
fix(agent-cli): install ori at sandbox startup instead of image build

### DIFF
--- a/src/benchmarks/agent-cli/harness.ts
+++ b/src/benchmarks/agent-cli/harness.ts
@@ -28,6 +28,9 @@ export interface OriRunScriptOptions {
 
 export interface OriImageStepsOptions {
   readonly agentPackage: string;
+}
+
+export interface OriBootstrapOptions {
   readonly oriInstallUrl: string;
   readonly oriChannel: OriChannel;
 }
@@ -51,26 +54,36 @@ export interface OriHarnessDef {
   readonly binaryName: string;
   readonly remoteLogPath: string;
   readonly imageBuildSteps: (options: OriImageStepsOptions) => string[];
+  readonly buildBootstrapScript: (options: OriBootstrapOptions) => string;
   readonly buildRunScript: (options: OriRunScriptOptions) => string;
   readonly parseRun: (stdout: string) => OriAgentRun;
 }
 
 function buildImageSteps(opts: {
   agentPackage: string;
-  oriInstallUrl: string;
-  oriChannel: OriChannel;
   binaryName: string;
 }): string[] {
-  const channelPrefix =
-    opts.oriChannel === "stable" ? "" : `ORI_CHANNEL=${opts.oriChannel} `;
   return [
     "RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git",
     "ENV NVM_DIR=/root/.nvm",
     `RUN curl -o- ${NVM_INSTALL_URL} | bash`,
     `RUN . /root/.nvm/nvm.sh && nvm install ${NODE_VERSION} && npm install -g ${opts.agentPackage} && ln -sf $(which ${opts.binaryName}) /usr/local/bin/${opts.binaryName} && ln -sf $(which node) /usr/local/bin/node && ln -sf $(which npm) /usr/local/bin/npm`,
-    `RUN curl -fsSL ${opts.oriInstallUrl} | ${channelPrefix}ORI_INSTALL_DIR=${ORI_INSTALL_DIR} bash`,
-    `RUN ori --version && ${opts.binaryName} --version`,
+    `RUN ${opts.binaryName} --version`,
   ];
+}
+
+function buildBootstrapScript(opts: {
+  oriInstallUrl: string;
+  oriChannel: OriChannel;
+  binaryName: string;
+}): string {
+  const channelPrefix =
+    opts.oriChannel === "stable" ? "" : `ORI_CHANNEL=${opts.oriChannel} `;
+  return [
+    "set -euo pipefail",
+    `curl -fsSL ${opts.oriInstallUrl} | ${channelPrefix}ORI_INSTALL_DIR=${ORI_INSTALL_DIR} bash`,
+    `ori --version && ${opts.binaryName} --version`,
+  ].join("\n");
 }
 
 function numberField(source: unknown, key: string): number {
@@ -253,6 +266,8 @@ const CLAUDE_HARNESS: OriHarnessDef = {
   remoteLogPath: "/logs/agent/claude.txt",
   imageBuildSteps: (options) =>
     buildImageSteps({ ...options, binaryName: "claude" }),
+  buildBootstrapScript: (options) =>
+    buildBootstrapScript({ ...options, binaryName: "claude" }),
   buildRunScript: (options) =>
     [
       "set -euo pipefail",
@@ -292,6 +307,8 @@ const ORI_PI_HARNESS: OriHarnessDef = {
   remoteLogPath: "/logs/agent/pi.txt",
   imageBuildSteps: (options) =>
     buildImageSteps({ ...options, binaryName: "pi" }),
+  buildBootstrapScript: (options) =>
+    buildBootstrapScript({ ...options, binaryName: "pi" }),
   buildRunScript: (options) =>
     [
       "set -euo pipefail",

--- a/src/benchmarks/agent-cli/runner.ts
+++ b/src/benchmarks/agent-cli/runner.ts
@@ -28,6 +28,10 @@ export const AGENT_EXEC_UNAVAILABLE_EXIT = -1;
 
 const LOG_RECOVERY_TIMEOUT_MS = 60000;
 
+const ORI_BOOTSTRAP_TIMEOUT_MS = 300000;
+
+const BOOTSTRAP_DETAIL_TAIL_CHARS = 1000;
+
 function recoverAfterExecFailure(
   session: SandboxSessionInstance,
   harness: OriHarnessDef,
@@ -145,8 +149,30 @@ export function agentImageBuildSteps(
 ): string[] {
   return harness.imageBuildSteps({
     agentPackage: opts.agentPackage ?? harness.defaultPackage,
+  });
+}
+
+export function installOri(input: {
+  readonly session: SandboxSessionInstance;
+  readonly harness: OriHarnessDef;
+  readonly opts: AgentCliOpts;
+}): Effect<void, SolverError> {
+  const { session, harness, opts } = input;
+  const script = harness.buildBootstrapScript({
     oriInstallUrl: opts.oriInstallUrl ?? DEFAULT_ORI_INSTALL_URL,
     oriChannel: opts.oriChannel ?? DEFAULT_ORI_CHANNEL,
+  });
+  return gen(function* () {
+    const run = yield* session.exec(
+      ["bash", "-c", script],
+      {},
+      ORI_BOOTSTRAP_TIMEOUT_MS
+    );
+    if (run.exitCode !== 0) {
+      return yield* new SolverError({
+        message: `Failed to install ori in the sandbox (exit ${run.exitCode}): ${`${run.stdout}\n${run.stderr}`.slice(-BOOTSTRAP_DETAIL_TAIL_CHARS)}`,
+      });
+    }
   });
 }
 
@@ -178,6 +204,7 @@ export function runAgentCli(input: {
         message: `sessionId contains a control character, which ori replaces with a fresh UUID and silently detaches the run from its generations (id=${JSON.stringify(opts.sessionId)})`,
       });
     }
+    yield* installOri({ session, harness, opts });
     const startedAt = yield* currentTimeMillis;
     const outcome = yield* session
       .exec(["bash", "-c", script], buildAgentCliEnv(opts), timeoutMs)

--- a/src/benchmarks/swe-atlas/solver.test.ts
+++ b/src/benchmarks/swe-atlas/solver.test.ts
@@ -300,7 +300,7 @@ describe("swe-atlas claude agent via ori", () => {
     expect(appended).toContain("Be terse.");
   });
 
-  it("installs the agent into the task image", async () => {
+  it("installs the agent into the task image and ori into the sandbox", async () => {
     const log: ExecLog = { calls: [], creates: [] };
     await runSweAtlasSolver(
       scriptedModel(newConfigRecord()),
@@ -309,7 +309,11 @@ describe("swe-atlas claude agent via ori", () => {
     );
     const steps = log.creates[0]?.imageBuildSteps ?? [];
     expect(steps.join("\n")).toContain("@anthropic-ai/claude-code");
-    expect(steps.join("\n")).toContain("ORI_INSTALL_DIR=/usr/local/bin");
+    expect(steps.join("\n")).not.toContain("ORI_INSTALL_DIR");
+    const installCall = log.calls.find((c) =>
+      c.argv.join(" ").includes("ORI_INSTALL_DIR=/usr/local/bin")
+    );
+    expect(installCall).toBeDefined();
   });
 
   it("carries agent usage, generation ids and counters into the result", async () => {

--- a/src/benchmarks/terminal-bench/ori-solver.test.ts
+++ b/src/benchmarks/terminal-bench/ori-solver.test.ts
@@ -3,14 +3,24 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { either, gen, provide, runPromise } from "effect/Effect";
+import { failureOption } from "effect/Cause";
+import {
+  either,
+  gen,
+  provide,
+  runPromise,
+  runPromiseExit,
+} from "effect/Effect";
+import type { Exit } from "effect/Exit";
 import type { Layer } from "effect/Layer";
 import {
   effect as layerEffect,
   mergeAll as layerMergeAll,
   provide as layerProvide,
 } from "effect/Layer";
+import { getOrThrow } from "effect/Option";
 
+import { assertFailure } from "../../../test/helpers/exit-asserts";
 import {
   noopProgressLayer,
   noopCheckpointLayer,
@@ -19,7 +29,12 @@ import {
   makeTerminalBenchFakeSandboxLayer,
   SandboxSession,
 } from "../../../test/helpers/terminal-bench-sandbox";
-import type { Sample, TaskState } from "../../harness/core";
+import type {
+  ModelError,
+  Sample,
+  SolverError,
+  TaskState,
+} from "../../harness/core";
 import { initialTaskState, ScoreValue } from "../../harness/core";
 import { Solver } from "../../harness/solver";
 import {
@@ -105,6 +120,34 @@ async function runOriSolver(
     })
   );
   return runPromise(
+    gen(function* () {
+      const solver = yield* Solver;
+      return yield* solver(sampleState());
+    }).pipe(
+      provide(
+        layerMergeAll(
+          solverLayer.pipe(layerProvide(sandboxLayer)),
+          noopProgressLayer,
+          noopCheckpointLayer
+        )
+      )
+    )
+  );
+}
+
+async function runOriSolverExit(
+  sandboxLayer: Layer<SandboxSession>,
+  opts: OriSolverOpts = SOLVER_OPTS
+): Promise<Exit<TaskState, SolverError | ModelError>> {
+  const solverLayer = layerEffect(Solver)(
+    gen(function* () {
+      const sessionFactory = yield* SandboxSession;
+      return Solver.of(
+        oriSolver(sessionFactory, opts, getOriHarness("claude"))
+      );
+    })
+  );
+  return runPromiseExit(
     gen(function* () {
       const solver = yield* Solver;
       return yield* solver(sampleState());
@@ -554,25 +597,72 @@ describe("terminal-bench ori solver", () => {
     expect(finalState.sample.metadata?.["agentToolCalls"]).toBe(2);
   });
 
-  it("installs ori and the claude package in the image", () => {
+  it("installs the claude package in the image and leaves ori out of it", () => {
     const steps = ORI_HARNESSES.claude.imageBuildSteps({
       agentPackage: DEFAULT_CLAUDE_PACKAGE,
-      oriInstallUrl: "https://openrouter.ai/labs/ori/install.sh",
-      oriChannel: "stable",
     });
     expect(steps.join("\n")).toContain(DEFAULT_CLAUDE_PACKAGE);
-    expect(steps.join("\n")).toContain("ORI_INSTALL_DIR=/usr/local/bin bash");
-    expect(steps.at(-1)).toBe("RUN ori --version && claude --version");
+    expect(steps.join("\n")).not.toContain("ORI_INSTALL_DIR");
+    expect(steps.join("\n")).not.toContain("ori --version");
+    expect(steps.at(-1)).toBe("RUN claude --version");
   });
 
   it("honors an agent package override", () => {
     const steps = ORI_HARNESSES.claude.imageBuildSteps({
       agentPackage: "@anthropic-ai/claude-code@1.2.3",
-      oriInstallUrl: "https://openrouter.ai/labs/ori/install.sh",
-      oriChannel: "stable",
     });
     expect(steps.join("\n")).toContain("@anthropic-ai/claude-code@1.2.3");
     expect(steps.join("\n")).not.toContain("claude-code@latest");
+  });
+
+  it("installs ori in the running sandbox on the requested channel", async () => {
+    const oriInstallScripts: string[] = [];
+    await runOriSolver(
+      makeTerminalBenchFakeSandboxLayer({
+        reward: 1,
+        agentEventStream: CLAUDE_STREAM,
+        agentExitCode: 0,
+        oriInstallScripts,
+      }),
+      { ...SOLVER_OPTS, oriChannel: "alpha" }
+    );
+    expect(oriInstallScripts).toHaveLength(1);
+    expect(oriInstallScripts[0]).toContain(
+      "curl -fsSL https://openrouter.ai/labs/ori/install.sh"
+    );
+    expect(oriInstallScripts[0]).toContain(
+      "ORI_CHANNEL=alpha ORI_INSTALL_DIR=/usr/local/bin bash"
+    );
+    expect(oriInstallScripts[0]).toContain("ori --version && claude --version");
+  });
+
+  it("omits the channel override when ori comes from stable", () => {
+    const script = ORI_HARNESSES.claude.buildBootstrapScript({
+      oriInstallUrl: "https://openrouter.ai/labs/ori/install.sh",
+      oriChannel: "stable",
+    });
+    expect(script).toContain("ORI_INSTALL_DIR=/usr/local/bin bash");
+    expect(script).not.toContain("ORI_CHANNEL");
+  });
+
+  it("fails the sample when ori cannot be installed and never runs the agent", async () => {
+    const execCalls: ExecCalls = [];
+    const exit = await runOriSolverExit(
+      makeTerminalBenchFakeSandboxLayer({
+        reward: 1,
+        agentEventStream: CLAUDE_STREAM,
+        agentExitCode: 0,
+        oriInstallExitCode: 1,
+        execCalls,
+      })
+    );
+    assertFailure(exit);
+    expect(getOrThrow(failureOption(exit.cause)).message).toContain(
+      "Failed to install ori"
+    );
+    expect(
+      execCalls.some((call) => call.argv.join(" ").includes("ori claude"))
+    ).toBe(false);
   });
 });
 
@@ -851,22 +941,21 @@ describe("terminal-bench pi via ori", () => {
     expect(outcome._tag).toBe("Left");
   });
 
-  it("installs pi and ori into the image", () => {
+  it("installs pi into the image", () => {
     const steps = ORI_HARNESSES.pi.imageBuildSteps({
       agentPackage: "@earendil-works/pi-coding-agent@latest",
-      oriInstallUrl: "https://openrouter.ai/labs/ori/install.sh",
-      oriChannel: "stable",
     });
     expect(steps.join("\n")).toContain("@earendil-works/pi-coding-agent");
-    expect(steps.at(-1)).toBe("RUN ori --version && pi --version");
+    expect(steps.join("\n")).not.toContain("ORI_INSTALL_DIR");
+    expect(steps.at(-1)).toBe("RUN pi --version");
   });
 
   it("can install ori from the alpha channel when asked", () => {
-    const steps = ORI_HARNESSES.pi.imageBuildSteps({
-      agentPackage: "pi@1",
+    const script = ORI_HARNESSES.pi.buildBootstrapScript({
       oriInstallUrl: "https://openrouter.ai/labs/ori/install.sh",
       oriChannel: "alpha",
     });
-    expect(steps.join("\n")).toContain("ORI_CHANNEL=alpha");
+    expect(script).toContain("ORI_CHANNEL=alpha");
+    expect(script).toContain("ori --version && pi --version");
   });
 });

--- a/test/helpers/terminal-bench-sandbox.ts
+++ b/test/helpers/terminal-bench-sandbox.ts
@@ -25,9 +25,13 @@ export interface FakeTerminalBenchBehavior {
   readonly uploadedDirs?: { localDir: string; remoteDir: string }[];
   readonly failAgentExec?: boolean;
   readonly recoveredLog?: string;
+  readonly oriInstallScripts?: string[];
+  readonly oriInstallExitCode?: number;
 }
 
 const AGENT_COMMAND_MARKERS = ["pi --print", "pi ", "ori claude"] as const;
+
+const ORI_INSTALL_MARKER = "ORI_INSTALL_DIR=" as const;
 
 function isAgentCommand(joined: string): boolean {
   return AGENT_COMMAND_MARKERS.some((marker) => joined.includes(marker));
@@ -44,8 +48,16 @@ export function makeTerminalBenchFakeSandboxLayer(
       behavior.uploadedDirs?.push({ localDir, remoteDir });
     },
     execHandler: (argv, env, timeoutMs): ExecResult => {
-      behavior.execCalls?.push({ argv: [...argv], env: { ...env }, timeoutMs });
       const joined = argv.join(" ");
+      if (joined.includes(ORI_INSTALL_MARKER)) {
+        behavior.oriInstallScripts?.push(joined);
+        return {
+          stdout: "",
+          stderr: "",
+          exitCode: behavior.oriInstallExitCode ?? 0,
+        };
+      }
+      behavior.execCalls?.push({ argv: [...argv], env: { ...env }, timeoutMs });
       if (joined.startsWith("cat /logs/agent/")) {
         return {
           stdout: behavior.recoveredLog ?? "",


### PR DESCRIPTION
## TL;DR

Move the `ori` install out of the Modal image build and into the running sandbox, so agent-cli runs get the ori release they asked for instead of a crashed build or a stale cached layer.

## What changed?

- `OriHarnessDef` gains `buildBootstrapScript`, which produces the runtime install script. `imageBuildSteps` now only takes `agentPackage` and no longer installs or verifies ori.
- `runAgentCli` calls the new `installOri` before launching `ori pi` / `ori claude`, failing the sample with a `SolverError` (including the tail of stdout/stderr) when the install fails, so the agent never runs against a missing binary.
- `oriChannel` and `oriInstallUrl` keep their meaning: stable omits the channel override, non-stable prefixes `ORI_CHANNEL=`, and `ORI_INSTALL_DIR` is unchanged.

```
set -euo pipefail
curl -fsSL <oriInstallUrl> | [ORI_CHANNEL=<channel> ]ORI_INSTALL_DIR=/usr/local/bin bash
ori --version && pi --version
```

## Why?

Two failure modes made it impossible to run a benchmark against a specific ori release, tracked in [ECO-3411](https://linear.app/openrouter/issue/ECO-3411):

1. A fresh image build fails. ori ships as a Bun single-file executable and dies with `SyntaxError: Invalid character: '\0'` when run from a Modal image layer, inside `install.sh`'s own `ori --version` check, so no `oriChannel`/`oriInstallUrl` setting works around it. Reproduced with direct Modal probes on both channels.
2. When the install command is byte-identical to a previous run's, Modal reuses the cached layer, so the sandbox silently runs whatever ori version was baked months ago. A stable-channel run intended to exercise ori 0.10.0 sent every request to `/api/v1/responses`, the pre-fix path.

Installing at runtime succeeds in both cases (verified in a live Modal sandbox) and makes the ori version a function of the run config rather than of layer cache state.

## How to test

Launch a terminal-bench run through the agent-cli harness with `agent: "pi"` and `oriChannel: "stable"`, then confirm from the sandbox log that the bootstrap step ran and reported the current stable ori version, and from generation metadata that requests go to the completions path rather than `/api/v1/responses`.

## Benchmark impact

No solver, scorer, prompt, or dataset change. Scores can move for agent-cli runs only because they now execute the requested ori version instead of a cached one; runs that previously produced zero tokens due to the image-build crash will now execute.

## Reviewer focus

- Placement of `installOri` inside `runAgentCli` — it covers terminal-bench, swe-atlas, and deep-swe, which all go through that path.
- Install cost is now per sandbox rather than per image; the bootstrap timeout is 300s.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/89c9f7842c2d4737b841fab397ccdd60
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->