### PR TITLE
feat: preserve the raw chat response on ModelOutput

### DIFF
--- a/src/harness/core.ts
+++ b/src/harness/core.ts
@@ -151,6 +151,9 @@ export interface ModelOutput {
   readonly message: ChatMessage;
   readonly usage?: ModelUsage;
   readonly generationTimeMs?: number;
+  // oxlint-disable-next-line openrouter/no-comments
+  /** Populated only on the non-streaming OpenRouter chat path; absent when the output is synthesized. */
+  readonly rawResponse?: Readonly<Record<string, unknown>>;
 }
 
 export interface TaskState {

--- a/src/harness/core.ts
+++ b/src/harness/core.ts
@@ -151,8 +151,6 @@ export interface ModelOutput {
   readonly message: ChatMessage;
   readonly usage?: ModelUsage;
   readonly generationTimeMs?: number;
-  // oxlint-disable-next-line openrouter/no-comments
-  /** Populated only on the non-streaming OpenRouter chat path; absent when the output is synthesized. */
   readonly rawResponse?: Readonly<Record<string, unknown>>;
 }
 

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -494,6 +494,35 @@ describe("openrouter-model request parity", () => {
       captured.value?.headers["cloudflare-workers-version-overrides"]
     ).toBeUndefined();
   });
