### PR TITLE
feat(datasets): log dataset cache hits, misses and checkout hydrates

### DIFF
--- a/src/datasets/cache-store.test.ts
+++ b/src/datasets/cache-store.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import {
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -13,6 +14,7 @@ import { PassThrough, Readable } from "node:stream";
 
 import type { GcsObjectClient } from "./cache-store";
 import {
+  makeDiskCacheStore,
   makeGcsCacheStore,
   pipeTarGzTo,
   resolveCacheStore,
@@ -76,7 +78,10 @@ function makeMemoryGcsClient(): GcsObjectClient & {
 describe("GcsCacheStore", () => {
   const savedBackend = process.env.BENCH_DATASET_CACHE_BACKEND;
   const savedDisable = process.env.BENCH_DATASET_CACHE_DISABLE;
+  const savedLogLevel = process.env.LOG_LEVEL;
+  const savedOrEnv = process.env.OR_ENV;
   const tmpDirs: string[] = [];
+  const infoSpies: { mockRestore: () => void }[] = [];
   afterEach(() => {
     for (const name of [
       "BENCH_DATASET_CACHE_BACKEND",
@@ -89,6 +94,19 @@ describe("GcsCacheStore", () => {
     }
     if (savedDisable !== undefined) {
       process.env.BENCH_DATASET_CACHE_DISABLE = savedDisable;
+    }
+    if (savedLogLevel === undefined) {
+      delete process.env.LOG_LEVEL;
+    } else {
+      process.env.LOG_LEVEL = savedLogLevel;
+    }
+    if (savedOrEnv === undefined) {
+      delete process.env.OR_ENV;
+    } else {
+      process.env.OR_ENV = savedOrEnv;
+    }
+    for (const info of infoSpies.splice(0)) {
+      info.mockRestore();
     }
     while (tmpDirs.length > 0) {
       const dir = tmpDirs.pop();
@@ -103,6 +121,83 @@ describe("GcsCacheStore", () => {
     tmpDirs.push(dir);
     return dir;
   }
+
+  function captureInfo() {
+    process.env.OR_ENV = "development";
+    process.env.LOG_LEVEL = "1";
+    const info = spyOn(console, "info").mockImplementation(() => {});
+    infoSpies.push(info);
+    return info;
+  }
+
+  it("logs a hit when a fresh JSON object is read", async () => {
+    const client = makeMemoryGcsClient();
+    const store = makeGcsCacheStore({ bucket: "b", client });
+    await store.writeJson("hit.json", { ok: true });
+    const info = captureInfo();
+
+    await expect(store.readJson("hit.json")).resolves.toEqual({ ok: true });
+
+    expect(info.mock.calls).toEqual([
+      [
+        "dataset cache read",
+        { backend: "gcs", key: "hit.json", result: "hit" },
+      ],
+    ]);
+  });
+
+  it("logs a miss when a JSON object is absent", async () => {
+    const client = makeMemoryGcsClient();
+    const store = makeGcsCacheStore({ bucket: "b", client });
+    const info = captureInfo();
+
+    await expect(store.readJson("missing.json")).resolves.toBeUndefined();
+
+    expect(info.mock.calls).toEqual([
+      [
+        "dataset cache read",
+        { backend: "gcs", key: "missing.json", result: "miss" },
+      ],
+    ]);
+  });
+
+  it("logs stale when a JSON object exceeds maxAgeMs", async () => {
+    const client = makeMemoryGcsClient();
+    const store = makeGcsCacheStore({ bucket: "b", client });
+    await store.writeJson("stale.json", { ok: true });
+    client.setUpdated("stale.json", 1_000);
+    const info = captureInfo();
+
+    await expect(
+      store.readJson("stale.json", { maxAgeMs: 1_000, now: 3_000 })
+    ).resolves.toBeUndefined();
+
+    expect(info.mock.calls).toEqual([
+      [
+        "dataset cache read",
+        { backend: "gcs", key: "stale.json", result: "stale" },
+      ],
+    ]);
+  });
+
+  it("logs invalid when a JSON object cannot be parsed", async () => {
+    const client = makeMemoryGcsClient();
+    client.store.set("invalid.json", {
+      content: Buffer.from("{"),
+      updated: Date.now(),
+    });
+    const store = makeGcsCacheStore({ bucket: "b", client });
+    const info = captureInfo();
+
+    await expect(store.readJson("invalid.json")).resolves.toBeUndefined();
+
+    expect(info.mock.calls).toEqual([
+      [
+        "dataset cache read",
+        { backend: "gcs", key: "invalid.json", result: "invalid" },
+      ],
+    ]);
+  });
 
   it("readJson/writeJson round-trip under the configured prefix", async () => {
     const client = makeMemoryGcsClient();
@@ -189,13 +284,74 @@ describe("GcsCacheStore", () => {
     );
   });
 
+  it("logs a checkout hydrate hit after extraction succeeds", async () => {
+    const client = makeMemoryGcsClient();
+    const store = makeGcsCacheStore({ bucket: "b", client });
+    const src = makeTmpDir();
+    writeFileSync(join(src, "task.toml"), "name = 'a'\n");
+    await store.snapshotCheckout(src, "harbor", "deadbeefdeadbeef");
+    const info = captureInfo();
+    const dest = makeTmpDir();
+
+    await expect(
+      store.tryHydrateCheckout(dest, "harbor", "deadbeefdeadbeef")
+    ).resolves.toBe(true);
+
+    expect(info.mock.calls).toEqual([
+      [
+        "checkout cache hydrate",
+        {
+          key: "repos/harbor-deadbeefdead.tar.gz",
+          scope: "harbor",
+          commit: "deadbeefdeadbeef",
+          result: "hit",
+        },
+      ],
+    ]);
+  });
+
   it("tryHydrateCheckout returns false when no snapshot exists", async () => {
     const client = makeMemoryGcsClient();
     const store = makeGcsCacheStore({ bucket: "b", client });
     const dir = makeTmpDir();
+    const info = captureInfo();
+
     await expect(
       store.tryHydrateCheckout(dir, "harbor", "abc123")
     ).resolves.toBe(false);
+
+    expect(info.mock.calls).toEqual([
+      [
+        "checkout cache hydrate",
+        {
+          key: "repos/harbor-abc123.tar.gz",
+          scope: "harbor",
+          commit: "abc123",
+          result: "miss",
+        },
+      ],
+    ]);
+  });
+
+  it("logs when a checkout snapshot is written", async () => {
+    const client = makeMemoryGcsClient();
+    const store = makeGcsCacheStore({ bucket: "b", client });
+    const src = makeTmpDir();
+    writeFileSync(join(src, "task.toml"), "name = 'a'\n");
+    const info = captureInfo();
+
+    await store.snapshotCheckout(src, "harbor", "deadbeefdeadbeef");
+
+    expect(info.mock.calls).toEqual([
+      [
+        "checkout cache snapshot written",
+        {
+          key: "repos/harbor-deadbeefdead.tar.gz",
+          scope: "harbor",
+          commit: "deadbeefdeadbeef",
+        },
+      ],
+    ]);
   });
 
   it("aborts the upload when tar exits nonzero", async () => {
@@ -215,6 +371,105 @@ describe("GcsCacheStore", () => {
     const cacheStore = await import("./cache-store");
     expect("createTarGz" in cacheStore).toBe(false);
     expect("extractTarGz" in cacheStore).toBe(false);
+  });
+});
+
+describe("DiskCacheStore", () => {
+  const savedCacheDir = process.env.BENCH_DATASET_CACHE_DIR;
+  const savedDisable = process.env.BENCH_DATASET_CACHE_DISABLE;
+  const savedLogLevel = process.env.LOG_LEVEL;
+  const savedOrEnv = process.env.OR_ENV;
+  const tmpDirs: string[] = [];
+  const infoSpies: { mockRestore: () => void }[] = [];
+
+  afterEach(() => {
+    if (savedCacheDir === undefined) {
+      delete process.env.BENCH_DATASET_CACHE_DIR;
+    } else {
+      process.env.BENCH_DATASET_CACHE_DIR = savedCacheDir;
+    }
+    if (savedDisable === undefined) {
+      delete process.env.BENCH_DATASET_CACHE_DISABLE;
+    } else {
+      process.env.BENCH_DATASET_CACHE_DISABLE = savedDisable;
+    }
+    if (savedLogLevel === undefined) {
+      delete process.env.LOG_LEVEL;
+    } else {
+      process.env.LOG_LEVEL = savedLogLevel;
+    }
+    if (savedOrEnv === undefined) {
+      delete process.env.OR_ENV;
+    } else {
+      process.env.OR_ENV = savedOrEnv;
+    }
+    for (const info of infoSpies.splice(0)) {
+      info.mockRestore();
+    }
+    while (tmpDirs.length > 0) {
+      const dir = tmpDirs.pop();
+      if (dir !== undefined) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("logs enabled disk JSON cache classifications", async () => {
+    const root = mkdtempSync(join(tmpdir(), "disk-cache-test-"));
+    tmpDirs.push(root);
+    process.env.BENCH_DATASET_CACHE_DIR = root;
+    process.env.BENCH_DATASET_CACHE_DISABLE = "0";
+    process.env.OR_ENV = "development";
+    process.env.LOG_LEVEL = "1";
+    const info = spyOn(console, "info").mockImplementation(() => {});
+    infoSpies.push(info);
+    const store = makeDiskCacheStore();
+    writeFileSync(join(root, "hit.json"), JSON.stringify({ ok: true }));
+    writeFileSync(join(root, "invalid.json"), "{");
+    writeFileSync(join(root, "stale.json"), JSON.stringify({ ok: true }));
+    const staleTime = new Date(1_000);
+    utimesSync(join(root, "stale.json"), staleTime, staleTime);
+
+    await expect(store.readJson("hit.json")).resolves.toEqual({ ok: true });
+    await expect(store.readJson("missing.json")).resolves.toBeUndefined();
+    await expect(
+      store.readJson("stale.json", { maxAgeMs: 1_000, now: 3_000 })
+    ).resolves.toBeUndefined();
+    await expect(store.readJson("invalid.json")).resolves.toBeUndefined();
+
+    expect(info.mock.calls).toEqual([
+      [
+        "dataset cache read",
+        { backend: "disk", key: "hit.json", result: "hit" },
+      ],
+      [
+        "dataset cache read",
+        { backend: "disk", key: "missing.json", result: "miss" },
+      ],
+      [
+        "dataset cache read",
+        { backend: "disk", key: "stale.json", result: "stale" },
+      ],
+      [
+        "dataset cache read",
+        { backend: "disk", key: "invalid.json", result: "invalid" },
+      ],
+    ]);
+  });
+
+  it("does not log disabled disk checkout no-ops", async () => {
+    process.env.BENCH_DATASET_CACHE_DISABLE = "1";
+    process.env.OR_ENV = "development";
+    process.env.LOG_LEVEL = "1";
+    const info = spyOn(console, "info").mockImplementation(() => {});
+    infoSpies.push(info);
+    const store = makeDiskCacheStore();
+
+    await store.readJson("disabled.json");
+    await store.tryHydrateCheckout("unused", "harbor", "abc123");
+    await store.snapshotCheckout("unused", "harbor", "abc123");
+
+    expect(info).not.toHaveBeenCalled();
   });
 });
 

--- a/src/datasets/cache-store.test.ts
+++ b/src/datasets/cache-store.test.ts
@@ -5,7 +5,6 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
-  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -425,17 +424,9 @@ describe("DiskCacheStore", () => {
     infoSpies.push(info);
     const store = makeDiskCacheStore();
     writeFileSync(join(root, "hit.json"), JSON.stringify({ ok: true }));
-    writeFileSync(join(root, "invalid.json"), "{");
-    writeFileSync(join(root, "stale.json"), JSON.stringify({ ok: true }));
-    const staleTime = new Date(1_000);
-    utimesSync(join(root, "stale.json"), staleTime, staleTime);
 
     await expect(store.readJson("hit.json")).resolves.toEqual({ ok: true });
     await expect(store.readJson("missing.json")).resolves.toBeUndefined();
-    await expect(
-      store.readJson("stale.json", { maxAgeMs: 1_000, now: 3_000 })
-    ).resolves.toBeUndefined();
-    await expect(store.readJson("invalid.json")).resolves.toBeUndefined();
 
     expect(info.mock.calls).toEqual([
       [
@@ -445,14 +436,6 @@ describe("DiskCacheStore", () => {
       [
         "dataset cache read",
         { backend: "disk", key: "missing.json", result: "miss" },
-      ],
-      [
-        "dataset cache read",
-        { backend: "disk", key: "stale.json", result: "stale" },
-      ],
-      [
-        "dataset cache read",
-        { backend: "disk", key: "invalid.json", result: "invalid" },
       ],
     ]);
   });

--- a/src/datasets/cache-store.ts
+++ b/src/datasets/cache-store.ts
@@ -1,5 +1,4 @@
 import { spawn } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { Readable, Writable } from "node:stream";
 import { finished, pipeline } from "node:stream/promises";
@@ -135,22 +134,7 @@ export function makeDiskCacheStore(): CacheStore {
         logDatasetCacheRead("disk", key, "hit");
         return value;
       }
-      if (opts?.maxAgeMs !== undefined) {
-        try {
-          const ageMs = Math.max(
-            0,
-            (opts.now ?? Date.now()) - statSync(path).mtimeMs
-          );
-          if (ageMs >= opts.maxAgeMs) {
-            logDatasetCacheRead("disk", key, "stale");
-            return undefined;
-          }
-        } catch {
-          logDatasetCacheRead("disk", key, "miss");
-          return undefined;
-        }
-      }
-      logDatasetCacheRead("disk", key, existsSync(path) ? "invalid" : "miss");
+      logDatasetCacheRead("disk", key, "miss");
       return undefined;
     },
     async writeJson(key, value) {

--- a/src/datasets/cache-store.ts
+++ b/src/datasets/cache-store.ts
@@ -1,10 +1,11 @@
 import { spawn } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import type { Readable, Writable } from "node:stream";
 import { finished, pipeline } from "node:stream/promises";
 
 import { getGcsStorage } from "../internal/gcs";
-import { wLog } from "../internal/log";
+import { iLog, wLog } from "../internal/log";
 import {
   datasetCacheDisabled,
   datasetCacheRoot,
@@ -22,6 +23,16 @@ export type DatasetCacheBackend = "disk" | "gcs";
 export interface ReadJsonOptions {
   readonly maxAgeMs?: number;
   readonly now?: number;
+}
+
+type DatasetCacheReadResult = "hit" | "miss" | "stale" | "invalid";
+
+function logDatasetCacheRead(
+  backend: DatasetCacheBackend,
+  key: string,
+  result: DatasetCacheReadResult
+): void {
+  iLog("dataset cache read", { backend, key, result });
 }
 
 export interface CacheStore {
@@ -118,7 +129,29 @@ export function makeDiskCacheStore(): CacheStore {
       if (root === undefined) {
         return undefined;
       }
-      return readJsonCacheFile(join(root, key), opts);
+      const path = join(root, key);
+      const value = readJsonCacheFile(path, opts);
+      if (value !== undefined) {
+        logDatasetCacheRead("disk", key, "hit");
+        return value;
+      }
+      if (opts?.maxAgeMs !== undefined) {
+        try {
+          const ageMs = Math.max(
+            0,
+            (opts.now ?? Date.now()) - statSync(path).mtimeMs
+          );
+          if (ageMs >= opts.maxAgeMs) {
+            logDatasetCacheRead("disk", key, "stale");
+            return undefined;
+          }
+        } catch {
+          logDatasetCacheRead("disk", key, "miss");
+          return undefined;
+        }
+      }
+      logDatasetCacheRead("disk", key, existsSync(path) ? "invalid" : "miss");
+      return undefined;
     },
     async writeJson(key, value) {
       const root = datasetCacheRoot();
@@ -232,20 +265,26 @@ export function makeGcsCacheStore(opts: GcsCacheStoreOptions): CacheStore {
       if (readOpts?.maxAgeMs !== undefined) {
         const updated = await client.objectUpdatedMs(full);
         if (updated === undefined) {
+          logDatasetCacheRead("gcs", full, "miss");
           return undefined;
         }
         const now = readOpts.now ?? Date.now();
         if (Math.max(0, now - updated) >= readOpts.maxAgeMs) {
+          logDatasetCacheRead("gcs", full, "stale");
           return undefined;
         }
       }
       const buf = await client.downloadObject(full);
       if (buf === undefined) {
+        logDatasetCacheRead("gcs", full, "miss");
         return undefined;
       }
       try {
-        return JSON.parse(buf.toString("utf8"));
+        const value: unknown = JSON.parse(buf.toString("utf8"));
+        logDatasetCacheRead("gcs", full, "hit");
+        return value;
       } catch {
+        logDatasetCacheRead("gcs", full, "invalid");
         return undefined;
       }
     },
@@ -266,9 +305,21 @@ export function makeGcsCacheStore(opts: GcsCacheStoreOptions): CacheStore {
       try {
         const src = await client.openObjectReadStream(full);
         if (src === undefined) {
+          iLog("checkout cache hydrate", {
+            key: full,
+            scope,
+            commit,
+            result: "miss",
+          });
           return false;
         }
         await extractTarGzFrom(src, localDir);
+        iLog("checkout cache hydrate", {
+          key: full,
+          scope,
+          commit,
+          result: "hit",
+        });
         return true;
       } catch (error) {
         wLog("GCS checkout hydrate failed", {
@@ -283,6 +334,7 @@ export function makeGcsCacheStore(opts: GcsCacheStoreOptions): CacheStore {
       try {
         const dest = client.openObjectWriteStream(full, "application/gzip");
         await pipeTarGzTo(localDir, dest);
+        iLog("checkout cache snapshot written", { key: full, scope, commit });
       } catch (error) {
         wLog("GCS checkout snapshot failed", {
           key: full,


### PR DESCRIPTION
## TL;DR

Emit a log line for every dataset-cache read and checkout hydrate/snapshot, so a cache hit is distinguishable from a cold miss in production.

## What changed?

- `readJson` on both stores now emits one `dataset cache read` info line per call. The GCS store classifies `result` as `hit`, `miss`, `stale` (object older than `maxAgeMs`) or `invalid` (object present but not parseable JSON); the disk store logs `hit`/`miss` only, since `readJsonCacheFile` owns the staleness rules and re-deriving them here would duplicate them.
- `tryHydrateCheckout` emits `checkout cache hydrate` with `result: hit | miss`, and `snapshotCheckout` emits `checkout cache snapshot written` once the tarball is committed.
- Fields are named scalars only (`backend`, `key`, `scope`, `commit`, `result`) — no buffers, parsed bodies or raw errors.
- Return values, control flow and the existing `wLog` failure paths are untouched; a disabled cache stays silent (both stores return before logging when the cache is off).

## Why?

The cache had failure telemetry but no success telemetry, so in production a hit and a miss were both completely silent — and not just at info level: in `readJson` with `maxAgeMs`, a missing object returns at `objectUpdatedMs() === undefined` before `downloadObject`, so even the existing `GCS cache download miss/failed` warn never fires on the ordinary miss path. After enabling the GCS backend on the bench workers there was no way to answer "did that run hit cache?" from logs, which is what prompted this.

## How to test

```bash
bun test src/datasets
```

Unit tests assert the emitted lines for all four GCS classifications, hydrate hit/miss and snapshot-written.

In production, `dataset cache read` with `result:hit` on a run whose dataset a previous run already fetched, and `checkout cache hydrate` with `result:hit` on a second terminal-bench/harbor run at the same task-repo commit.

## Reviewer focus

- Log volume: one line per HF row page (tens per run) and one per checkout. Info level is deliberate so it is visible with default harness log settings.
- The disk store deliberately does not distinguish `stale`/`invalid`.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/aa04db333dcb4c80a68f1ea832e72857
Open in Devin Desktop: https://openrouter.devinenterprise.com/desktop/session/aa04db333dcb4c80a68f1ea832e72857?variant=devin
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->