### PR TITLE
feat(runner): persist and resume partial sample outcomes across aborted runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "./scorer": "./src/harness/scorer.ts",
     "./solver": "./src/harness/solver.ts",
     "./parquet": "./src/results/parquet.ts",
+    "./partial-outcome-store": "./src/results/partial-outcome-store.ts",
     "./parquet-schema": "./src/results/parquet-schema.ts",
     "./progress": "./src/harness/progress.ts",
     "./result-store": "./src/results/result-store.ts",

--- a/src/harness/run.test.ts
+++ b/src/harness/run.test.ts
@@ -26,7 +26,8 @@ import { Dataset } from "./dataset";
 import type { ModelService } from "./model";
 import { Model } from "./model";
 import type { CheckpointStore, ProgressReporter } from "./progress";
-import { runBenchmark } from "./run";
+import type { SampleOutcome } from "./run";
+import { aggregateOutcomes, runBenchmark, sampleEpochKey } from "./run";
 import { Scorer } from "./scorer";
 import type { SolverService } from "./solver";
 import { systemMessage, chain, generate, Solver } from "./solver";
@@ -396,5 +397,53 @@ describe("runBenchmark", () => {
     );
     expect(result.usage.generationTimeMs).toBe(200);
     expect(result.usage.outputTokens).toBe(0);
+  });
+  it("evaluates only the sample-epochs not listed in skipSampleEpochs", async () => {
+    const model = fakeModel(() => "Answer: B");
+    const solver = chain(
+      systemMessage("You are a helpful assistant."),
+      generate(model.service, { temperature: 0.5 })
+    );
+    const result = await runPromise(
+      runBenchmark({
+        epochs: 2,
+        maxConcurrency: 2,
+        skipSampleEpochs: new Set([
+          sampleEpochKey("s-correct", 0),
+          sampleEpochKey("s-wrong", 1),
+        ]),
+      }).pipe(provide(makeLayers(model, solver)))
+    );
+    const evaluated = result.sampleScores.map((score) =>
+      sampleEpochKey(score.sampleId, score.epoch)
+    );
+    expect(evaluated.toSorted()).toEqual([
+      sampleEpochKey("s-correct", 1),
+      sampleEpochKey("s-wrong", 0),
+    ]);
+  });
+  it("reports every completed outcome through onOutcome as it folds", async () => {
+    const model = fakeModel((input) =>
+      input.includes("Q1") ? "Answer: B" : "Answer: A"
+    );
+    const solver = chain(
+      systemMessage("You are a helpful assistant."),
+      generate(model.service, { temperature: 0.5 })
+    );
+    const collected: SampleOutcome[] = [];
+    const result = await runPromise(
+      runBenchmark({
+        epochs: 1,
+        maxConcurrency: 2,
+        onOutcome: (outcome) => {
+          collected.push(outcome);
+        },
+      }).pipe(provide(makeLayers(model, solver)))
+    );
+    const collectedIds = collected
+      .map((outcome) => outcome.sampleScore.sampleId)
+      .toSorted();
+    expect(collectedIds).toEqual(["s-correct", "s-wrong"]);
+    expect(aggregateOutcomes(collected)).toEqual(result);
   });
 });

--- a/src/harness/run.test.ts
+++ b/src/harness/run.test.ts
@@ -26,6 +26,10 @@ import { Dataset } from "./dataset";
 import type { ModelService } from "./model";
 import { Model } from "./model";
 import type { CheckpointStore, ProgressReporter } from "./progress";
+import {
+  makeProgressReporter,
+  ProgressReporter as ProgressReporterTag,
+} from "./progress";
 import type { SampleOutcome } from "./run";
 import { aggregateOutcomes, runBenchmark, sampleEpochKey } from "./run";
 import { Scorer } from "./scorer";
@@ -421,6 +425,41 @@ describe("runBenchmark", () => {
       sampleEpochKey("s-correct", 1),
       sampleEpochKey("s-wrong", 0),
     ]);
