### PR TITLE
feat: let host applications inject their own benchmark into the runner

### DIFF
--- a/src/benchmarks/benchmark-config.test.ts
+++ b/src/benchmarks/benchmark-config.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+
+import { assertLeft, assertRight } from "../internal/testing";
+import { parseSchema } from "../internal/zod";
+import {
+  BenchmarkRunConfigSchema,
+  HostBenchmarkRunConfigSchema,
+  isHostBenchmarkConfig,
+  isModelBenchmarkConfig,
+  isSearchBenchmarkConfig,
+  NativeBenchmarkRunConfigSchema,
+} from "./benchmark-config";
+
+describe("benchmark config", () => {
+  it("keeps native configs precise while parsing them through the native schema", () => {
+    const result = parseSchema(NativeBenchmarkRunConfigSchema, {
+      benchmarkId: "search_hle",
+      model: "openai/gpt-5.4",
+    });
+
+    assertRight(result);
+    expect(result.right.benchmarkId).toBe("search_hle");
+    expect(result.right.lane).toEqual({
+      webSearch: "server-tool",
+      engine: "auto",
+    });
+    expect(isSearchBenchmarkConfig(result.right)).toBe(true);
+    expect(isModelBenchmarkConfig(result.right)).toBe(true);
+  });
+
+  it("does not let malformed native configs fall through to the host variant", () => {
+    const result = parseSchema(BenchmarkRunConfigSchema, {
+      benchmarkId: "gpqa_diamond",
+      model: 42,
+    });
+
+    assertLeft(result);
+  });
+
+  it("parses host configs with opaque options", () => {
+    const result = parseSchema(BenchmarkRunConfigSchema, {
+      benchmarkId: "host_benchmark",
+      model: "host/model",
+      options: {
+        subsets: ["all"],
+        customFlag: true,
+      },
+    });
+
+    assertRight(result);
+    expect(result.right).toEqual({
+      benchmarkId: "host_benchmark",
+      model: "host/model",
+      options: {
+        subsets: ["all"],
+        customFlag: true,
+      },
+    });
+    expect(isHostBenchmarkConfig(result.right)).toBe(true);
+    expect(isModelBenchmarkConfig(result.right)).toBe(true);
+    expect(isSearchBenchmarkConfig(result.right)).toBe(false);
+  });
+
+  it("defaults host options to an empty object", () => {
+    const result = parseSchema(HostBenchmarkRunConfigSchema, {
+      benchmarkId: "host_benchmark",
+      model: "host/model",
+    });
+
+    assertRight(result);
+    expect(result.right.options).toEqual({});
+  });
+
+  it("rejects a host config that reuses a native benchmark id", () => {
+    const result = parseSchema(HostBenchmarkRunConfigSchema, {
+      benchmarkId: "gpqa_diamond",
+      model: "host/model",
+      options: { subsets: ["all"] },
+    });
+
+    assertLeft(result);
+  });
+});

--- a/src/benchmarks/benchmark-config.ts
+++ b/src/benchmarks/benchmark-config.ts
@@ -318,43 +318,42 @@ export type SearchBenchmarkConfig =
   | DsqaBenchmarkConfig
   | WideSearchBenchmarkConfig;
 
-export const BenchmarkRunConfigSchema = z.discriminatedUnion("benchmarkId", [
-  GpqaBenchmarkConfigSchema,
-  MmluProBenchmarkConfigSchema,
-  TauBenchAirlineConfigSchema,
-  Tau3BenchBankingConfigSchema,
-  MmmuProVisionBenchmarkConfigSchema,
-  TerminalBenchConfigSchema,
-  DracoBenchmarkConfigSchema,
-  IfStructBenchmarkConfigSchema,
-  SweAtlasQaConfigSchema,
-  SweAtlasTwConfigSchema,
-  SweAtlasRfConfigSchema,
-  DeepSweConfigSchema,
-  WandrConfigSchema,
-  BrowseCompBenchmarkConfigSchema,
-  HleBenchmarkConfigSchema,
-  DsqaBenchmarkConfigSchema,
-  WideSearchBenchmarkConfigSchema,
-  VgiBenchmarkConfigSchema,
-]);
+export const NativeBenchmarkRunConfigSchema = z.discriminatedUnion(
+  "benchmarkId",
+  [
+    GpqaBenchmarkConfigSchema,
+    MmluProBenchmarkConfigSchema,
+    TauBenchAirlineConfigSchema,
+    Tau3BenchBankingConfigSchema,
+    MmmuProVisionBenchmarkConfigSchema,
+    TerminalBenchConfigSchema,
+    DracoBenchmarkConfigSchema,
+    IfStructBenchmarkConfigSchema,
+    SweAtlasQaConfigSchema,
+    SweAtlasTwConfigSchema,
+    SweAtlasRfConfigSchema,
+    DeepSweConfigSchema,
+    WandrConfigSchema,
+    BrowseCompBenchmarkConfigSchema,
+    HleBenchmarkConfigSchema,
+    DsqaBenchmarkConfigSchema,
+    WideSearchBenchmarkConfigSchema,
+    VgiBenchmarkConfigSchema,
+  ]
+);
 
