### PR TITLE
feat(exports): expose agent-cli harness and runner modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "./benchmarks/harbor/sandbox": "./src/benchmarks/harbor/sandbox.ts",
     "./benchmarks/harbor/modal-sandbox": "./src/benchmarks/harbor/modal-sandbox.ts",
     "./benchmarks/agent-cli/schema": "./src/benchmarks/agent-cli/schema.ts",
+    "./benchmarks/agent-cli/harness": "./src/benchmarks/agent-cli/harness.ts",
+    "./benchmarks/agent-cli/runner": "./src/benchmarks/agent-cli/runner.ts",
     "./core": "./src/harness/core.ts",
     "./constants": "./src/harness/constants.ts",
     "./dataset": "./src/harness/dataset.ts",


### PR DESCRIPTION
## Summary
Adds two subpath exports so host applications can reuse the generic agent-cli execution layer (`OriHarnessDef`, `getOriHarness`, `buildFailureDetail`, `normalizeAgentModel`, etc.) without reaching into unexported source paths:

```diff
 "./benchmarks/agent-cli/schema": "./src/benchmarks/agent-cli/schema.ts",
+"./benchmarks/agent-cli/harness": "./src/benchmarks/agent-cli/harness.ts",
+"./benchmarks/agent-cli/runner": "./src/benchmarks/agent-cli/runner.ts",
```

Exports-only, no code change. Needed by the internal agent-dx benchmark in openrouter-web to drop its bespoke harness adapters in favor of the ori harness definitions maintained here.

Link to Devin session: https://openrouter.devinenterprise.com/sessions/58ddb9e5bf0b4b2c80858d33f8acccfe
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->