### PR TITLE
refactor: rename the host benchmark extension point to injected benchmark

### DIFF
--- a/src/benchmarks/benchmark-config.test.ts
+++ b/src/benchmarks/benchmark-config.test.ts
@@ -4,8 +4,8 @@ import { assertLeft, assertRight } from "../internal/testing";
 import { parseSchema } from "../internal/zod";
 import {
   BenchmarkRunConfigSchema,
-  HostBenchmarkRunConfigSchema,
-  isHostBenchmarkConfig,
+  InjectedBenchmarkRunConfigSchema,
+  isInjectedBenchmarkConfig,
   isModelBenchmarkConfig,
   isSearchBenchmarkConfig,
   NativeBenchmarkRunConfigSchema,
@@ -28,7 +28,7 @@ describe("benchmark config", () => {
     expect(isModelBenchmarkConfig(result.right)).toBe(true);
   });
 
-  it("does not let malformed native configs fall through to the host variant", () => {
+  it("does not let malformed native configs fall through to the injected variant", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "gpqa_diamond",
       model: 42,
@@ -37,10 +37,10 @@ describe("benchmark config", () => {
     assertLeft(result);
   });
 
-  it("parses host configs with opaque options", () => {
+  it("parses injected benchmark configs with opaque options", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
-      benchmarkId: "host_benchmark",
-      model: "host/model",
+      benchmarkId: "injected_benchmark",
+      model: "injected/model",
       options: {
         subsets: ["all"],
         customFlag: true,
@@ -49,32 +49,32 @@ describe("benchmark config", () => {
 
     assertRight(result);
     expect(result.right).toEqual({
-      benchmarkId: "host_benchmark",
-      model: "host/model",
+      benchmarkId: "injected_benchmark",
+      model: "injected/model",
       options: {
         subsets: ["all"],
         customFlag: true,
       },
     });
-    expect(isHostBenchmarkConfig(result.right)).toBe(true);
+    expect(isInjectedBenchmarkConfig(result.right)).toBe(true);
     expect(isModelBenchmarkConfig(result.right)).toBe(true);
     expect(isSearchBenchmarkConfig(result.right)).toBe(false);
   });
 
-  it("defaults host options to an empty object", () => {
-    const result = parseSchema(HostBenchmarkRunConfigSchema, {
-      benchmarkId: "host_benchmark",
-      model: "host/model",
+  it("defaults injected benchmark options to an empty object", () => {
+    const result = parseSchema(InjectedBenchmarkRunConfigSchema, {
+      benchmarkId: "injected_benchmark",
+      model: "injected/model",
     });
 
     assertRight(result);
     expect(result.right.options).toEqual({});
   });
 
-  it("rejects a host config that reuses a native benchmark id", () => {
-    const result = parseSchema(HostBenchmarkRunConfigSchema, {
+  it("rejects an injected config that reuses a native benchmark id", () => {
+    const result = parseSchema(InjectedBenchmarkRunConfigSchema, {
       benchmarkId: "gpqa_diamond",
-      model: "host/model",
+      model: "injected/model",
       options: { subsets: ["all"] },
     });
 

--- a/src/benchmarks/benchmark-config.ts
+++ b/src/benchmarks/benchmark-config.ts
@@ -382,34 +382,34 @@ const NATIVE_BENCHMARK_ID_SET: ReadonlySet<string> = new Set(
   })
 );
 
-const HostBenchmarkIdSchema = z
+const InjectedBenchmarkIdSchema = z
   .string()
   .min(1)
   .refine(
     (benchmarkId) => !NATIVE_BENCHMARK_ID_SET.has(benchmarkId),
-    "Host benchmark ids must not reuse native benchmark ids"
+    "Injected benchmark ids must not reuse native benchmark ids"
   );
 
-export const HostBenchmarkRunConfigSchema = z.object({
-  benchmarkId: HostBenchmarkIdSchema,
+export const InjectedBenchmarkRunConfigSchema = z.object({
+  benchmarkId: InjectedBenchmarkIdSchema,
   ...ModelBenchmarkBaseSchema.shape,
   options: z.record(z.string(), z.unknown()).default({}),
 });
 
-export type HostBenchmarkRunConfig = z.infer<
-  typeof HostBenchmarkRunConfigSchema
+export type InjectedBenchmarkRunConfig = z.infer<
+  typeof InjectedBenchmarkRunConfigSchema
 >;
 
 export const BenchmarkRunConfigSchema = z.union([
   NativeBenchmarkRunConfigSchema,
-  HostBenchmarkRunConfigSchema,
+  InjectedBenchmarkRunConfigSchema,
 ]);
 
 export type BenchmarkRunConfig = z.infer<typeof BenchmarkRunConfigSchema>;
 
 export type ModelBenchmarkConfig =
   | NativeModelBenchmarkConfig
-  | HostBenchmarkRunConfig;
+  | InjectedBenchmarkRunConfig;
 
 export function isModelBenchmarkConfig(
   config: BenchmarkRunConfig
@@ -423,9 +423,9 @@ export function isNativeBenchmarkConfig(
   return NATIVE_BENCHMARK_ID_SET.has(config.benchmarkId);
 }
 
-export function isHostBenchmarkConfig(
+export function isInjectedBenchmarkConfig(
   config: BenchmarkRunConfig
-): config is HostBenchmarkRunConfig {
+): config is InjectedBenchmarkRunConfig {
   return !isNativeBenchmarkConfig(config);
 }
 

--- a/src/runner/run-by-id.test.ts
+++ b/src/runner/run-by-id.test.ts
@@ -4,68 +4,68 @@ import { succeed } from "effect/Effect";
 import { fail as layerFail, succeed as layerSucceed } from "effect/Layer";
 import { fromIterable } from "effect/Stream";
 
-import type { HostBenchmarkRunConfig } from "../benchmarks/benchmark-config";
+import type { InjectedBenchmarkRunConfig } from "../benchmarks/benchmark-config";
 import type { Benchmark } from "../benchmarks/types";
 import { Dataset } from "../harness/dataset";
 import { assertLeft, assertRight } from "../internal/testing";
 import { datasetSizeById, runBenchmarkById } from "./run-by-id";
 
-const HOST_BENCHMARK: Benchmark<HostBenchmarkRunConfig> = {
-  id: "host_benchmark",
+const INJECTED_BENCHMARK: Benchmark<InjectedBenchmarkRunConfig> = {
+  id: "injected_benchmark",
   makeDatasetLayer: () =>
     layerSucceed(Dataset, {
       stream: () => fromIterable([]),
       size: succeed(7),
     }),
-  makeLayer: () => layerFail(new Error("host benchmark used")),
+  makeLayer: () => layerFail(new Error("injected benchmark used")),
   temperature: 0,
   defaultEpochs: 1,
 };
 
-const HOST_CONFIG = {
-  benchmarkId: "host_benchmark",
-  model: "host/model",
+const INJECTED_CONFIG = {
+  benchmarkId: "injected_benchmark",
+  model: "injected/model",
   options: { subset: "all" },
 } as const;
 
 describe("benchmark runner by id", () => {
-  it("runs an injected host benchmark instead of the native registry", async () => {
+  it("runs an injected benchmark instead of the native registry", async () => {
     const result = await runBenchmarkById({
-      benchmarkId: HOST_BENCHMARK.id,
-      hostBenchmark: HOST_BENCHMARK,
+      benchmarkId: INJECTED_BENCHMARK.id,
+      injectedBenchmark: INJECTED_BENCHMARK,
       apiKey: "unused",
-      benchmarkConfig: HOST_CONFIG,
+      benchmarkConfig: INJECTED_CONFIG,
       epochs: 1,
       maxConcurrency: 1,
       sessionId: "test",
     });
 
     assertLeft(result);
-    expect(result.left).toContain("host benchmark used");
+    expect(result.left).toContain("injected benchmark used");
   });
 
-  it("rejects a host config without an injected benchmark", async () => {
+  it("rejects an injected-id config without an injected benchmark", async () => {
     const result = await runBenchmarkById({
-      benchmarkId: HOST_BENCHMARK.id,
+      benchmarkId: INJECTED_BENCHMARK.id,
       apiKey: "unused",
-      benchmarkConfig: HOST_CONFIG,
+      benchmarkConfig: INJECTED_CONFIG,
       epochs: 1,
       maxConcurrency: 1,
       sessionId: "test",
     });
 
     assertLeft(result);
-    expect(result.left).toContain("host benchmark is required");
+    expect(result.left).toContain("injected benchmark is required");
   });
 
   it("rejects an injected benchmark for a native config", async () => {
     const result = await runBenchmarkById({
       benchmarkId: "search_hle",
-      hostBenchmark: HOST_BENCHMARK,
+      injectedBenchmark: INJECTED_BENCHMARK,
       apiKey: "unused",
       benchmarkConfig: {
         benchmarkId: "search_hle",
-        model: "host/model",
+        model: "injected/model",
       },
       epochs: 1,
       maxConcurrency: 1,
@@ -76,26 +76,32 @@ describe("benchmark runner by id", () => {
     expect(result.left).toContain("cannot be supplied for native benchmark");
   });
 
-  it("resolves dataset size from an injected host benchmark", async () => {
-    const result = await datasetSizeById(HOST_BENCHMARK.id, HOST_BENCHMARK);
+  it("resolves dataset size from an injected benchmark", async () => {
+    const result = await datasetSizeById(
+      INJECTED_BENCHMARK.id,
+      INJECTED_BENCHMARK
+    );
 
     assertRight(result);
     expect(result.right).toBe(7);
   });
 
   it("rejects an injected benchmark whose id does not match", async () => {
-    const mismatched = { ...HOST_BENCHMARK, id: "other_host_benchmark" };
+    const mismatched = {
+      ...INJECTED_BENCHMARK,
+      id: "other_injected_benchmark",
+    };
 
     const runResult = await runBenchmarkById({
-      benchmarkId: HOST_BENCHMARK.id,
-      hostBenchmark: mismatched,
+      benchmarkId: INJECTED_BENCHMARK.id,
+      injectedBenchmark: mismatched,
       apiKey: "unused",
-      benchmarkConfig: HOST_CONFIG,
+      benchmarkConfig: INJECTED_CONFIG,
       epochs: 1,
       maxConcurrency: 1,
       sessionId: "test",
     });
-    const sizeResult = await datasetSizeById(HOST_BENCHMARK.id, mismatched);
+    const sizeResult = await datasetSizeById(INJECTED_BENCHMARK.id, mismatched);
 
     assertLeft(runResult);
     assertLeft(sizeResult);

--- a/src/runner/run-by-id.ts
+++ b/src/runner/run-by-id.ts
@@ -8,7 +8,7 @@ import {
 
 import type {
   BenchmarkRunConfig,
-  HostBenchmarkRunConfig,
+  InjectedBenchmarkRunConfig,
 } from "../benchmarks/benchmark-config";
 import {
   isNativeBenchmarkConfig,
@@ -48,7 +48,7 @@ import { filterTraceHeaders } from "./trace-headers";
 
 export interface RunBenchmarkInput {
   readonly benchmarkId: string;
-  readonly hostBenchmark?: Benchmark<HostBenchmarkRunConfig>;
+  readonly injectedBenchmark?: Benchmark<InjectedBenchmarkRunConfig>;
   readonly apiKey: string;
   readonly baseUrl?: string;
   readonly benchmarkConfig: BenchmarkRunConfig;
@@ -160,9 +160,9 @@ export function runBenchmarkById(
 
 export function datasetSizeById(
   benchmarkId: string,
-  hostBenchmark?: Benchmark<HostBenchmarkRunConfig>
+  injectedBenchmark?: Benchmark<InjectedBenchmarkRunConfig>
 ): AsyncEither<number, string> {
-  const benchmarkResult = resolveBenchmark(benchmarkId, hostBenchmark);
+  const benchmarkResult = resolveBenchmark(benchmarkId, injectedBenchmark);
   if (Either.isLeft(benchmarkResult)) {
     return Promise.resolve(Either.left(benchmarkResult.left));
   }
@@ -176,13 +176,13 @@ export function datasetSizeById(
 
 function resolveBenchmark(
   benchmarkId: string,
-  hostBenchmark: Benchmark<HostBenchmarkRunConfig> | undefined
+  injectedBenchmark: Benchmark<InjectedBenchmarkRunConfig> | undefined
 ): Either.Either<BenchmarkMetadata, string> {
-  if (hostBenchmark !== undefined) {
-    return hostBenchmark.id === benchmarkId
-      ? Either.right(hostBenchmark)
+  if (injectedBenchmark !== undefined) {
+    return injectedBenchmark.id === benchmarkId
+      ? Either.right(injectedBenchmark)
       : Either.left(
-          `Benchmark id mismatch: requested "${benchmarkId}", supplied "${hostBenchmark.id}"`
+          `Benchmark id mismatch: requested "${benchmarkId}", supplied "${injectedBenchmark.id}"`
         );
   }
   const benchmark = getBenchmark(benchmarkId);
@@ -199,9 +199,9 @@ function resolveRunBenchmark(input: RunBenchmarkInput): Either.Either<
   string
 > {
   if (isNativeBenchmarkConfig(input.benchmarkConfig)) {
-    if (input.hostBenchmark !== undefined) {
+    if (input.injectedBenchmark !== undefined) {
       return Either.left(
-        `A host benchmark cannot be supplied for native benchmark "${input.benchmarkId}"`
+        `An injected benchmark cannot be supplied for native benchmark "${input.benchmarkId}"`
       );
     }
     const nativeBenchmark = getBenchmark(input.benchmarkId);
@@ -217,20 +217,20 @@ function resolveRunBenchmark(input: RunBenchmarkInput): Either.Either<
       ),
     });
   }
-  if (input.hostBenchmark === undefined) {
+  if (input.injectedBenchmark === undefined) {
     return Either.left(
-      `A host benchmark is required for host config "${input.benchmarkId}"`
+      `An injected benchmark is required for injected config "${input.benchmarkId}"`
     );
   }
-  if (input.hostBenchmark.id !== input.benchmarkId) {
+  if (input.injectedBenchmark.id !== input.benchmarkId) {
     return Either.left(
-      `Benchmark id mismatch: requested "${input.benchmarkId}", supplied "${input.hostBenchmark.id}"`
+      `Benchmark id mismatch: requested "${input.benchmarkId}", supplied "${input.injectedBenchmark.id}"`
     );
   }
   return Either.right({
-    benchmark: input.hostBenchmark,
+    benchmark: input.injectedBenchmark,
     benchmarkLayer: makeBenchmarkLayer(
-      input.hostBenchmark,
+      input.injectedBenchmark,
       input,
       input.benchmarkConfig
     ),


### PR DESCRIPTION
## TL;DR

Pure rename of the #51 extension point: "host benchmark" becomes "injected benchmark" everywhere in the public API, error messages, and tests. No behavior change.

## What changed?

- `HostBenchmarkRunConfig` / `HostBenchmarkRunConfigSchema` → `InjectedBenchmarkRunConfig` / `InjectedBenchmarkRunConfigSchema`
- `isHostBenchmarkConfig` → `isInjectedBenchmarkConfig`
- `RunBenchmarkInput.hostBenchmark` and the `datasetSizeById` parameter → `injectedBenchmark`
- Error messages and test fixtures updated to match

## Why?

"Host benchmark" was confusing — it names the benchmark by where it lives rather than what it is. "Injected benchmark" describes the mechanism: a `Benchmark` the caller injects into `runBenchmarkById` instead of resolving from the native registry.

## How to test

Rename only — CI covers it (`bun test`: 1320 pass locally).

## Benchmark impact

None. No solver, scorer, dataset, or config semantics change.

## Reviewer focus

- This is a breaking rename of the public extension-point API; the only known consumer (openrouter-web) is updated in the same stack via a subtree pull.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed

Link to Devin session: https://openrouter.devinenterprise.com/sessions/774ae0a1f6154be29e00b62bac0e0097
Open in Devin Desktop: https://openrouter.devinenterprise.com/desktop/session/774ae0a1f6154be29e00b62bac0e0097?variant=devin
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->