+  it("preserves the raw non-streaming response alongside the mapped output", async () => {
+    const captured: CapturedRequest[] = [];
+    restore = installFetchSequence([CHAT_RESULT_WITH_RAW_USAGE], captured);
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+    });
+    const exit = await runPromiseExit(
+      gen(function* run() {
+        const model = yield* Model;
+        return yield* model.generate(MESSAGES, {});
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    assertSuccess(exit);
+    expect(exit.value.rawResponse).toEqual(CHAT_RESULT_WITH_RAW_USAGE);
+    expect(exit.value.completion).toBe("Answer: A");
+    expect(exit.value.message).toEqual({
+      role: MessageRole.Assistant,
+      content: "Answer: A",
+      model: "m",
+    });
+    expect(exit.value.usage).toEqual({
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 2,
+      reasoningTokens: 3,
+      totalCost: 0.25,
+    });
+  });
 });
 describe("openrouter-model response caching", () => {
   let restore: (() => void) | undefined;
@@ -737,35 +766,6 @@ describe("openrouter-model auto-router plugin", () => {
     );
     assertSuccess(exit);
     expect(exit.value.message.model).toBe("m");
-  });
-  it("preserves the raw non-streaming response alongside the mapped output", async () => {
-    const captured: CapturedRequest[] = [];
-    restore = installFetchSequence([CHAT_RESULT_WITH_RAW_USAGE], captured);
-    const layer = makeOpenRouterModelLayer({
-      model: "openai/gpt-4o",
-      apiKey: "sk-test",
-    });
-    const exit = await runPromiseExit(
-      gen(function* run() {
-        const model = yield* Model;
-        return yield* model.generate(MESSAGES, {});
-      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
-    );
-    assertSuccess(exit);
-    expect(exit.value.rawResponse).toEqual(CHAT_RESULT_WITH_RAW_USAGE);
-    expect(exit.value.completion).toBe("Answer: A");
-    expect(exit.value.message).toEqual({
-      role: MessageRole.Assistant,
-      content: "Answer: A",
-      model: "m",
-    });
-    expect(exit.value.usage).toEqual({
-      inputTokens: 1,
-      outputTokens: 1,
-      totalTokens: 2,
-      reasoningTokens: 3,
-      totalCost: 0.25,
-    });
   });
   it("re-emits model on assistant messages sent back in history", async () => {
     const captured = newHolder();

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -50,6 +50,21 @@ const CHAT_RESULT = {
 
 const CHAT_RESULT_JSON = JSON.stringify(CHAT_RESULT);
 
+const CHAT_RESULT_WITH_RAW_USAGE = {
+  ...CHAT_RESULT,
+  choices: [
+    {
+      ...CHAT_RESULT.choices[0],
+      logprobs: null,
+    },
+  ],
+  usage: {
+    ...CHAT_RESULT.usage,
+    cost: 0.25,
+    completion_tokens_details: { reasoning_tokens: 3 },
+  },
+};
+
 const REASONING_CHAT_RESULT = {
   ...CHAT_RESULT,
   model: "openai/gpt-4o",
@@ -722,6 +737,35 @@ describe("openrouter-model auto-router plugin", () => {
     );
     assertSuccess(exit);
     expect(exit.value.message.model).toBe("m");
+  });
+  it("preserves the raw non-streaming response alongside the mapped output", async () => {
+    const captured: CapturedRequest[] = [];
+    restore = installFetchSequence([CHAT_RESULT_WITH_RAW_USAGE], captured);
+    const layer = makeOpenRouterModelLayer({
+      model: "openai/gpt-4o",
+      apiKey: "sk-test",
+    });
+    const exit = await runPromiseExit(
+      gen(function* run() {
+        const model = yield* Model;
+        return yield* model.generate(MESSAGES, {});
+      }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
+    );
+    assertSuccess(exit);
+    expect(exit.value.rawResponse).toEqual(CHAT_RESULT_WITH_RAW_USAGE);
+    expect(exit.value.completion).toBe("Answer: A");
+    expect(exit.value.message).toEqual({
+      role: MessageRole.Assistant,
+      content: "Answer: A",
+      model: "m",
+    });
+    expect(exit.value.usage).toEqual({
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 2,
+      reasoningTokens: 3,
+      totalCost: 0.25,
+    });
   });
   it("re-emits model on assistant messages sent back in history", async () => {
     const captured = newHolder();

--- a/src/providers/openrouter-model.ts
+++ b/src/providers/openrouter-model.ts
@@ -521,6 +521,7 @@ function decodeResult(
         },
         generationTimeMs: Math.round(performance.now() - startedAt),
         ...(usage && { usage }),
+        ...(isRecord(raw) && { rawResponse: raw }),
       })
     )
   );


### PR DESCRIPTION
## TL;DR

`ModelOutput` gains an optional `rawResponse`, populated on the non-streaming OpenRouter chat path, so a benchmark can score against the unmodified provider response instead of reimplementing the HTTP call.

## What changed?

- `ModelOutput.rawResponse?: Readonly<Record<string, unknown>>` in `harness/core.ts`, set in `providers/openrouter-model.ts` only when the parsed body passes the existing `isRecord` guard.
- Nothing in the harness reads it. Streaming, `responses-model.ts` (which returns `ResponsesTurn`, not `ModelOutput`) and every existing field are untouched.

## Why?

The mapped output is a deliberate normalization: `message` keeps `reasoning` and `toolCalls`, but there is no `finish_reason`, no `logprobs`, and usage becomes camelCase `ModelUsage`. A host benchmark whose scorers were written against the OpenRouter chat response — snake_case `usage` with `cost` and `completion_tokens_details`, plus finish reason and logprobs — therefore cannot use the `Model` layer at all, and the one we have downstream carries its own HTTP client and retry logic purely to keep those fields. One passthrough field deletes that fork instead of growing `ModelOutput` a field at a time as each consumer discovers something else missing.

Optional rather than required because the agentic producers synthesize `ModelOutput` from an agent run and have no single chat response to supply: `benchmarks/draco/solver.ts`, `benchmarks/terminal-bench/ori-solver.ts` and tau3-bench's solver would have to invent a value.

## Benchmark impact

None. `harness/run.ts` is the only consumer of the output object and reads just `usage` and `generationTimeMs`; `ModelOutput` is not serialized into results or logs, so no existing scorer can observe the new field. The cost is memory: the raw body is retained per sample for the life of the task state, which is why it is populated only on the path that needs it.

## How to test

```sh
bun test src/providers/openrouter-model.test.ts
```

The added case asserts a stubbed response round-trips through `rawResponse` with `finish_reason`, `logprobs`, and snake_case `usage` including `cost` and `completion_tokens_details`, while `completion`, `message` and the mapped camelCase `usage` stay exactly as the existing assertions expect.

## Reviewer focus

- Whether `rawResponse` should be narrower than an opaque record. I kept it opaque deliberately: the host validates it with its own schema, and a harness-side type would drift from the API.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/774ae0a1f6154be29e00b62bac0e0097
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->