+  });
+  it("offsets progress counts by the skipped sample-epochs when resuming", async () => {
+    const model = fakeModel(() => "Answer: B");
+    const solver = chain(
+      systemMessage("You are a helpful assistant."),
+      generate(model.service, { temperature: 0.5 })
+    );
+    const reported: number[] = [];
+    const reporterLayer = layerSucceed(
+      ProgressReporterTag,
+      makeProgressReporter({
+        onSampleComplete: (count) => {
+          reported.push(count);
+        },
+      })
+    );
+    const layers = mergeAll(
+      fakeDatasetLayer(SAMPLES),
+      layerSucceed(Solver, Solver.of(solver)),
+      layerSucceed(Scorer, Scorer.of(mcqScorer)),
+      model.layer,
+      reporterLayer,
+      noopCheckpointLayer
+    );
+    await runPromise(
+      runBenchmark({
+        epochs: 2,
+        maxConcurrency: 1,
+        skipSampleEpochs: new Set([
+          sampleEpochKey("s-correct", 0),
+          sampleEpochKey("s-wrong", 1),
+        ]),
+      }).pipe(provide(layers))
+    );
+    expect(reported.toSorted()).toEqual([3, 4]);
   });
   it("reports every completed outcome through onOutcome as it folds", async () => {
     const model = fakeModel((input) =>

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -11,6 +11,7 @@ import {
 } from "effect/Effect";
 import type { Stream } from "effect/Stream";
 import {
+  filter as streamFilter,
   flatMap as streamFlatMap,
   fromIterable as streamFromIterable,
   mapEffect as streamMapEffect,
@@ -54,6 +55,8 @@ export interface RunConfig {
   };
   readonly degradeSolverErrors?: boolean;
   readonly logAnnotations?: Readonly<Record<string, string>>;
+  readonly skipSampleEpochs?: ReadonlySet<string>;
+  readonly onOutcome?: (outcome: SampleOutcome) => void;
 }
 
 export interface RunResult {
@@ -73,11 +76,28 @@ interface FoldAccumulator {
   usage: UsageTotals;
 }
 
-type EvalOutcome = {
+export type SampleOutcome = {
   sampleScore: SampleScore;
   usage?: ModelUsage;
   generationTimeMs?: number;
 };
+
+export function sampleEpochKey(sampleId: string, epoch: number): string {
+  return `${sampleId}:${epoch}`;
+}
+
+export function aggregateOutcomes(
+  outcomes: readonly SampleOutcome[]
+): RunResult {
+  let acc: FoldAccumulator = {
+    scores: [],
+    usage: { ...ZERO_USAGE },
+  };
+  for (const outcome of outcomes) {
+    acc = accumulateOutcome(acc, outcome);
+  }
+  return finalizeRun(acc);
+}
 
 function sampleEpochStream(
   dataset: DatasetService,
@@ -107,12 +127,12 @@ function sampleEpochStream(
 function evalWithProgress(
   sampleEpoch: SampleEpoch,
   evaluate: Effect<
-    EvalOutcome,
+    SampleOutcome,
     ModelError | SolverError,
     Solver | Scorer | ProgressReporter | CheckpointStore
   >
 ): Effect<
-  EvalOutcome,
+  SampleOutcome,
   ModelError | SolverError,
   Solver | Scorer | ProgressReporter | CheckpointStore
 > {
@@ -139,7 +159,7 @@ function evalWithProgress(
 
 function accumulateOutcome(
   acc: FoldAccumulator,
-  item: EvalOutcome
+  item: SampleOutcome
 ): FoldAccumulator {
   acc.scores.push(item.sampleScore);
   const u = item.usage;
@@ -163,9 +183,9 @@ function finalizeRun(acc: FoldAccumulator): RunResult {
 }
 
 function applyReplayedUsage(
-  outcome: EvalOutcome,
+  outcome: SampleOutcome,
   replayed: ReplayedUsage | undefined
-): EvalOutcome {
+): SampleOutcome {
   if (replayed === undefined) {
     return outcome;
   }
@@ -193,7 +213,7 @@ interface EvaluateOneOpts {
 function evaluateOne(
   opts: EvaluateOneOpts
 ): Effect<
-  EvalOutcome,
+  SampleOutcome,
   ModelError | SolverError,
   Solver | Scorer | ProgressReporter | CheckpointStore
 > {
@@ -296,7 +316,7 @@ interface ErrorOutcomeOpts {
   readonly explanation: string;
 }
 
-function errorOutcome(opts: ErrorOutcomeOpts): EvalOutcome {
+function errorOutcome(opts: ErrorOutcomeOpts): SampleOutcome {
   const { sample, epoch, value, explanation } = opts;
   const score: Score = {
     value,
@@ -334,10 +354,17 @@ export function runBenchmark(
 > {
   return Dataset.pipe(
     effectFlatMap((dataset) => {
+      const skipKeys = config.skipSampleEpochs;
       const sampleEpochs = sampleEpochStream(
         dataset,
         config.epochs,
         config.range
+      ).pipe(
+        streamFilter(
+          (se) =>
+            skipKeys === undefined ||
+            !skipKeys.has(sampleEpochKey(se.sample.id, se.epoch))
+        )
       );
       const initialAcc: FoldAccumulator = {
         scores: [],
@@ -364,6 +391,7 @@ export function runBenchmark(
         streamRunFoldEffect(initialAcc, (acc, item) =>
           effectGen(function* () {
             const updated = accumulateOutcome(acc, item);
+            config.onOutcome?.(item);
             const reporter = yield* ProgressReporter;
             yield* reporter.onSampleComplete(updated.scores.length);
             return updated;

--- a/src/harness/run.ts
+++ b/src/harness/run.ts
@@ -366,6 +366,7 @@ export function runBenchmark(
             !skipKeys.has(sampleEpochKey(se.sample.id, se.epoch))
         )
       );
+      const completedOffset = skipKeys?.size ?? 0;
       const initialAcc: FoldAccumulator = {
         scores: [],
         usage: { ...ZERO_USAGE },
@@ -393,7 +394,9 @@ export function runBenchmark(
             const updated = accumulateOutcome(acc, item);
             config.onOutcome?.(item);
             const reporter = yield* ProgressReporter;
-            yield* reporter.onSampleComplete(updated.scores.length);
+            yield* reporter.onSampleComplete(
+              completedOffset + updated.scores.length
+            );
             return updated;
           })
         ),

--- a/src/results/partial-outcome-store.test.ts
+++ b/src/results/partial-outcome-store.test.ts
@@ -4,7 +4,11 @@ import { MessageRole, ScoreValue } from "../harness/core";
 import type { SampleOutcome } from "../harness/run";
 import { assertLeft, assertRight } from "../internal/testing";
 import { parseSchema } from "../internal/zod";
-import { PartialOutcomesSchema } from "./partial-outcome-store";
+import type { PartialOutcomesPayload } from "./partial-outcome-store";
+import {
+  isSameRunScope,
+  PartialOutcomesPayloadSchema,
+} from "./partial-outcome-store";
 
 const OUTCOME: SampleOutcome = {
   sampleScore: {
@@ -14,44 +18,127 @@ const OUTCOME: SampleOutcome = {
       value: ScoreValue.Correct,
       answer: "B",
       explanation: "matched target",
+      trajectory: { kind: "verifier_log", log: "verified B" },
     },
     messages: [{ role: MessageRole.Assistant, content: "Answer: B" }],
+    responseItems: [{ type: "message", id: "resp-1" }],
+    requestBody: { model: "test-model", temperature: 0 },
     generationIds: ["gen-1"],
+    metadata: { category: "math" },
+    input: "Q1 target B",
+    target: "B",
   },
   usage: {
     inputTokens: 10,
     outputTokens: 5,
     totalTokens: 15,
+    reasoningTokens: 2,
     totalCost: 0.001,
+    serverToolUse: {
+      webSearchRequests: 1,
+      toolCallsRequested: 2,
+      toolCallsExecuted: 2,
+    },
   },
   generationTimeMs: 100,
 };
 
-describe("PartialOutcomesSchema", () => {
-  it("round-trips a JSON-serialized outcome back to an equal SampleOutcome", () => {
-    const wire: unknown = JSON.parse(JSON.stringify([OUTCOME]));
+const PAYLOAD: PartialOutcomesPayload = {
+  scope: { epochs: 2, range: { start: 0, end: 10 } },
+  outcomes: [OUTCOME],
+};
 
-    const parsed = parseSchema(PartialOutcomesSchema, wire);
+describe("PartialOutcomesPayloadSchema", () => {
+  it("round-trips a JSON-serialized payload back to an equal value", () => {
+    const wire: unknown = JSON.parse(JSON.stringify(PAYLOAD));
+
+    const parsed = parseSchema(PartialOutcomesPayloadSchema, wire);
 
     assertRight(parsed);
-    expect(parsed.right).toEqual([OUTCOME]);
+    expect(parsed.right).toEqual(PAYLOAD);
+  });
+
+  it("round-trips a payload with only required fields", () => {
+    const minimal: PartialOutcomesPayload = {
+      scope: { epochs: 1 },
+      outcomes: [
+        {
+          sampleScore: {
+            sampleId: "s-2",
+            epoch: 1,
+            score: {
+              value: ScoreValue.Skipped,
+              answer: null,
+              explanation: "interrupted",
+            },
+          },
+        },
+      ],
+    };
+    const wire: unknown = JSON.parse(JSON.stringify(minimal));
+
+    const parsed = parseSchema(PartialOutcomesPayloadSchema, wire);
+
+    assertRight(parsed);
+    expect(parsed.right).toEqual(minimal);
   });
 
   it("rejects an outcome with an unknown score value", () => {
     const wire: unknown = JSON.parse(
-      JSON.stringify([
-        {
-          ...OUTCOME,
-          sampleScore: {
-            ...OUTCOME.sampleScore,
-            score: { ...OUTCOME.sampleScore.score, value: "X" },
+      JSON.stringify({
+        ...PAYLOAD,
+        outcomes: [
+          {
+            ...OUTCOME,
+            sampleScore: {
+              ...OUTCOME.sampleScore,
+              score: { ...OUTCOME.sampleScore.score, value: "X" },
+            },
           },
-        },
-      ])
+        ],
+      })
     );
 
-    const parsed = parseSchema(PartialOutcomesSchema, wire);
+    const parsed = parseSchema(PartialOutcomesPayloadSchema, wire);
 
     assertLeft(parsed);
+  });
+
+  it("rejects a payload without a run scope", () => {
+    const wire: unknown = JSON.parse(
+      JSON.stringify({ outcomes: PAYLOAD.outcomes })
+    );
+
+    const parsed = parseSchema(PartialOutcomesPayloadSchema, wire);
+
+    assertLeft(parsed);
+  });
+});
+
+describe("isSameRunScope", () => {
+  it("matches identical scopes with and without ranges", () => {
+    expect(isSameRunScope({ epochs: 2 }, { epochs: 2 })).toBe(true);
+    expect(
+      isSameRunScope(
+        { epochs: 2, range: { start: 0, end: 10 } },
+        { epochs: 2, range: { start: 0, end: 10 } }
+      )
+    ).toBe(true);
+  });
+
+  it("rejects scopes with different epochs", () => {
+    expect(isSameRunScope({ epochs: 2 }, { epochs: 3 })).toBe(false);
+  });
+
+  it("rejects scopes with different or missing ranges", () => {
+    expect(
+      isSameRunScope(
+        { epochs: 2, range: { start: 0, end: 10 } },
+        { epochs: 2, range: { start: 0, end: 5 } }
+      )
+    ).toBe(false);
+    expect(
+      isSameRunScope({ epochs: 2, range: { start: 0, end: 10 } }, { epochs: 2 })
+    ).toBe(false);
   });
 });

--- a/src/results/partial-outcome-store.test.ts
+++ b/src/results/partial-outcome-store.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+
+import { MessageRole, ScoreValue } from "../harness/core";
+import type { SampleOutcome } from "../harness/run";
+import { assertLeft, assertRight } from "../internal/testing";
+import { parseSchema } from "../internal/zod";
+import { PartialOutcomesSchema } from "./partial-outcome-store";
+
+const OUTCOME: SampleOutcome = {
+  sampleScore: {
+    sampleId: "s-1",
+    epoch: 0,
+    score: {
+      value: ScoreValue.Correct,
+      answer: "B",
+      explanation: "matched target",
+    },
+    messages: [{ role: MessageRole.Assistant, content: "Answer: B" }],
+    generationIds: ["gen-1"],
+  },
+  usage: {
+    inputTokens: 10,
+    outputTokens: 5,
+    totalTokens: 15,
+    totalCost: 0.001,
+  },
+  generationTimeMs: 100,
+};
+
+describe("PartialOutcomesSchema", () => {
+  it("round-trips a JSON-serialized outcome back to an equal SampleOutcome", () => {
+    const wire: unknown = JSON.parse(JSON.stringify([OUTCOME]));
+
+    const parsed = parseSchema(PartialOutcomesSchema, wire);
+
+    assertRight(parsed);
+    expect(parsed.right).toEqual([OUTCOME]);
+  });
+
+  it("rejects an outcome with an unknown score value", () => {
+    const wire: unknown = JSON.parse(
+      JSON.stringify([
+        {
+          ...OUTCOME,
+          sampleScore: {
+            ...OUTCOME.sampleScore,
+            score: { ...OUTCOME.sampleScore.score, value: "X" },
+          },
+        },
+      ])
+    );
+
+    const parsed = parseSchema(PartialOutcomesSchema, wire);
+
+    assertLeft(parsed);
+  });
+});

--- a/src/results/partial-outcome-store.ts
+++ b/src/results/partial-outcome-store.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+import { ChatMessageSchema, ScoreValue } from "../harness/core";
+import type { SampleOutcome } from "../harness/run";
+
+export interface PartialOutcomeStoreService {
+  readonly read: () => Promise<readonly SampleOutcome[] | null>;
+  readonly write: (outcomes: readonly SampleOutcome[]) => Promise<void>;
+  readonly remove: () => Promise<void>;
+}
+
+const ScoreValueSchema = z.enum([
+  ScoreValue.Correct,
+  ScoreValue.Incorrect,
+  ScoreValue.Skipped,
+]);
+
+const ScorerTrajectorySchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("verifier_log"), log: z.string() }),
+  z.object({
+    kind: z.literal("judge_runs"),
+    runs: z.array(z.unknown()).readonly(),
+  }),
+]);
+
+const ScoreSchema = z.object({
+  value: ScoreValueSchema,
+  answer: z.string().nullable(),
+  explanation: z.string(),
+  trajectory: ScorerTrajectorySchema.optional(),
+});
+
+const SampleScoreSchema = z.object({
+  sampleId: z.string(),
+  epoch: z.number(),
+  score: ScoreSchema,
+  messages: z.array(ChatMessageSchema).readonly().optional(),
+  responseItems: z
+    .array(z.record(z.string(), z.unknown()).readonly())
+    .readonly()
+    .optional(),
+  requestBody: z.record(z.string(), z.unknown()).readonly().optional(),
+  generationIds: z.array(z.string()).readonly().optional(),
+  metadata: z.record(z.string(), z.unknown()).readonly().optional(),
+  input: z.string().optional(),
+  target: z.string().optional(),
+});
+
+const ServerToolUseCountsSchema = z.object({
+  webSearchRequests: z.number().optional(),
+  toolCallsRequested: z.number().optional(),
+  toolCallsExecuted: z.number().optional(),
+});
+
+const ModelUsageSchema = z.object({
+  inputTokens: z.number().optional(),
+  outputTokens: z.number().optional(),
+  totalTokens: z.number().optional(),
+  reasoningTokens: z.number().optional(),
+  totalCost: z.number().optional(),
+  serverToolUse: ServerToolUseCountsSchema.optional(),
+});
+
+export const SampleOutcomeSchema = z.object({
+  sampleScore: SampleScoreSchema,
+  usage: ModelUsageSchema.optional(),
+  generationTimeMs: z.number().optional(),
+});
+
+export const PartialOutcomesSchema = z.array(SampleOutcomeSchema).readonly();

--- a/src/results/partial-outcome-store.ts
+++ b/src/results/partial-outcome-store.ts
@@ -1,11 +1,32 @@
-import { z } from "zod";
-
 import { ChatMessageSchema, ScoreValue } from "../harness/core";
+import type {
+  ModelUsage,
+  ResponseItem,
+  Score,
+  ScorerTrajectory,
+  ServerToolUseCounts,
+} from "../harness/core";
+import type { SampleScore } from "../harness/metric";
 import type { SampleOutcome } from "../harness/run";
+import type { ZodShape } from "../internal/zod";
+import { z } from "../internal/zod";
+
+export interface PartialOutcomeRunScope {
+  readonly epochs: number;
+  readonly range?: {
+    readonly start?: number;
+    readonly end?: number;
+  };
+}
+
+export interface PartialOutcomesPayload {
+  readonly scope: PartialOutcomeRunScope;
+  readonly outcomes: readonly SampleOutcome[];
+}
 
 export interface PartialOutcomeStoreService {
-  readonly read: () => Promise<readonly SampleOutcome[] | null>;
-  readonly write: (outcomes: readonly SampleOutcome[]) => Promise<void>;
+  readonly read: () => Promise<PartialOutcomesPayload | null>;
+  readonly write: (payload: PartialOutcomesPayload) => Promise<void>;
   readonly remove: () => Promise<void>;
 }
 
@@ -15,42 +36,53 @@ const ScoreValueSchema = z.enum([
   ScoreValue.Skipped,
 ]);
 
-const ScorerTrajectorySchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("verifier_log"), log: z.string() }),
-  z.object({
-    kind: z.literal("judge_runs"),
-    runs: z.array(z.unknown()).readonly(),
-  }),
-]);
+type VerifierLogTrajectory = Extract<
+  ScorerTrajectory,
+  { kind: "verifier_log" }
+>;
+type JudgeRunsTrajectory = Extract<ScorerTrajectory, { kind: "judge_runs" }>;
+
+const ScorerTrajectorySchema: z.ZodType<ScorerTrajectory> =
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("verifier_log"),
+      log: z.string(),
+    } satisfies ZodShape<VerifierLogTrajectory>),
+    z.object({
+      kind: z.literal("judge_runs"),
+      runs: z.array(z.unknown()).readonly(),
+    } satisfies ZodShape<JudgeRunsTrajectory>),
+  ]);
 
 const ScoreSchema = z.object({
   value: ScoreValueSchema,
   answer: z.string().nullable(),
   explanation: z.string(),
   trajectory: ScorerTrajectorySchema.optional(),
-});
+} satisfies ZodShape<Score>);
+
+const ResponseItemSchema: z.ZodType<ResponseItem> = z
+  .record(z.string(), z.unknown())
+  .readonly();
 
 const SampleScoreSchema = z.object({
   sampleId: z.string(),
   epoch: z.number(),
   score: ScoreSchema,
   messages: z.array(ChatMessageSchema).readonly().optional(),
-  responseItems: z
-    .array(z.record(z.string(), z.unknown()).readonly())
-    .readonly()
-    .optional(),
+  responseItems: z.array(ResponseItemSchema).readonly().optional(),
   requestBody: z.record(z.string(), z.unknown()).readonly().optional(),
   generationIds: z.array(z.string()).readonly().optional(),
   metadata: z.record(z.string(), z.unknown()).readonly().optional(),
   input: z.string().optional(),
   target: z.string().optional(),
-});
+} satisfies ZodShape<SampleScore>);
 
 const ServerToolUseCountsSchema = z.object({
   webSearchRequests: z.number().optional(),
   toolCallsRequested: z.number().optional(),
   toolCallsExecuted: z.number().optional(),
-});
+} satisfies ZodShape<ServerToolUseCounts>);
 
 const ModelUsageSchema = z.object({
   inputTokens: z.number().optional(),
@@ -59,12 +91,36 @@ const ModelUsageSchema = z.object({
   reasoningTokens: z.number().optional(),
   totalCost: z.number().optional(),
   serverToolUse: ServerToolUseCountsSchema.optional(),
-});
+} satisfies ZodShape<ModelUsage>);
 
 export const SampleOutcomeSchema = z.object({
   sampleScore: SampleScoreSchema,
   usage: ModelUsageSchema.optional(),
   generationTimeMs: z.number().optional(),
-});
+} satisfies ZodShape<SampleOutcome>);
 
-export const PartialOutcomesSchema = z.array(SampleOutcomeSchema).readonly();
+const PartialOutcomeRunScopeRangeSchema = z.object({
+  start: z.number().optional(),
+  end: z.number().optional(),
+} satisfies ZodShape<NonNullable<PartialOutcomeRunScope["range"]>>);
+
+export const PartialOutcomeRunScopeSchema = z.object({
+  epochs: z.number(),
+  range: PartialOutcomeRunScopeRangeSchema.optional(),
+} satisfies ZodShape<PartialOutcomeRunScope>);
+
+export const PartialOutcomesPayloadSchema = z.object({
+  scope: PartialOutcomeRunScopeSchema,
+  outcomes: z.array(SampleOutcomeSchema).readonly(),
+} satisfies ZodShape<PartialOutcomesPayload>);
+
+export function isSameRunScope(
+  a: PartialOutcomeRunScope,
+  b: PartialOutcomeRunScope
+): boolean {
+  return (
+    a.epochs === b.epochs &&
+    a.range?.start === b.range?.start &&
+    a.range?.end === b.range?.end
+  );
+}

--- a/src/runner/run-by-id.test.ts
+++ b/src/runner/run-by-id.test.ts
@@ -1,13 +1,26 @@
 import { describe, expect, it } from "bun:test";
 
-import { succeed } from "effect/Effect";
-import { fail as layerFail, succeed as layerSucceed } from "effect/Layer";
+import { dieMessage, succeed } from "effect/Effect";
+import {
+  fail as layerFail,
+  mergeAll,
+  succeed as layerSucceed,
+} from "effect/Layer";
 import { fromIterable } from "effect/Stream";
 
 import type { HostBenchmarkRunConfig } from "../benchmarks/benchmark-config";
+import { mcqScorer } from "../benchmarks/scorers/mcq/scorer";
 import type { Benchmark } from "../benchmarks/types";
+import { MessageRole, ScoreValue } from "../harness/core";
 import { Dataset } from "../harness/dataset";
+import type { SampleOutcome } from "../harness/run";
+import { Scorer } from "../harness/scorer";
+import { generate, Solver } from "../harness/solver";
 import { assertLeft, assertRight } from "../internal/testing";
+import type {
+  PartialOutcomesPayload,
+  PartialOutcomeStoreService,
+} from "../results/partial-outcome-store";
 import { datasetSizeById, runBenchmarkById } from "./run-by-id";
 
 const HOST_BENCHMARK: Benchmark<HostBenchmarkRunConfig> = {
@@ -101,5 +114,195 @@ describe("benchmark runner by id", () => {
     assertLeft(sizeResult);
     expect(runResult.left).toContain("Benchmark id mismatch");
     expect(sizeResult.left).toBe(runResult.left);
+  });
+});
+
+const RUNNABLE_SAMPLES = [
+  { id: "s-1", input: "Q1 target B", target: { text: "B" } },
+  { id: "s-2", input: "Q2 target B", target: { text: "B" } },
+] as const;
+
+function makeRunnableHostBenchmark(
+  solverCalls: string[]
+): Benchmark<HostBenchmarkRunConfig> {
+  const datasetLayer = layerSucceed(Dataset, {
+    stream: () => fromIterable(RUNNABLE_SAMPLES),
+    size: succeed(RUNNABLE_SAMPLES.length),
+  });
+  const solver = generate(
+    {
+      generate: (messages) => {
+        const userMsg =
+          messages.find((m) => m.role === MessageRole.User)?.content ?? "";
+        solverCalls.push(userMsg);
+        return succeed({
+          completion: "Answer: B",
+          message: { role: MessageRole.Assistant, content: "Answer: B" },
+          generationTimeMs: 100,
+        });
+      },
+    },
+    { temperature: 0 }
+  );
+  return {
+    ...HOST_BENCHMARK,
+    makeLayer: () =>
+      mergeAll(
+        datasetLayer,
+        layerSucceed(Solver, Solver.of(solver)),
+        layerSucceed(Scorer, Scorer.of(mcqScorer))
+      ),
+  };
+}
+
+function priorOutcome(sampleId: string, epoch: number): SampleOutcome {
+  return {
+    sampleScore: {
+      sampleId,
+      epoch,
+      score: {
+        value: ScoreValue.Correct,
+        answer: "B",
+        explanation: "persisted",
+      },
+    },
+  };
+}
+
+function makePartialStore(payload: PartialOutcomesPayload | null): {
+  store: PartialOutcomeStoreService;
+  removals: number[];
+} {
+  const removals: number[] = [];
+  return {
+    store: {
+      read: () => Promise.resolve(payload),
+      write: () => Promise.resolve(),
+      remove: () => {
+        removals.push(1);
+        return Promise.resolve();
+      },
+    },
+    removals,
+  };
+}
+
+describe("runBenchmarkById partial outcome resume", () => {
+  it("skips sample-epochs persisted under the same run scope", async () => {
+    const solverCalls: string[] = [];
+    const { store, removals } = makePartialStore({
+      scope: { epochs: 1 },
+      outcomes: [priorOutcome("s-1", 0)],
+    });
+
+    const result = await runBenchmarkById({
+      benchmarkId: HOST_BENCHMARK.id,
+      hostBenchmark: makeRunnableHostBenchmark(solverCalls),
+      apiKey: "unused",
+      benchmarkConfig: HOST_CONFIG,
+      epochs: 1,
+      maxConcurrency: 1,
+      sessionId: "test",
+      partialOutcomeStore: store,
+    });
+
+    assertRight(result);
+    expect(solverCalls).toEqual(["Q2 target B"]);
+    expect(result.right.result.sampleScores).toHaveLength(2);
+    expect(removals).toHaveLength(1);
+  });
+
+  it("discards persisted outcomes from a mismatched run scope", async () => {
+    const solverCalls: string[] = [];
+    const { store } = makePartialStore({
+      scope: { epochs: 2 },
+      outcomes: [priorOutcome("s-1", 0)],
+    });
+
+    const result = await runBenchmarkById({
+      benchmarkId: HOST_BENCHMARK.id,
+      hostBenchmark: makeRunnableHostBenchmark(solverCalls),
+      apiKey: "unused",
+      benchmarkConfig: HOST_CONFIG,
+      epochs: 1,
+      maxConcurrency: 1,
+      sessionId: "test",
+      partialOutcomeStore: store,
+    });
+
+    assertRight(result);
+    expect(solverCalls.toSorted()).toEqual(["Q1 target B", "Q2 target B"]);
+    expect(result.right.result.sampleScores).toHaveLength(2);
+  });
+
+  it("starts fresh when the partial store read fails", async () => {
+    const solverCalls: string[] = [];
+    const store: PartialOutcomeStoreService = {
+      read: () => Promise.reject(new Error("read failed")),
+      write: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+    };
+
+    const result = await runBenchmarkById({
+      benchmarkId: HOST_BENCHMARK.id,
+      hostBenchmark: makeRunnableHostBenchmark(solverCalls),
+      apiKey: "unused",
+      benchmarkConfig: HOST_CONFIG,
+      epochs: 1,
+      maxConcurrency: 1,
+      sessionId: "test",
+      partialOutcomeStore: store,
+    });
+
+    assertRight(result);
+    expect(solverCalls).toHaveLength(2);
+  });
+
+  it("keeps the partial store when result persistence fails", async () => {
+    const solverCalls: string[] = [];
+    const { store, removals } = makePartialStore({
+      scope: { epochs: 1 },
+      outcomes: [priorOutcome("s-1", 0)],
+    });
+
+    const result = await runBenchmarkById({
+      benchmarkId: HOST_BENCHMARK.id,
+      hostBenchmark: makeRunnableHostBenchmark(solverCalls),
+      apiKey: "unused",
+      benchmarkConfig: HOST_CONFIG,
+      epochs: 1,
+      maxConcurrency: 1,
+      sessionId: "test",
+      partialOutcomeStore: store,
+      resultStore: { write: () => dieMessage("results store down") },
+    });
+
+    assertRight(result);
+    expect(result.right.resultsPath).toBeNull();
+    expect(removals).toHaveLength(0);
+  });
+
+  it("removes the partial store after result persistence succeeds", async () => {
+    const solverCalls: string[] = [];
+    const { store, removals } = makePartialStore({
+      scope: { epochs: 1 },
+      outcomes: [priorOutcome("s-1", 0)],
+    });
+
+    const result = await runBenchmarkById({
+      benchmarkId: HOST_BENCHMARK.id,
+      hostBenchmark: makeRunnableHostBenchmark(solverCalls),
+      apiKey: "unused",
+      benchmarkConfig: HOST_CONFIG,
+      epochs: 1,
+      maxConcurrency: 1,
+      sessionId: "test",
+      partialOutcomeStore: store,
+      resultStore: { write: () => succeed("/tmp/results.parquet") },
+    });
+
+    assertRight(result);
+    expect(result.right.resultsPath).toBe("/tmp/results.parquet");
+    expect(removals).toHaveLength(1);
   });
 });

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -41,7 +41,12 @@ import { runHarnessPromise } from "../internal/effect-logger";
 import type { AsyncEither } from "../internal/either";
 import { Either } from "../internal/either";
 import { wLog } from "../internal/log";
-import type { PartialOutcomeStoreService } from "../results/partial-outcome-store";
+import type {
+  PartialOutcomeRunScope,
+  PartialOutcomesPayload,
+  PartialOutcomeStoreService,
+} from "../results/partial-outcome-store";
+import { isSameRunScope } from "../results/partial-outcome-store";
 import type { ResultStoreService } from "../results/result-store";
 import {
   GenerationResolver,
@@ -87,10 +92,14 @@ export async function runBenchmarkById(
   }
   const { benchmark, benchmarkLayer } = benchmarkResult.right;
   const partialStore = input.partialOutcomeStore;
+  const runScope: PartialOutcomeRunScope = {
+    epochs: input.epochs,
+    ...(input.range !== undefined && { range: input.range }),
+  };
   const priorOutcomes =
     partialStore === undefined
       ? []
-      : ((await partialStore.read().catch(() => null)) ?? []);
+      : await readPartialOutcomes(partialStore, runScope);
   const collectedOutcomes: SampleOutcome[] = [];
   const progressLayer = layerSucceed(
     ProgressReporter,
@@ -163,6 +172,7 @@ export async function runBenchmarkById(
     await flushPartialOutcomes({
       partialStore,
       abortSignal: input.abortSignal,
+      runScope,
       outcomes: [...priorOutcomes, ...collectedOutcomes],
       newOutcomeCount: collectedOutcomes.length,
     });
@@ -172,37 +182,77 @@ export async function runBenchmarkById(
     priorOutcomes.length > 0
       ? aggregateOutcomes([...priorOutcomes, ...collectedOutcomes])
       : harnessResult;
-  if (partialStore !== undefined) {
-    await partialStore.remove().catch(() => {});
-  }
   if (input.resultStore === undefined) {
+    await removePartialOutcomes(partialStore);
     return Either.right({ result, resultsPath: null });
   }
-  return runHarnessPromise(
-    input.resultStore.write({
-      result,
-      benchmark,
-      benchmarkConfig: input.benchmarkConfig,
-      epochs: input.epochs,
-      sessionId: input.sessionId,
-    })
-  )
-    .then((resultsPath) => Either.right({ result, resultsPath }))
-    .catch((storeErr) => {
-      wLog("Failed to persist benchmark results", {
-        error: String(storeErr),
-      });
-      return Either.right({ result, resultsPath: null });
+  try {
+    const resultsPath = await runHarnessPromise(
+      input.resultStore.write({
+        result,
+        benchmark,
+        benchmarkConfig: input.benchmarkConfig,
+        epochs: input.epochs,
+        sessionId: input.sessionId,
+      })
+    );
+    await removePartialOutcomes(partialStore);
+    return Either.right({ result, resultsPath });
+  } catch (storeErr) {
+    wLog("Failed to persist benchmark results", {
+      error: String(storeErr),
     });
+    return Either.right({ result, resultsPath: null });
+  }
+}
+
+async function readPartialOutcomes(
+  partialStore: PartialOutcomeStoreService,
+  runScope: PartialOutcomeRunScope
+): Promise<readonly SampleOutcome[]> {
+  let payload: PartialOutcomesPayload | null;
+  try {
+    payload = await partialStore.read();
+  } catch (error) {
+    wLog("Failed to read partial benchmark outcomes; starting fresh", {
+      error: String(error),
+    });
+    return [];
+  }
+  if (payload === null) {
+    return [];
+  }
+  if (!isSameRunScope(payload.scope, runScope)) {
+    wLog("Discarding partial benchmark outcomes from a mismatched run scope", {
+      persisted_epochs: payload.scope.epochs,
+      current_epochs: runScope.epochs,
+      persisted_range: JSON.stringify(payload.scope.range ?? null),
+      current_range: JSON.stringify(runScope.range ?? null),
+      discarded_outcome_count: payload.outcomes.length,
+    });
+    return [];
+  }
+  return payload.outcomes;
+}
+
+async function removePartialOutcomes(
+  partialStore: PartialOutcomeStoreService | undefined
+): Promise<void> {
+  if (partialStore === undefined) {
+    return;
+  }
+  await partialStore.remove().catch(() => {});
 }
 
 async function flushPartialOutcomes(opts: {
   readonly partialStore: PartialOutcomeStoreService | undefined;
   readonly abortSignal: AbortSignal | undefined;
+  readonly runScope: PartialOutcomeRunScope;
   readonly outcomes: readonly SampleOutcome[];
   readonly newOutcomeCount: number;
 }): Promise<void> {
-  const { partialStore, abortSignal, outcomes, newOutcomeCount } = opts;
+  const { partialStore, abortSignal, runScope, outcomes, newOutcomeCount } =
+    opts;
   if (
     partialStore === undefined ||
     abortSignal?.aborted !== true ||
@@ -211,7 +261,7 @@ async function flushPartialOutcomes(opts: {
     return;
   }
   try {
-    await partialStore.write(outcomes);
+    await partialStore.write({ scope: runScope, outcomes });
     wLog("Flushed partial benchmark outcomes after abort", {
       outcome_count: outcomes.length,
       new_outcome_count: newOutcomeCount,

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -31,12 +31,17 @@ import {
   NOOP_PROGRESS_REPORTER,
   ProgressReporter,
 } from "../harness/progress";
-import type { RunResult, RunConfig } from "../harness/run";
-import { runBenchmark } from "../harness/run";
+import type { RunResult, RunConfig, SampleOutcome } from "../harness/run";
+import {
+  aggregateOutcomes,
+  runBenchmark,
+  sampleEpochKey,
+} from "../harness/run";
 import { runHarnessPromise } from "../internal/effect-logger";
 import type { AsyncEither } from "../internal/either";
 import { Either } from "../internal/either";
 import { wLog } from "../internal/log";
+import type { PartialOutcomeStoreService } from "../results/partial-outcome-store";
 import type { ResultStoreService } from "../results/result-store";
 import {
   GenerationResolver,
@@ -64,6 +69,7 @@ export interface RunBenchmarkInput {
   readonly checkpointStore?: CheckpointStoreService;
   readonly abortSignal?: AbortSignal;
   readonly resultStore?: ResultStoreService;
+  readonly partialOutcomeStore?: PartialOutcomeStoreService;
   readonly maxOutputTokensCeiling?: number;
 }
 
@@ -72,14 +78,20 @@ export interface RunBenchmarkOutput {
   readonly resultsPath: string | null;
 }
 
-export function runBenchmarkById(
+export async function runBenchmarkById(
   input: RunBenchmarkInput
 ): AsyncEither<RunBenchmarkOutput, string> {
   const benchmarkResult = resolveRunBenchmark(input);
   if (Either.isLeft(benchmarkResult)) {
-    return Promise.resolve(Either.left(benchmarkResult.left));
+    return Either.left(benchmarkResult.left);
   }
   const { benchmark, benchmarkLayer } = benchmarkResult.right;
+  const partialStore = input.partialOutcomeStore;
+  const priorOutcomes =
+    partialStore === undefined
+      ? []
+      : ((await partialStore.read().catch(() => null)) ?? []);
+  const collectedOutcomes: SampleOutcome[] = [];
   const progressLayer = layerSucceed(
     ProgressReporter,
     input.progressReporter ?? NOOP_PROGRESS_REPORTER
@@ -104,6 +116,21 @@ export function runBenchmarkById(
         run_attempt: `${input.runAttempt}`,
       }),
     },
+    ...(partialStore !== undefined && {
+      onOutcome: (outcome: SampleOutcome) => {
+        collectedOutcomes.push(outcome);
+      },
+    }),
+    ...(priorOutcomes.length > 0 && {
+      skipSampleEpochs: new Set(
+        priorOutcomes.map((outcome) =>
+          sampleEpochKey(
+            outcome.sampleScore.sampleId,
+            outcome.sampleScore.epoch
+          )
+        )
+      ),
+    }),
   };
   const fullBenchmarkLayer = benchmarkLayer.pipe(
     layerProvide(FetchHttpClient.layer)
@@ -124,34 +151,76 @@ export function runBenchmarkById(
   const runOpts =
     input.abortSignal !== undefined ? { signal: input.abortSignal } : undefined;
   const program = runBenchmark(runConfig).pipe(provide(layers));
+  let harnessResult: RunResult;
+  try {
+    harnessResult = await runHarnessPromise(
+      input.runAttempt === undefined
+        ? program
+        : withRunAttempt(input.runAttempt, program),
+      runOpts
+    );
+  } catch (error) {
+    await flushPartialOutcomes({
+      partialStore,
+      abortSignal: input.abortSignal,
+      outcomes: [...priorOutcomes, ...collectedOutcomes],
+      newOutcomeCount: collectedOutcomes.length,
+    });
+    return Either.left(String(error));
+  }
+  const result =
+    priorOutcomes.length > 0
+      ? aggregateOutcomes([...priorOutcomes, ...collectedOutcomes])
+      : harnessResult;
+  if (partialStore !== undefined) {
+    await partialStore.remove().catch(() => {});
+  }
+  if (input.resultStore === undefined) {
+    return Either.right({ result, resultsPath: null });
+  }
   return runHarnessPromise(
-    input.runAttempt === undefined
-      ? program
-      : withRunAttempt(input.runAttempt, program),
-    runOpts
-  )
-    .then((result) => {
-      if (input.resultStore !== undefined) {
-        return runHarnessPromise(
-          input.resultStore.write({
-            result,
-            benchmark,
-            benchmarkConfig: input.benchmarkConfig,
-            epochs: input.epochs,
-            sessionId: input.sessionId,
-          })
-        )
-          .then((resultsPath) => Either.right({ result, resultsPath }))
-          .catch((storeErr) => {
-            wLog("Failed to persist benchmark results", {
-              error: String(storeErr),
-            });
-            return Either.right({ result, resultsPath: null });
-          });
-      }
-      return Either.right({ result, resultsPath: null });
+    input.resultStore.write({
+      result,
+      benchmark,
+      benchmarkConfig: input.benchmarkConfig,
+      epochs: input.epochs,
+      sessionId: input.sessionId,
     })
-    .catch((error) => Either.left(String(error)));
+  )
+    .then((resultsPath) => Either.right({ result, resultsPath }))
+    .catch((storeErr) => {
+      wLog("Failed to persist benchmark results", {
+        error: String(storeErr),
+      });
+      return Either.right({ result, resultsPath: null });
+    });
+}
+
+async function flushPartialOutcomes(opts: {
+  readonly partialStore: PartialOutcomeStoreService | undefined;
+  readonly abortSignal: AbortSignal | undefined;
+  readonly outcomes: readonly SampleOutcome[];
+  readonly newOutcomeCount: number;
+}): Promise<void> {
+  const { partialStore, abortSignal, outcomes, newOutcomeCount } = opts;
+  if (
+    partialStore === undefined ||
+    abortSignal?.aborted !== true ||
+    newOutcomeCount === 0
+  ) {
+    return;
+  }
+  try {
+    await partialStore.write(outcomes);
+    wLog("Flushed partial benchmark outcomes after abort", {
+      outcome_count: outcomes.length,
+      new_outcome_count: newOutcomeCount,
+    });
+  } catch (error) {
+    wLog("Failed to flush partial benchmark outcomes after abort", {
+      error: String(error),
+    });
+  }
 }
 
 export function datasetSizeById(


### PR DESCRIPTION
## TL;DR

Adds an optional `PartialOutcomeStoreService` so an aborted run (e.g. Cloud Run SIGTERM) flushes completed sample outcomes durably, and the retry skips those sample/epochs and aggregates the combined result.

## What changed?

- `src/results/partial-outcome-store.ts` (new): `PartialOutcomeStoreService` contract (`read`/`write`/`remove`) plus Zod schemas (`SampleOutcomeSchema`, `PartialOutcomesSchema`) to validate persisted JSON at runtime. Exported as `./partial-outcome-store`.
- `src/harness/run.ts`:
  - `RunConfig` gains `skipSampleEpochs?: ReadonlySet<string>` and `onOutcome?: (outcome: SampleOutcome) => void`.
  - New helpers `sampleEpochKey(sampleId, epoch)` and `aggregateOutcomes(outcomes)` (loop-based fold into the existing `FoldAccumulator`/`finalizeRun`).
  - The sample-epoch stream filters out already-completed keys; each completed outcome invokes `onOutcome` before progress reporting.
- `src/runner/run-by-id.ts`: `partialOutcomeStore?` on the run input. Flow:
  1. `read()` prior outcomes (best-effort) and build the skip set.
  2. Run with `skipSampleEpochs` + collect new outcomes via `onOutcome`.
  3. On abort (`abortSignal.aborted` and new outcomes exist): `write()` prior + new outcomes, then rethrow/return the abort as before.
  4. On success: aggregate prior + new outcomes into the final `RunResult` and `remove()` the partial object.
  - Failures other than abort leave existing partial data untouched.

## Why?

Cloud Run gives ~10s between SIGTERM and SIGKILL. Without a durable flush, every completed-but-unpersisted sample in an in-flight chunk is lost and re-run on retry. With this, the retry only reruns missing sample/epochs. Cancellation semantics are unchanged — an aborted run still surfaces as aborted; the flush is a side effect.

## How to test

- `bun test src/harness/run.test.ts src/results/partial-outcome-store.test.ts` — covers skip-set filtering, `onOutcome` invocation, aggregation, and schema accept/reject.
- Simulate resume: run with a store whose `read()` returns prior outcomes; observe skipped sample/epochs in the run and a final result aggregating both sets, followed by `remove()`.

## Benchmark impact

No score changes for uninterrupted runs (store is optional and unused by default). Resumed runs aggregate persisted + new outcomes identically to a single full run over the same sample/epochs.

## Reviewer focus

- Abort-flush condition in `run-by-id.ts` (only when abort signal fired and new outcomes exist; write errors are logged, never masked into a different failure).
- `sampleEpochKey` identity — stable across attempts so skip sets are safe.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [ ] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [ ] Documentation is updated where needed

Link to Devin session: https://openrouter.devinenterprise.com/sessions/4899435489c14bba8242921472c31807
Requested by: @jamespsterling