### PR TITLE
perf(datasets): stream checkout cache tarballs instead of buffering them

### DIFF
--- a/src/datasets/cache-store.test.ts
+++ b/src/datasets/cache-store.test.ts
@@ -63,6 +63,7 @@ function makeMemoryGcsClient(): GcsObjectClient & {
           updated: Date.now(),
         });
       });
+      stream.on("error", () => {});
       return stream;
     },
     async objectUpdatedMs(key) {
@@ -197,12 +198,17 @@ describe("GcsCacheStore", () => {
     ).resolves.toBe(false);
   });
 
-  it("surfaces a nonzero tar exit instead of silently succeeding", async () => {
+  it("aborts the upload when tar exits nonzero", async () => {
+    const client = makeMemoryGcsClient();
     const dir = makeTmpDir();
-    const dest = new PassThrough();
-    await expect(pipeTarGzTo(join(dir, "missing"), dest)).rejects.toThrow(
-      "tar create exited"
-    );
+    const snapshotKey = "repos/harbor-missing.tar.gz";
+    await expect(
+      pipeTarGzTo(
+        join(dir, "missing"),
+        client.openObjectWriteStream(snapshotKey, "application/gzip")
+      )
+    ).rejects.toThrow("tar create exited");
+    expect(client.store.has(snapshotKey)).toBe(false);
   });
 
   it("does not export full-buffer tar helpers", async () => {

--- a/src/datasets/cache-store.test.ts
+++ b/src/datasets/cache-store.test.ts
@@ -9,9 +9,14 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough, Readable } from "node:stream";
 
 import type { GcsObjectClient } from "./cache-store";
-import { makeGcsCacheStore, resolveCacheStore } from "./cache-store";
+import {
+  makeGcsCacheStore,
+  pipeTarGzTo,
+  resolveCacheStore,
+} from "./cache-store";
 
 interface StoredObject {
   readonly content: Buffer;
@@ -42,6 +47,23 @@ function makeMemoryGcsClient(): GcsObjectClient & {
         contentType,
         updated: Date.now(),
       });
+    },
+    async openObjectReadStream(key) {
+      const obj = store.get(key);
+      return obj === undefined ? undefined : Readable.from(obj.content);
+    },
+    openObjectWriteStream(key, contentType) {
+      const stream = new PassThrough();
+      const chunks: Buffer[] = [];
+      stream.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+      stream.on("finish", () => {
+        store.set(key, {
+          content: Buffer.concat(chunks),
+          contentType,
+          updated: Date.now(),
+        });
+      });
+      return stream;
     },
     async objectUpdatedMs(key) {
       const obj = store.get(key);
@@ -170,7 +192,23 @@ describe("GcsCacheStore", () => {
     const client = makeMemoryGcsClient();
     const store = makeGcsCacheStore({ bucket: "b", client });
     const dir = makeTmpDir();
-    expect(await store.tryHydrateCheckout(dir, "harbor", "abc123")).toBe(false);
+    await expect(
+      store.tryHydrateCheckout(dir, "harbor", "abc123")
+    ).resolves.toBe(false);
+  });
+
+  it("surfaces a nonzero tar exit instead of silently succeeding", async () => {
+    const dir = makeTmpDir();
+    const dest = new PassThrough();
+    await expect(pipeTarGzTo(join(dir, "missing"), dest)).rejects.toThrow(
+      "tar create exited"
+    );
+  });
+
+  it("does not export full-buffer tar helpers", async () => {
+    const cacheStore = await import("./cache-store");
+    expect("createTarGz" in cacheStore).toBe(false);
+    expect("extractTarGz" in cacheStore).toBe(false);
   });
 });
 

--- a/src/datasets/cache-store.ts
+++ b/src/datasets/cache-store.ts
@@ -1,6 +1,7 @@
-import { execFile, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { join } from "node:path";
-import { promisify } from "node:util";
+import type { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 
 import { getGcsStorage } from "../internal/gcs";
 import { wLog } from "../internal/log";
@@ -43,40 +44,62 @@ export interface CacheStore {
   ) => Promise<void>;
 }
 
-const pExecFile = promisify(execFile);
-
-const TAR_MAX_BUFFER = 256 * 1024 * 1024;
-
-export async function createTarGz(dir: string): Promise<Buffer> {
-  const { stdout } = await pExecFile("tar", ["-czf", "-", "-C", dir, "."], {
-    maxBuffer: TAR_MAX_BUFFER,
-    encoding: "buffer",
-  });
-  return stdout as unknown as Buffer;
-}
-
-export async function extractTarGz(
-  tarball: Buffer,
-  dir: string
+async function waitForTar(
+  proc: ReturnType<typeof spawn>,
+  operation: string
 ): Promise<void> {
-  mkdirOwnerOnly(dir);
+  let stderr = "";
+  proc.stderr?.on("data", (d: Buffer) => (stderr += d.toString()));
   await new Promise<void>((resolve, reject) => {
-    const proc = spawn("tar", ["-xzf", "-", "-C", dir], {
-      stdio: ["pipe", "ignore", "pipe"],
-    });
-    let stderr = "";
-    proc.stderr?.on("data", (d: Buffer) => (stderr += d.toString()));
-    proc.on("error", reject);
-    proc.on("close", (code) =>
+    proc.once("error", reject);
+    proc.once("close", (code) =>
       code === 0
         ? resolve()
         : reject(
-            new Error(`tar extract exited ${code}: ${stderr.slice(-1000)}`)
+            new Error(`tar ${operation} exited ${code}: ${stderr.slice(-1000)}`)
           )
     );
-    proc.stdin.on("error", reject);
-    proc.stdin.end(tarball);
   });
+}
+
+export async function pipeTarGzTo(dir: string, dest: Writable): Promise<void> {
+  const proc = spawn("tar", ["-czf", "-", "-C", dir, "."], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (proc.stdout === null) {
+    throw new Error("tar create did not provide stdout");
+  }
+  const exit = waitForTar(proc, "create");
+  try {
+    await pipeline(proc.stdout, dest);
+  } catch (error) {
+    proc.kill();
+    await exit.catch(() => undefined);
+    throw error;
+  }
+  await exit;
+}
+
+export async function extractTarGzFrom(
+  src: Readable,
+  dir: string
+): Promise<void> {
+  mkdirOwnerOnly(dir);
+  const proc = spawn("tar", ["-xzf", "-", "-C", dir], {
+    stdio: ["pipe", "ignore", "pipe"],
+  });
+  if (proc.stdin === null) {
+    throw new Error("tar extract did not provide stdin");
+  }
+  const exit = waitForTar(proc, "extract");
+  try {
+    await pipeline(src, proc.stdin);
+  } catch (error) {
+    proc.kill();
+    await exit.catch(() => undefined);
+    throw error;
+  }
+  await exit;
 }
 
 export function makeDiskCacheStore(): CacheStore {
@@ -113,6 +136,11 @@ export interface GcsObjectClient {
     content: Buffer,
     contentType?: string
   ) => Promise<void>;
+  readonly openObjectReadStream: (key: string) => Promise<Readable | undefined>;
+  readonly openObjectWriteStream: (
+    key: string,
+    contentType?: string
+  ) => Writable;
   readonly objectUpdatedMs: (key: string) => Promise<number | undefined>;
 }
 
@@ -161,6 +189,17 @@ export function makeDefaultGcsClient(bucket: string): GcsObjectClient {
       } catch (error) {
         wLog("GCS cache upload failed", { key, error: String(error) });
       }
+    },
+    async openObjectReadStream(key) {
+      const file = bucketRef.file(key);
+      const [exists] = await file.exists();
+      return exists ? file.createReadStream() : undefined;
+    },
+    openObjectWriteStream(key, contentType = "application/octet-stream") {
+      return bucketRef.file(key).createWriteStream({
+        contentType,
+        resumable: false,
+      });
     },
     async objectUpdatedMs(key) {
       try {
@@ -219,12 +258,12 @@ export function makeGcsCacheStore(opts: GcsCacheStoreOptions): CacheStore {
     },
     async tryHydrateCheckout(localDir, scope, commit) {
       const full = joinKey(prefix, checkoutSnapshotKey(scope, commit));
-      const buf = await client.downloadObject(full);
-      if (buf === undefined) {
-        return false;
-      }
       try {
-        await extractTarGz(buf, localDir);
+        const src = await client.openObjectReadStream(full);
+        if (src === undefined) {
+          return false;
+        }
+        await extractTarGzFrom(src, localDir);
         return true;
       } catch (error) {
         wLog("GCS checkout hydrate failed", {
@@ -237,8 +276,8 @@ export function makeGcsCacheStore(opts: GcsCacheStoreOptions): CacheStore {
     async snapshotCheckout(localDir, scope, commit) {
       const full = joinKey(prefix, checkoutSnapshotKey(scope, commit));
       try {
-        const buf = await createTarGz(localDir);
-        await client.uploadObject(full, buf, "application/gzip");
+        const dest = client.openObjectWriteStream(full, "application/gzip");
+        await pipeTarGzTo(localDir, dest);
       } catch (error) {
         wLog("GCS checkout snapshot failed", {
           key: full,

--- a/src/datasets/cache-store.ts
+++ b/src/datasets/cache-store.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { join } from "node:path";
 import type { Readable, Writable } from "node:stream";
-import { pipeline } from "node:stream/promises";
+import { finished, pipeline } from "node:stream/promises";
 
 import { getGcsStorage } from "../internal/gcs";
 import { wLog } from "../internal/log";
@@ -71,13 +71,18 @@ export async function pipeTarGzTo(dir: string, dest: Writable): Promise<void> {
   }
   const exit = waitForTar(proc, "create");
   try {
-    await pipeline(proc.stdout, dest);
+    await pipeline(proc.stdout, dest, { end: false });
+    await exit;
+    dest.end();
+    await finished(dest);
   } catch (error) {
+    const destinationError =
+      error instanceof Error ? error : new Error(String(error));
+    dest.destroy(destinationError);
     proc.kill();
     await exit.catch(() => undefined);
     throw error;
   }
-  await exit;
 }
 
 export async function extractTarGzFrom(


### PR DESCRIPTION
## TL;DR

The GCS checkout cache no longer holds a whole task-repo tarball in memory: `tar` is piped straight to and from GCS, so peak RSS is a stream buffer instead of the archive size.

## What changed?

- `createTarGz` / `extractTarGz` (both `Buffer`-shaped) are replaced by `pipeTarGzTo(dir, dest: Writable)` and `extractTarGzFrom(src: Readable, dir)`, using `node:stream/promises` `pipeline`. The 256 MiB `TAR_MAX_BUFFER` cap and the `promisify(execFile)` capture are gone.
- `GcsObjectClient` gains `openObjectReadStream(key): Promise<Readable | undefined>` and `openObjectWriteStream(key, contentType): Writable`. The default client resolves `undefined` from `file.exists()` so an absent snapshot stays distinguishable from a failed transfer, and writes with `createWriteStream({ resumable: false })`.
- `snapshotCheckout` and `tryHydrateCheckout` use those streams. `downloadObject` / `uploadObject` stay `Buffer`-based and continue to serve the HF `/rows` page entries, where a single small JSON body is the right shape.

Before and after, in outline:

```ts
// before: two full copies of the archive live in memory at once
const buf = await createTarGz(localDir);              // tar stdout -> Buffer (256 MiB cap)
await client.uploadObject(full, buf, "application/gzip"); // Buffer -> file.save()

// after
const dest = client.openObjectWriteStream(full, "application/gzip");
await pipeTarGzTo(localDir, dest);                    // tar stdout -> GCS, chunk by chunk
```

Failure behaviour is deliberately unchanged: both operations remain best effort, never throw into callers, and still log `GCS cache upload failed`, `GCS cache write failed`, `GCS checkout hydrate failed`, and `GCS checkout snapshot failed`. A downstream Datadog monitor matches those exact strings. A nonzero `tar` exit still fails with the trailing stderr rather than resolving quietly, which is the one regression a naive pipeline would introduce.

## Why?

The consumer of this cache is a Cloud Run worker pool with a 2 GiB memory limit and `HOME=/tmp`, so the hydrated checkout already occupies in-memory tmpfs. On top of that, `snapshotCheckout` held the archive twice (tar stdout buffer plus the `file.save()` copy) and `tryHydrateCheckout` held it once, and a repo whose archive exceeded 256 MiB failed outright on the `maxBuffer` cap. Streaming removes both the ceiling and the competition with the checkout itself.

## How to test

Round-trip a real checkout against a bucket you can write to, and watch RSS stay flat while the object grows:

```bash
export BENCH_DATASET_CACHE_BACKEND=gcs
export BENCH_GCS_BUCKET=<your-test-bucket>
export BENCH_GCS_PREFIX=dataset-cache-scratch
bun test src/datasets/cache-store.test.ts
```

Then confirm the two behaviours that only show up against real GCS:

1. A cold hydrate of a missing snapshot returns `false` and logs nothing at warn level (`openObjectReadStream` short-circuits on `exists()`).
2. Revoking `storage.objects.create` on the bucket makes `snapshotCheckout` log `GCS checkout snapshot failed` and the run continues by cloning.

`resumable: false` sends the object as a single multipart request, which streams the body but does not retry a mid-flight transfer failure. That is the intended tradeoff for a best-effort cache write: a failed snapshot costs one re-clone on the next run, whereas resumable uploads add a session round trip to every write.

## Benchmark impact

None. Task-repo contents and dataset rows are byte-identical; only the transport between the checkout directory and GCS changed.

## Reviewer focus

- `pipeTarGzTo` / `extractTarGzFrom`: the `pipeline` result and the `tar` exit code are awaited separately, and an error in either kills the process and surfaces the original error.
- Whether `resumable: false` is the right upload mode here, given the no-mid-flight-retry tradeoff above.
- The `GcsObjectClient` split: streams for archives, `Buffer` for JSON pages.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/aa04db333dcb4c80a68f1ea832e72857
Open in Devin Desktop: https://openrouter.devinenterprise.com/desktop/session/aa04db333dcb4c80a68f1ea832e72857?variant=devin
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->