-export type BenchmarkRunConfig = z.infer<typeof BenchmarkRunConfigSchema>;
+export type NativeBenchmarkRunConfig = z.infer<
+  typeof NativeBenchmarkRunConfigSchema
+>;
 
-export type ModelBenchmarkConfig = Extract<
-  BenchmarkRunConfig,
+type NativeModelBenchmarkConfig = Extract<
+  NativeBenchmarkRunConfig,
   {
     model: string;
   }
 >;
 
-export type ModelBenchmarkId = ModelBenchmarkConfig["benchmarkId"];
-
-export function isModelBenchmarkConfig(
-  config: BenchmarkRunConfig
-): config is ModelBenchmarkConfig {
-  return "model" in config;
-}
+export type ModelBenchmarkId = NativeModelBenchmarkConfig["benchmarkId"];
 
 export const BENCHMARK_OPTIONS_SCHEMAS = {
   gpqa_diamond: GpqaOptionsSchema,
@@ -375,6 +374,55 @@ export const BENCHMARK_OPTIONS_SCHEMAS = {
   search_widesearch: SearchBenchmarkOptionsSchema,
   vgi_bench: VgiBenchOptionsSchema,
 } as const satisfies Record<ModelBenchmarkId, z.ZodObject<z.ZodRawShape>>;
+
+const NATIVE_BENCHMARK_ID_SET: ReadonlySet<string> = new Set(
+  NativeBenchmarkRunConfigSchema.options.flatMap((schema) => {
+    const benchmarkId = schema.shape.benchmarkId;
+    return benchmarkId instanceof z.ZodLiteral ? [benchmarkId.value] : [];
+  })
+);
+
+const HostBenchmarkIdSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (benchmarkId) => !NATIVE_BENCHMARK_ID_SET.has(benchmarkId),
+    "Host benchmark ids must not reuse native benchmark ids"
+  )
+  .brand<"HostBenchmarkId">();
+
+export const HostBenchmarkRunConfigSchema = z.object({
+  benchmarkId: HostBenchmarkIdSchema,
+  ...ModelBenchmarkBaseSchema.shape,
+  options: z.record(z.string(), z.unknown()).default({}),
+});
+
+export type HostBenchmarkRunConfig = z.infer<
+  typeof HostBenchmarkRunConfigSchema
+>;
+
+export const BenchmarkRunConfigSchema = z.union([
+  NativeBenchmarkRunConfigSchema,
+  HostBenchmarkRunConfigSchema,
+]);
+
+export type BenchmarkRunConfig = z.infer<typeof BenchmarkRunConfigSchema>;
+
+export type ModelBenchmarkConfig =
+  | NativeModelBenchmarkConfig
+  | HostBenchmarkRunConfig;
+
+export function isModelBenchmarkConfig(
+  config: BenchmarkRunConfig
+): config is ModelBenchmarkConfig {
+  return "model" in config;
+}
+
+export function isHostBenchmarkConfig(
+  config: BenchmarkRunConfig
+): config is HostBenchmarkRunConfig {
+  return !NATIVE_BENCHMARK_ID_SET.has(config.benchmarkId);
+}
 
 const SEARCH_BENCHMARK_ID_SET: ReadonlySet<string> = new Set([
   "search_browsecomp",

--- a/src/benchmarks/benchmark-config.ts
+++ b/src/benchmarks/benchmark-config.ts
@@ -388,8 +388,7 @@ const HostBenchmarkIdSchema = z
   .refine(
     (benchmarkId) => !NATIVE_BENCHMARK_ID_SET.has(benchmarkId),
     "Host benchmark ids must not reuse native benchmark ids"
-  )
-  .brand<"HostBenchmarkId">();
+  );
 
 export const HostBenchmarkRunConfigSchema = z.object({
   benchmarkId: HostBenchmarkIdSchema,
@@ -418,10 +417,16 @@ export function isModelBenchmarkConfig(
   return "model" in config;
 }
 
+export function isNativeBenchmarkConfig(
+  config: BenchmarkRunConfig
+): config is NativeBenchmarkRunConfig {
+  return NATIVE_BENCHMARK_ID_SET.has(config.benchmarkId);
+}
+
 export function isHostBenchmarkConfig(
   config: BenchmarkRunConfig
 ): config is HostBenchmarkRunConfig {
-  return !NATIVE_BENCHMARK_ID_SET.has(config.benchmarkId);
+  return !isNativeBenchmarkConfig(config);
 }
 
 const SEARCH_BENCHMARK_ID_SET: ReadonlySet<string> = new Set([

--- a/src/benchmarks/types.ts
+++ b/src/benchmarks/types.ts
@@ -8,12 +8,17 @@ import type { Scorer } from "../harness/scorer";
 import type { Solver } from "../harness/solver";
 import type { ResponsesModel } from "../providers/responses-model";
 import type { RetryConfig } from "../runtime/retry";
-import type { BenchmarkRunConfig } from "./benchmark-config";
+import type {
+  BenchmarkRunConfig,
+  NativeBenchmarkRunConfig,
+} from "./benchmark-config";
 
-export interface BenchmarkRunInput {
+export interface BenchmarkRunInput<
+  Config extends BenchmarkRunConfig = NativeBenchmarkRunConfig,
+> {
   readonly apiKey: string;
   readonly baseUrl?: string;
-  readonly benchmarkConfig: BenchmarkRunConfig;
+  readonly benchmarkConfig: Config;
   readonly sessionId: string;
   readonly datasetRetry?: RetryConfig;
   readonly modelRetry?: RetryConfig;
@@ -31,12 +36,15 @@ export interface BenchmarkPrimaryScore {
   readonly weight: number;
 }
 
-export interface Benchmark {
+export interface Benchmark<
+  Config extends BenchmarkRunConfig = NativeBenchmarkRunConfig,
+> {
   readonly id: string;
   readonly makeDatasetLayer: (retryConfig?: RetryConfig) => Layer<Dataset>;
-  readonly makeLayer: (
-    input: BenchmarkRunInput
-  ) => Layer<Dataset | Solver | Scorer, Error, HttpClient.HttpClient>;
+  // oxlint-disable-next-line typescript/method-signature-style
+  makeLayer(
+    input: BenchmarkRunInput<Config>
+  ): Layer<Dataset | Solver | Scorer, Error, HttpClient.HttpClient>;
   readonly temperature: number;
   readonly defaultEpochs: number;
   readonly degradeSolverErrors?: boolean;

--- a/src/benchmarks/types.ts
+++ b/src/benchmarks/types.ts
@@ -41,10 +41,9 @@ export interface Benchmark<
 > {
   readonly id: string;
   readonly makeDatasetLayer: (retryConfig?: RetryConfig) => Layer<Dataset>;
-  // oxlint-disable-next-line typescript/method-signature-style
-  makeLayer(
+  readonly makeLayer: (
     input: BenchmarkRunInput<Config>
-  ): Layer<Dataset | Solver | Scorer, Error, HttpClient.HttpClient>;
+  ) => Layer<Dataset | Solver | Scorer, Error, HttpClient.HttpClient>;
   readonly temperature: number;
   readonly defaultEpochs: number;
   readonly degradeSolverErrors?: boolean;
@@ -65,6 +64,8 @@ export interface Benchmark<
     result: RunResult
   ) => BenchmarkPrimaryScore | undefined;
 }
+
+export type BenchmarkMetadata = Omit<Benchmark, "makeLayer">;
 
 export interface BenchmarkCliContext {
   readonly argv: readonly string[];

--- a/src/results/result-store.ts
+++ b/src/results/result-store.ts
@@ -7,14 +7,14 @@ import { succeed } from "effect/Effect";
 
 import type { BenchmarkRunConfig } from "../benchmarks/benchmark-config";
 import { modelFromConfig } from "../benchmarks/benchmark-config";
-import type { Benchmark } from "../benchmarks/types";
+import type { BenchmarkMetadata } from "../benchmarks/types";
 import type { RunResult } from "../harness/run";
 import { runResultToParquet } from "./parquet";
 
 export interface ResultStoreService {
   readonly write: (opts: {
     readonly result: RunResult;
-    readonly benchmark: Benchmark;
+    readonly benchmark: BenchmarkMetadata;
     readonly benchmarkConfig: BenchmarkRunConfig;
     readonly epochs: number;
     readonly sessionId: string;

--- a/src/runner/run-by-id.test.ts
+++ b/src/runner/run-by-id.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+
+import { succeed } from "effect/Effect";
+import { fail as layerFail, succeed as layerSucceed } from "effect/Layer";
+import { fromIterable } from "effect/Stream";
+
+import type { Benchmark } from "../benchmarks/types";
+import { Dataset } from "../harness/dataset";
+import { assertLeft, assertRight } from "../internal/testing";
+import { datasetSizeById, runBenchmarkById } from "./run-by-id";
+
+const HOST_BENCHMARK: Benchmark = {
+  id: "host_benchmark",
+  makeDatasetLayer: () =>
+    layerSucceed(Dataset, {
+      stream: () => fromIterable([]),
+      size: succeed(7),
+    }),
+  makeLayer: () => layerFail(new Error("host benchmark used")),
+  temperature: 0,
+  defaultEpochs: 1,
+};
+
+const HOST_CONFIG = {
+  benchmarkId: "host_benchmark",
+  model: "host/model",
+  options: { subset: "all" },
+} as const;
+
+describe("benchmark runner by id", () => {
+  it("runs an injected host benchmark instead of the native registry", async () => {
+    const result = await runBenchmarkById({
+      benchmarkId: HOST_BENCHMARK.id,
+      hostBenchmark: HOST_BENCHMARK,
+      apiKey: "unused",
+      benchmarkConfig: HOST_CONFIG,
+      epochs: 1,
+      maxConcurrency: 1,
+      sessionId: "test",
+    });
+
+    assertLeft(result);
+    expect(result.left).toContain("host benchmark used");
+  });
+
+  it("resolves dataset size from an injected host benchmark", async () => {
+    const result = await datasetSizeById(HOST_BENCHMARK.id, HOST_BENCHMARK);
+
+    assertRight(result);
+    expect(result.right).toBe(7);
+  });
+
+  it("rejects an injected benchmark whose id does not match", async () => {
+    const mismatched = { ...HOST_BENCHMARK, id: "other_host_benchmark" };
+
+    const runResult = await runBenchmarkById({
+      benchmarkId: HOST_BENCHMARK.id,
+      hostBenchmark: mismatched,
+      apiKey: "unused",
+      benchmarkConfig: HOST_CONFIG,
+      epochs: 1,
+      maxConcurrency: 1,
+      sessionId: "test",
+    });
+    const sizeResult = await datasetSizeById(HOST_BENCHMARK.id, mismatched);
+
+    assertLeft(runResult);
+    assertLeft(sizeResult);
+    expect(runResult.left).toContain("Benchmark id mismatch");
+    expect(sizeResult.left).toBe(runResult.left);
+  });
+});

--- a/src/runner/run-by-id.test.ts
+++ b/src/runner/run-by-id.test.ts
@@ -4,12 +4,13 @@ import { succeed } from "effect/Effect";
 import { fail as layerFail, succeed as layerSucceed } from "effect/Layer";
 import { fromIterable } from "effect/Stream";
 
+import type { HostBenchmarkRunConfig } from "../benchmarks/benchmark-config";
 import type { Benchmark } from "../benchmarks/types";
 import { Dataset } from "../harness/dataset";
 import { assertLeft, assertRight } from "../internal/testing";
 import { datasetSizeById, runBenchmarkById } from "./run-by-id";
 
-const HOST_BENCHMARK: Benchmark = {
+const HOST_BENCHMARK: Benchmark<HostBenchmarkRunConfig> = {
   id: "host_benchmark",
   makeDatasetLayer: () =>
     layerSucceed(Dataset, {
@@ -41,6 +42,38 @@ describe("benchmark runner by id", () => {
 
     assertLeft(result);
     expect(result.left).toContain("host benchmark used");
+  });
+
+  it("rejects a host config without an injected benchmark", async () => {
+    const result = await runBenchmarkById({
+      benchmarkId: HOST_BENCHMARK.id,
+      apiKey: "unused",
+      benchmarkConfig: HOST_CONFIG,
+      epochs: 1,
+      maxConcurrency: 1,
+      sessionId: "test",
+    });
+
+    assertLeft(result);
+    expect(result.left).toContain("host benchmark is required");
+  });
+
+  it("rejects an injected benchmark for a native config", async () => {
+    const result = await runBenchmarkById({
+      benchmarkId: "search_hle",
+      hostBenchmark: HOST_BENCHMARK,
+      apiKey: "unused",
+      benchmarkConfig: {
+        benchmarkId: "search_hle",
+        model: "host/model",
+      },
+      epochs: 1,
+      maxConcurrency: 1,
+      sessionId: "test",
+    });
+
+    assertLeft(result);
+    expect(result.left).toContain("cannot be supplied for native benchmark");
   });
 
   it("resolves dataset size from an injected host benchmark", async () => {

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -6,9 +6,13 @@ import {
   succeed as layerSucceed,
 } from "effect/Layer";
 
-import type { BenchmarkRunConfig } from "../benchmarks/benchmark-config";
+import type {
+  BenchmarkRunConfig,
+  HostBenchmarkRunConfig,
+} from "../benchmarks/benchmark-config";
 import { modelFromConfig } from "../benchmarks/benchmark-config";
 import { getBenchmark } from "../benchmarks/registry";
+import type { Benchmark } from "../benchmarks/types";
 import { Dataset } from "../harness/dataset";
 import type {
   CheckpointStoreService,
@@ -36,6 +40,7 @@ import type { RetryConfig } from "../runtime/retry";
 
 export interface RunBenchmarkInput {
   readonly benchmarkId: string;
+  readonly hostBenchmark?: Benchmark<HostBenchmarkRunConfig>;
   readonly apiKey: string;
   readonly baseUrl?: string;
   readonly benchmarkConfig: BenchmarkRunConfig;
@@ -63,12 +68,14 @@ export interface RunBenchmarkOutput {
 export function runBenchmarkById(
   input: RunBenchmarkInput
 ): AsyncEither<RunBenchmarkOutput, string> {
-  const benchmark = getBenchmark(input.benchmarkId);
-  if (benchmark === undefined) {
-    return Promise.resolve(
-      Either.left(`Unknown benchmark "${input.benchmarkId}"`)
-    );
+  const benchmarkResult = resolveBenchmark(
+    input.benchmarkId,
+    input.hostBenchmark
+  );
+  if (Either.isLeft(benchmarkResult)) {
+    return Promise.resolve(Either.left(benchmarkResult.left));
   }
+  const benchmark = benchmarkResult.right;
   const maxRetries = input.benchmarkConfig.maxRetries;
   const benchmarkLayer = benchmark.makeLayer({
     apiKey: input.apiKey,
@@ -158,15 +165,34 @@ export function runBenchmarkById(
 }
 
 export function datasetSizeById(
-  benchmarkId: string
+  benchmarkId: string,
+  hostBenchmark?: Benchmark<HostBenchmarkRunConfig>
 ): AsyncEither<number, string> {
-  const benchmark = getBenchmark(benchmarkId);
-  if (benchmark === undefined) {
-    return Promise.resolve(Either.left(`Unknown benchmark "${benchmarkId}"`));
+  const benchmarkResult = resolveBenchmark(benchmarkId, hostBenchmark);
+  if (Either.isLeft(benchmarkResult)) {
+    return Promise.resolve(Either.left(benchmarkResult.left));
   }
+  const benchmark = benchmarkResult.right;
   const datasetLayer = benchmark.makeDatasetLayer();
   const program = Dataset.pipe(flatMap((d) => d.size));
   return runHarnessPromise(program.pipe(provide(datasetLayer)))
     .then((size) => Either.right(size))
     .catch((error) => Either.left(String(error)));
+}
+
+function resolveBenchmark(
+  benchmarkId: string,
+  hostBenchmark: Benchmark<HostBenchmarkRunConfig> | undefined
+): Either.Either<Benchmark<BenchmarkRunConfig>, string> {
+  if (hostBenchmark !== undefined) {
+    return hostBenchmark.id === benchmarkId
+      ? Either.right(hostBenchmark)
+      : Either.left(
+          `Benchmark id mismatch: requested "${benchmarkId}", supplied "${hostBenchmark.id}"`
+        );
+  }
+  const benchmark = getBenchmark(benchmarkId);
+  return benchmark === undefined
+    ? Either.left(`Unknown benchmark "${benchmarkId}"`)
+    : Either.right(benchmark);
 }

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -75,50 +75,11 @@ export interface RunBenchmarkOutput {
 export function runBenchmarkById(
   input: RunBenchmarkInput
 ): AsyncEither<RunBenchmarkOutput, string> {
-  let benchmark: BenchmarkMetadata;
-  let benchmarkLayer: ReturnType<Benchmark["makeLayer"]>;
-  if (isNativeBenchmarkConfig(input.benchmarkConfig)) {
-    if (input.hostBenchmark !== undefined) {
-      return Promise.resolve(
-        Either.left(
-          `A host benchmark cannot be supplied for native benchmark "${input.benchmarkId}"`
-        )
-      );
-    }
-    const nativeBenchmark = getBenchmark(input.benchmarkId);
-    if (nativeBenchmark === undefined) {
-      return Promise.resolve(
-        Either.left(`Unknown benchmark "${input.benchmarkId}"`)
-      );
-    }
-    benchmark = nativeBenchmark;
-    benchmarkLayer = makeBenchmarkLayer(
-      nativeBenchmark,
-      input,
-      input.benchmarkConfig
-    );
-  } else {
-    if (input.hostBenchmark === undefined) {
-      return Promise.resolve(
-        Either.left(
-          `A host benchmark is required for host config "${input.benchmarkId}"`
-        )
-      );
-    }
-    if (input.hostBenchmark.id !== input.benchmarkId) {
-      return Promise.resolve(
-        Either.left(
-          `Benchmark id mismatch: requested "${input.benchmarkId}", supplied "${input.hostBenchmark.id}"`
-        )
-      );
-    }
-    benchmark = input.hostBenchmark;
-    benchmarkLayer = makeBenchmarkLayer(
-      input.hostBenchmark,
-      input,
-      input.benchmarkConfig
-    );
+  const benchmarkResult = resolveRunBenchmark(input);
+  if (Either.isLeft(benchmarkResult)) {
+    return Promise.resolve(Either.left(benchmarkResult.left));
   }
+  const { benchmark, benchmarkLayer } = benchmarkResult.right;
   const progressLayer = layerSucceed(
     ProgressReporter,
     input.progressReporter ?? NOOP_PROGRESS_REPORTER
@@ -224,6 +185,52 @@ function resolveBenchmark(
   return benchmark === undefined
     ? Either.left(`Unknown benchmark "${benchmarkId}"`)
     : Either.right(benchmark);
+}
+
+function resolveRunBenchmark(input: RunBenchmarkInput): Either.Either<
+  {
+    readonly benchmark: BenchmarkMetadata;
+    readonly benchmarkLayer: ReturnType<Benchmark["makeLayer"]>;
+  },
+  string
+> {
+  if (isNativeBenchmarkConfig(input.benchmarkConfig)) {
+    if (input.hostBenchmark !== undefined) {
+      return Either.left(
+        `A host benchmark cannot be supplied for native benchmark "${input.benchmarkId}"`
+      );
+    }
+    const nativeBenchmark = getBenchmark(input.benchmarkId);
+    if (nativeBenchmark === undefined) {
+      return Either.left(`Unknown benchmark "${input.benchmarkId}"`);
+    }
+    return Either.right({
+      benchmark: nativeBenchmark,
+      benchmarkLayer: makeBenchmarkLayer(
+        nativeBenchmark,
+        input,
+        input.benchmarkConfig
+      ),
+    });
+  }
+  if (input.hostBenchmark === undefined) {
+    return Either.left(
+      `A host benchmark is required for host config "${input.benchmarkId}"`
+    );
+  }
+  if (input.hostBenchmark.id !== input.benchmarkId) {
+    return Either.left(
+      `Benchmark id mismatch: requested "${input.benchmarkId}", supplied "${input.hostBenchmark.id}"`
+    );
+  }
+  return Either.right({
+    benchmark: input.hostBenchmark,
+    benchmarkLayer: makeBenchmarkLayer(
+      input.hostBenchmark,
+      input,
+      input.benchmarkConfig
+    ),
+  });
 }
 
 function makeBenchmarkLayer<Config extends BenchmarkRunConfig>(

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -10,9 +10,16 @@ import type {
   BenchmarkRunConfig,
   HostBenchmarkRunConfig,
 } from "../benchmarks/benchmark-config";
-import { modelFromConfig } from "../benchmarks/benchmark-config";
+import {
+  isNativeBenchmarkConfig,
+  modelFromConfig,
+} from "../benchmarks/benchmark-config";
 import { getBenchmark } from "../benchmarks/registry";
-import type { Benchmark } from "../benchmarks/types";
+import type {
+  Benchmark,
+  BenchmarkMetadata,
+  BenchmarkRunInput,
+} from "../benchmarks/types";
 import { Dataset } from "../harness/dataset";
 import type {
   CheckpointStoreService,
@@ -68,28 +75,50 @@ export interface RunBenchmarkOutput {
 export function runBenchmarkById(
   input: RunBenchmarkInput
 ): AsyncEither<RunBenchmarkOutput, string> {
-  const benchmarkResult = resolveBenchmark(
-    input.benchmarkId,
-    input.hostBenchmark
-  );
-  if (Either.isLeft(benchmarkResult)) {
-    return Promise.resolve(Either.left(benchmarkResult.left));
+  let benchmark: BenchmarkMetadata;
+  let benchmarkLayer: ReturnType<Benchmark["makeLayer"]>;
+  if (isNativeBenchmarkConfig(input.benchmarkConfig)) {
+    if (input.hostBenchmark !== undefined) {
+      return Promise.resolve(
+        Either.left(
+          `A host benchmark cannot be supplied for native benchmark "${input.benchmarkId}"`
+        )
+      );
+    }
+    const nativeBenchmark = getBenchmark(input.benchmarkId);
+    if (nativeBenchmark === undefined) {
+      return Promise.resolve(
+        Either.left(`Unknown benchmark "${input.benchmarkId}"`)
+      );
+    }
+    benchmark = nativeBenchmark;
+    benchmarkLayer = makeBenchmarkLayer(
+      nativeBenchmark,
+      input,
+      input.benchmarkConfig
+    );
+  } else {
+    if (input.hostBenchmark === undefined) {
+      return Promise.resolve(
+        Either.left(
+          `A host benchmark is required for host config "${input.benchmarkId}"`
+        )
+      );
+    }
+    if (input.hostBenchmark.id !== input.benchmarkId) {
+      return Promise.resolve(
+        Either.left(
+          `Benchmark id mismatch: requested "${input.benchmarkId}", supplied "${input.hostBenchmark.id}"`
+        )
+      );
+    }
+    benchmark = input.hostBenchmark;
+    benchmarkLayer = makeBenchmarkLayer(
+      input.hostBenchmark,
+      input,
+      input.benchmarkConfig
+    );
   }
-  const benchmark = benchmarkResult.right;
-  const maxRetries = input.benchmarkConfig.maxRetries;
-  const benchmarkLayer = benchmark.makeLayer({
-    apiKey: input.apiKey,
-    benchmarkConfig: input.benchmarkConfig,
-    ...(input.baseUrl !== undefined && { baseUrl: input.baseUrl }),
-    sessionId: input.sessionId,
-    ...(input.datasetRetry !== undefined && {
-      datasetRetry: input.datasetRetry,
-    }),
-    ...(maxRetries !== undefined && { modelRetry: { maxRetries } }),
-    ...(input.maxOutputTokensCeiling !== undefined && {
-      maxOutputTokensCeiling: input.maxOutputTokensCeiling,
-    }),
-  });
   const progressLayer = layerSucceed(
     ProgressReporter,
     input.progressReporter ?? NOOP_PROGRESS_REPORTER
@@ -183,7 +212,7 @@ export function datasetSizeById(
 function resolveBenchmark(
   benchmarkId: string,
   hostBenchmark: Benchmark<HostBenchmarkRunConfig> | undefined
-): Either.Either<Benchmark<BenchmarkRunConfig>, string> {
+): Either.Either<BenchmarkMetadata, string> {
   if (hostBenchmark !== undefined) {
     return hostBenchmark.id === benchmarkId
       ? Either.right(hostBenchmark)
@@ -195,4 +224,26 @@ function resolveBenchmark(
   return benchmark === undefined
     ? Either.left(`Unknown benchmark "${benchmarkId}"`)
     : Either.right(benchmark);
+}
+
+function makeBenchmarkLayer<Config extends BenchmarkRunConfig>(
+  benchmark: Benchmark<Config>,
+  input: RunBenchmarkInput,
+  benchmarkConfig: Config
+): ReturnType<Benchmark["makeLayer"]> {
+  const maxRetries = benchmarkConfig.maxRetries;
+  const benchmarkInput: BenchmarkRunInput<Config> = {
+    apiKey: input.apiKey,
+    benchmarkConfig,
+    ...(input.baseUrl !== undefined && { baseUrl: input.baseUrl }),
+    sessionId: input.sessionId,
+    ...(input.datasetRetry !== undefined && {
+      datasetRetry: input.datasetRetry,
+    }),
+    ...(maxRetries !== undefined && { modelRetry: { maxRetries } }),
+    ...(input.maxOutputTokensCeiling !== undefined && {
+      maxOutputTokensCeiling: input.maxOutputTokensCeiling,
+    }),
+  };
+  return benchmark.makeLayer(benchmarkInput);
 }


### PR DESCRIPTION
## TL;DR

Lets a host application run its own `Benchmark` through `runBenchmarkById` by injecting it, without adding that benchmark's id, dataset or dependencies to this catalog.

## What changed?

- `BenchmarkRunConfigSchema` becomes `NativeBenchmarkRunConfigSchema` (the unchanged 18-member discriminated union) or `HostBenchmarkRunConfigSchema` — the shared `ModelBenchmarkBaseSchema` fields plus an opaque `options` record the harness never interprets. Host ids are refused at parse time if they collide with a native id, which is what keeps a malformed native config from falling through into the permissive variant:

  ```ts
  parseSchema(BenchmarkRunConfigSchema, { benchmarkId: "gpqa_diamond", model: 42 }); // left, not a host config
  ```

- `Benchmark` and `BenchmarkRunInput` take a `Config` parameter defaulting to `NativeBenchmarkRunConfig`, so every existing benchmark keeps its precise config type and `ModelBenchmarkId` / `BENCHMARK_OPTIONS_SCHEMAS` / the search guards stay bound to native ids only — downstream `satisfies readonly ModelBenchmarkId[]` exhaustiveness nets keep working.
- `runBenchmarkById` takes an optional `hostBenchmark: Benchmark<HostBenchmarkRunConfig>` and dispatches on the config rather than erasing types: a native config goes through the registry and rejects a supplied host benchmark, a host config requires one and checks its id matches. `datasetSizeById` takes the same optional benchmark. `ResultStoreService.write` now asks for `BenchmarkMetadata` (`Benchmark` minus `makeLayer`), which is all it ever used.
- No new catalog entry, no registry mutation, no global registration side effect: the host passes its benchmark in explicitly.

## Why?

`packages/internal-benchmarks` in `OpenRouterTeam/openrouter-web` turns the endpoint eval templates into a chat benchmark, reusing the request bodies and response validators that live in `@openrouter-monorepo/evals` and `@openrouter-monorepo/llm-interfaces`. It cannot live here, because this repo deliberately depends on no `@openrouter-monorepo/*` package, and porting the templates and validators upstream would duplicate exactly what that work exists to share. Without an injection point it can only run from its own CLI, not from Temporal or mission-control, since both resolve benchmarks through `getBenchmark` and type configs as the closed union.

## How to test

```sh
bun test src/benchmarks/benchmark-config.test.ts src/runner/run-by-id.test.ts
```

The interesting cases are the negative ones: a native id with a malformed body must fail rather than parse as a host config, a host config reusing a native id must be rejected, and each of the four dispatch mistakes (host config without an injected benchmark, native config with one, id mismatch, unknown native id) must come back as its own `Either.left`.

## Reviewer focus

- The union is now `z.union`, not a discriminated union, so parse order matters: native is tried first and the host variant refuses native ids. If you can construct a payload that parses as a host config but was meant to be native, that's the bug worth finding.
- Whether `Benchmark<Config>`'s default keeps every existing call site's narrowing intact — the earlier draft of this used a method signature to sidestep variance, which made native and host benchmarks mutually assignable and let a host config reach a native `makeLayer`. That is gone; the runner branches instead.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/774ae0a1f6154be29e00b62bac0e0097
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->