### PR TITLE
feat: require explicit reasoning effort in every benchmark client (ECO-3608)

### DIFF
--- a/src/benchmarks/agent-cli/runner.ts
+++ b/src/benchmarks/agent-cli/runner.ts
@@ -14,11 +14,7 @@ import { recordGenerationId } from "../../runtime/generation-ids";
 import type { SandboxSessionInstance } from "../harbor/sandbox";
 import type { OriAgentRun, OriHarnessDef } from "./harness";
 import type { OriChannel, OriReasoningEffort } from "./schema";
-import {
-  DEFAULT_ORI_CHANNEL,
-  DEFAULT_ORI_INSTALL_URL,
-  DEFAULT_ORI_REASONING_EFFORT,
-} from "./schema";
+import { DEFAULT_ORI_CHANNEL, DEFAULT_ORI_INSTALL_URL } from "./schema";
 
 const EXIT_DETAIL_TAIL_CHARS = 500;
 
@@ -93,7 +89,7 @@ export interface AgentCliOpts {
   readonly oriInstallUrl?: string;
   readonly systemPrompt?: string;
   readonly appendSystemPrompt?: string;
-  readonly agentReasoningEffort?: OriReasoningEffort;
+  readonly agentReasoningEffort: OriReasoningEffort;
   readonly oriChannel?: OriChannel;
   readonly allowedTools?: readonly string[];
   readonly disallowedTools?: readonly string[];
@@ -187,7 +183,7 @@ export function runAgentCli(input: {
   const script = harness.buildRunScript({
     instructionPath,
     logPath: harness.remoteLogPath,
-    reasoningEffort: opts.agentReasoningEffort ?? DEFAULT_ORI_REASONING_EFFORT,
+    reasoningEffort: opts.agentReasoningEffort,
     hasSystemPrompt: opts.systemPrompt !== undefined,
     hasAppendSystemPrompt: opts.appendSystemPrompt !== undefined,
     hasAllowedTools: (opts.allowedTools ?? []).length > 0,

--- a/src/benchmarks/agent-cli/schema.ts
+++ b/src/benchmarks/agent-cli/schema.ts
@@ -22,8 +22,6 @@ export const ORI_REASONING_EFFORTS = [
 
 export type OriReasoningEffort = ValueOf<typeof ORI_REASONING_EFFORTS>;
 
-export const DEFAULT_ORI_REASONING_EFFORT: OriReasoningEffort = "medium";
-
 export const DEFAULT_CLAUDE_PACKAGE =
   "@anthropic-ai/claude-code@2.1.235" as const;
 

--- a/src/benchmarks/benchmark-config.test.ts
+++ b/src/benchmarks/benchmark-config.test.ts
@@ -16,6 +16,7 @@ describe("benchmark config", () => {
     const result = parseSchema(NativeBenchmarkRunConfigSchema, {
       benchmarkId: "search_hle",
       model: "openai/gpt-5.4",
+      reasoningEffort: "high",
     });
 
     assertRight(result);
@@ -37,10 +38,20 @@ describe("benchmark config", () => {
     assertLeft(result);
   });
 
+  it("requires reasoningEffort in model benchmark configs", () => {
+    const result = parseSchema(BenchmarkRunConfigSchema, {
+      benchmarkId: "gpqa_diamond",
+      model: "openai/gpt-5",
+    });
+
+    assertLeft(result);
+  });
+
   it("parses injected benchmark configs with opaque options", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "injected_benchmark",
       model: "injected/model",
+      reasoningEffort: "high",
       options: {
         subsets: ["all"],
         customFlag: true,
@@ -51,6 +62,7 @@ describe("benchmark config", () => {
     expect(result.right).toEqual({
       benchmarkId: "injected_benchmark",
       model: "injected/model",
+      reasoningEffort: "high",
       options: {
         subsets: ["all"],
         customFlag: true,
@@ -65,6 +77,7 @@ describe("benchmark config", () => {
     const result = parseSchema(InjectedBenchmarkRunConfigSchema, {
       benchmarkId: "injected_benchmark",
       model: "injected/model",
+      reasoningEffort: "high",
     });
 
     assertRight(result);
@@ -75,6 +88,7 @@ describe("benchmark config", () => {
     const result = parseSchema(InjectedBenchmarkRunConfigSchema, {
       benchmarkId: "gpqa_diamond",
       model: "injected/model",
+      reasoningEffort: "high",
       options: { subsets: ["all"] },
     });
 

--- a/src/benchmarks/benchmark-config.ts
+++ b/src/benchmarks/benchmark-config.ts
@@ -10,7 +10,6 @@ import {
   DEFAULT_HARBOR_AGENT,
   DEFAULT_ORI_CHANNEL,
   DEFAULT_ORI_INSTALL_URL,
-  DEFAULT_ORI_REASONING_EFFORT,
   HARBOR_AGENTS,
   ORI_CHANNELS,
   ORI_REASONING_EFFORTS,
@@ -42,7 +41,7 @@ export type GeminiMediaResolution = ValueOf<typeof GEMINI_MEDIA_RESOLUTIONS>;
 export const InferenceOverrideSchema = z.object({
   temperature: z.number().optional(),
   maxTokens: z.number().optional(),
-  reasoningEffort: z.enum(REASONING_EFFORTS).optional(),
+  reasoningEffort: z.enum(REASONING_EFFORTS),
   costTier: z.enum(COST_TIERS).optional(),
   timeoutMs: z.number().optional(),
   sort: z.nativeEnum(ProviderSort).optional(),
@@ -97,6 +96,7 @@ export type MmluProBenchmarkConfig = z.infer<
 
 export const TauBenchOptionsSchema = z.object({
   userModel: zDefaultedText(TAU_BENCH_AIRLINE_META.userModel),
+  userReasoningEffort: z.enum(REASONING_EFFORTS).default("medium"),
 });
 
 export const TauBenchAirlineConfigSchema = z.object({
@@ -146,9 +146,7 @@ export const TerminalBenchOptionsSchema = z.object({
   agent: z.enum(TERMINAL_BENCH_AGENTS).default(DEFAULT_TERMINAL_BENCH_AGENT),
   agentPackage: z.string().optional(),
   oriInstallUrl: z.string().default(DEFAULT_ORI_INSTALL_URL),
-  agentReasoningEffort: z
-    .enum(ORI_REASONING_EFFORTS)
-    .default(DEFAULT_ORI_REASONING_EFFORT),
+  agentReasoningEffort: z.enum(ORI_REASONING_EFFORTS),
   oriChannel: z.enum(ORI_CHANNELS).default(DEFAULT_ORI_CHANNEL),
   systemPrompt: z.string().optional(),
   allowedTools: z.array(z.string()).optional(),
@@ -192,9 +190,7 @@ const AgenticOptionsSchema = z.object({
   agent: z.enum(HARBOR_AGENTS).default(DEFAULT_HARBOR_AGENT),
   agentPackage: z.string().optional(),
   oriInstallUrl: z.string().default(DEFAULT_ORI_INSTALL_URL),
-  agentReasoningEffort: z
-    .enum(ORI_REASONING_EFFORTS)
-    .default(DEFAULT_ORI_REASONING_EFFORT),
+  agentReasoningEffort: z.enum(ORI_REASONING_EFFORTS),
   oriChannel: z.enum(ORI_CHANNELS).default(DEFAULT_ORI_CHANNEL),
   systemPrompt: z.string().optional(),
   appendSystemPrompt: z.string().optional(),

--- a/src/benchmarks/deep-swe/solver.test.ts
+++ b/src/benchmarks/deep-swe/solver.test.ts
@@ -180,6 +180,7 @@ const SOLVER_OPTS = {
   apiKey: "sk-test",
   stepLimit: 10,
   endpointId: "ep-pinned",
+  inference: { reasoningEffort: "low" },
 } as const;
 const CLAUDE_STREAM = [
   JSON.stringify({
@@ -413,7 +414,7 @@ describe("deep-swe solver", () => {
     expect(record.configs.length).toBeGreaterThan(0);
     for (const cfg of record.configs) {
       expect(cfg.endpointId).toBe("ep-pinned");
-      expect(cfg.reasoningEffort).toBe("high");
+      expect(cfg.reasoningEffort).toBe("low");
       expect(cfg.instructions).toContain("helpful assistant");
       expect(cfg.tools?.[0]?.name).toBe("bash");
     }

--- a/src/benchmarks/deep-swe/solver.ts
+++ b/src/benchmarks/deep-swe/solver.ts
@@ -56,8 +56,6 @@ import { ensureTasksCheckedOut } from "./tasks-source";
 
 const DEEP_SWE_TEMPERATURE = 1;
 
-const DEEP_SWE_REASONING_EFFORT = "high" as const;
-
 const PER_COMMAND_TIMEOUT_SEC = 1800;
 
 const SANDBOX_TIMEOUT_MARGIN_SEC = 300;
@@ -76,7 +74,7 @@ export interface DeepSweSolverOpts {
   readonly apiKey: string;
   readonly endpointId?: string;
   readonly stepLimit: number;
-  readonly inference?: InferenceOverride;
+  readonly inference: InferenceOverride;
   readonly sessionId?: string;
   readonly agent?: HarborAgent;
   readonly agentCli?: AgentCliOpts;
@@ -110,6 +108,7 @@ export function makeDeepSweSolver(
         apiKey: opts.apiKey,
         ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
         ...(opts.sessionId !== undefined && { sessionId: opts.sessionId }),
+        agentReasoningEffort: opts.inference.reasoningEffort,
       };
       const cliOpts: AgentCliOpts = {
         ...baseCliOpts,
@@ -190,10 +189,9 @@ export function makeDeepSweSolver(
           : undefined;
       const genConfig: ResponsesGenerateConfig = {
         temperature: DEEP_SWE_TEMPERATURE,
-        reasoningEffort: DEEP_SWE_REASONING_EFFORT,
         tools: [BASH_RESPONSES_TOOL_DEFINITION],
         instructions: MINI_SWE_SYSTEM_MESSAGE,
-        ...definedValues(opts.inference ?? {}),
+        ...definedValues(opts.inference),
         ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
       };
       const result = yield* gen(function* () {

--- a/src/benchmarks/draco/solver.ts
+++ b/src/benchmarks/draco/solver.ts
@@ -232,9 +232,7 @@ function dracoJudgeConfig(config: DracoPanelConfig): JudgeConfig {
     temperature: config.judgeTemperature ?? 0.2,
     timeoutMs: config.timeout * 1000,
     retry: { maxRetries: 0 },
-    ...(config.judgeReasoningEffort !== undefined && {
-      reasoningEffort: config.judgeReasoningEffort,
-    }),
+    reasoningEffort: config.judgeReasoningEffort,
     ...(config.versionOverride !== undefined && {
       versionOverride: config.versionOverride,
     }),

--- a/src/benchmarks/gpqa-solver.test.ts
+++ b/src/benchmarks/gpqa-solver.test.ts
@@ -63,13 +63,18 @@ async function runSolver(
 }
 describe("gpqaSolver inference overrides (openbench parity)", () => {
   it("uses the gpqa temperature default when no override is given", async () => {
-    const config = await runSolver();
+    const config = await runSolver({
+      inference: { reasoningEffort: "high" },
+    });
     expect(config?.temperature).toBe(GPQA_TEMPERATURE);
     expect(config?.endpointId).toBeUndefined();
     expect(config?.maxTokens).toBeUndefined();
   });
   it("forwards endpointId and falls back to the default temperature", async () => {
-    const config = await runSolver({ endpointId: "ep-1" });
+    const config = await runSolver({
+      endpointId: "ep-1",
+      inference: { reasoningEffort: "high" },
+    });
     expect(config?.temperature).toBe(GPQA_TEMPERATURE);
     expect(config?.endpointId).toBe("ep-1");
   });
@@ -100,10 +105,10 @@ describe("gpqaSolver inference overrides (openbench parity)", () => {
   });
   it("drops undefined override fields (does not clobber defaults with undefined)", async () => {
     const config = await runSolver({
-      inference: { maxTokens: 42 },
+      inference: { maxTokens: 42, reasoningEffort: "high" },
     });
     expect(config?.temperature).toBe(GPQA_TEMPERATURE);
     expect(config?.maxTokens).toBe(42);
-    expect(config?.reasoningEffort).toBeUndefined();
+    expect(config?.reasoningEffort).toBe("high");
   });
 });

--- a/src/benchmarks/gpqa.ts
+++ b/src/benchmarks/gpqa.ts
@@ -92,15 +92,15 @@ export const GPQA_DATASET = {
 
 export function gpqaSolver(
   model: ModelService,
-  opts?: {
+  opts: {
     readonly endpointId?: string;
-    readonly inference?: FixedTemperatureInferenceOverride;
+    readonly inference: FixedTemperatureInferenceOverride;
   }
 ): SolverService {
   const config: GenerateConfig = {
     temperature: GPQA_TEMPERATURE,
-    ...definedValues(opts?.inference ?? {}),
-    ...(opts?.endpointId !== undefined && { endpointId: opts.endpointId }),
+    ...definedValues(opts.inference),
+    ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
   };
   return chain(
     systemMessage(SIMPLE_EVALS_SYSTEM_MESSAGE),

--- a/src/benchmarks/ifstruct/benchmark.ts
+++ b/src/benchmarks/ifstruct/benchmark.ts
@@ -121,15 +121,15 @@ export const IFSTRUCT_DATASET = {
 
 export function ifStructSolver(
   model: ModelService,
-  opts?: {
+  opts: {
     readonly endpointId?: string;
-    readonly inference?: InferenceOverride;
+    readonly inference: InferenceOverride;
   }
 ): SolverService {
   const config: GenerateConfig = {
     temperature: IFSTRUCT_TEMPERATURE,
-    ...definedValues(opts?.inference ?? {}),
-    ...(opts?.endpointId !== undefined && { endpointId: opts.endpointId }),
+    ...definedValues(opts.inference),
+    ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
   };
   return generate(model, config);
 }

--- a/src/benchmarks/mmlu-pro-solver.test.ts
+++ b/src/benchmarks/mmlu-pro-solver.test.ts
@@ -34,7 +34,9 @@ describe("mmluProSolver", () => {
         });
       },
     };
-    const solver = mmluProSolver(model);
+    const solver = mmluProSolver(model, {
+      inference: { reasoningEffort: "high" },
+    });
     await runPromise(
       solver(
         initialTaskState({
@@ -46,6 +48,7 @@ describe("mmluProSolver", () => {
     );
     expect(recorded.config).toEqual({
       temperature: MMLU_PRO_TEMPERATURE,
+      reasoningEffort: "high",
     });
     expect(recorded.config?.maxTokens).toBeUndefined();
     expect(recorded.messages).toEqual([

--- a/src/benchmarks/mmlu-pro.ts
+++ b/src/benchmarks/mmlu-pro.ts
@@ -87,15 +87,15 @@ export function makeMmluProDatasetLayer(
 
 export function mmluProSolver(
   model: ModelService,
-  opts?: {
+  opts: {
     readonly endpointId?: string;
-    readonly inference?: InferenceOverride;
+    readonly inference: InferenceOverride;
   }
 ): SolverService {
   const config: GenerateConfig = {
     temperature: MMLU_PRO_TEMPERATURE,
-    ...definedValues(opts?.inference ?? {}),
-    ...(opts?.endpointId !== undefined && { endpointId: opts.endpointId }),
+    ...definedValues(opts.inference),
+    ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
   };
   return generate(model, config);
 }

--- a/src/benchmarks/mmmu-pro-vision.ts
+++ b/src/benchmarks/mmmu-pro-vision.ts
@@ -122,17 +122,17 @@ export function makeMmmuProVisionDatasetLayer(
 
 export function mmmuProVisionSolver(
   model: ModelService,
-  opts?: {
+  opts: {
     readonly endpointId?: string;
-    readonly inference?: InferenceOverride;
+    readonly inference: InferenceOverride;
     readonly mediaResolution?: GeminiMediaResolution;
   }
 ): SolverService {
   const config: GenerateConfig = {
     temperature: 0,
-    ...definedValues(opts?.inference ?? {}),
-    ...(opts?.endpointId !== undefined && { endpointId: opts.endpointId }),
-    ...(opts?.mediaResolution !== undefined && {
+    ...definedValues(opts.inference),
+    ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
+    ...(opts.mediaResolution !== undefined && {
       extraBody: { media_resolution: opts.mediaResolution },
     }),
   };

--- a/src/benchmarks/registry.test.ts
+++ b/src/benchmarks/registry.test.ts
@@ -33,7 +33,11 @@ describe("benchmark registry", () => {
     const result = await runBenchmarkById({
       benchmarkId: "gpqa_diamond",
       apiKey: "unused",
-      benchmarkConfig: { benchmarkId: "gpqa_diamond", model: "test/model" },
+      benchmarkConfig: {
+        benchmarkId: "gpqa_diamond",
+        model: "test/model",
+        reasoningEffort: "high",
+      },
       epochs: 1,
       maxConcurrency: 1,
       range: { start: 0, end: 1 },
@@ -64,11 +68,13 @@ describe("benchmark registry", () => {
     const config = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "search_hle",
       model: "openai/gpt-5.4-nano",
+      reasoningEffort: "high",
     });
     assertRight(config);
     expect(config.right).toEqual({
       benchmarkId: "search_hle",
       model: "openai/gpt-5.4-nano",
+      reasoningEffort: "high",
       lane: { webSearch: "server-tool", engine: "auto" },
     });
   });
@@ -82,11 +88,13 @@ describe("benchmark registry", () => {
     const config = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "search_dsqa",
       model: "openai/gpt-5.4-nano",
+      reasoningEffort: "high",
     });
     assertRight(config);
     expect(config.right).toEqual({
       benchmarkId: "search_dsqa",
       model: "openai/gpt-5.4-nano",
+      reasoningEffort: "high",
       lane: { webSearch: "server-tool", engine: "auto" },
     });
   });
@@ -96,6 +104,7 @@ describe("benchmark registry", () => {
       isSearchBenchmarkConfig({
         benchmarkId: "search_dsqa",
         model: "model",
+        reasoningEffort: "high",
         lane: { webSearch: "server-tool", engine: "auto" },
       })
     ).toBe(true);
@@ -112,11 +121,13 @@ describe("benchmark registry", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "search_widesearch",
       model: "openai/gpt-5.4-nano",
+      reasoningEffort: "high",
     });
     assertRight(result);
     expect(result.right).toEqual({
       benchmarkId: "search_widesearch",
       model: "openai/gpt-5.4-nano",
+      reasoningEffort: "high",
       lane: { webSearch: "server-tool", engine: "auto" },
     });
   });
@@ -126,6 +137,7 @@ describe("benchmark registry", () => {
     const config = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "wandr",
       model: "openai/gpt-5.5",
+      reasoningEffort: "high",
     });
     assertRight(config);
     expect(benchmark?.defaultEpochs).toBe(1);
@@ -133,6 +145,7 @@ describe("benchmark registry", () => {
     expect(config.right).toEqual({
       benchmarkId: "wandr",
       model: "openai/gpt-5.5",
+      reasoningEffort: "high",
       modalEnv: "main",
       stepLimit: 64,
       serverTools: [
@@ -146,6 +159,8 @@ describe("benchmark registry", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "swe_atlas_qa",
       model: "anthropic/claude-opus-4.5",
+      reasoningEffort: "high",
+      agentReasoningEffort: "high",
     });
     assertRight(result);
     if (result.right.benchmarkId !== "swe_atlas_qa") {
@@ -156,10 +171,12 @@ describe("benchmark registry", () => {
     expect(result.right.modalEnv).toBe("main");
   });
 
-  it("defaults terminal-bench to the pi agent and the ori install url", () => {
+  it("parses terminal-bench with the pi agent and the ori install url", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "terminal_bench",
       model: "anthropic/claude-opus-5",
+      reasoningEffort: "high",
+      agentReasoningEffort: "high",
     });
     assertRight(result);
     if (result.right.benchmarkId !== "terminal_bench") {
@@ -177,6 +194,8 @@ describe("benchmark registry", () => {
       benchmarkId: "terminal_bench",
       model: "anthropic/claude-opus-5",
       agent: "claude",
+      reasoningEffort: "high",
+      agentReasoningEffort: "high",
     });
     assertRight(result);
     if (result.right.benchmarkId !== "terminal_bench") {
@@ -191,6 +210,8 @@ describe("benchmark registry", () => {
         benchmarkId,
         model: "openai/gpt-5.4",
         agent: "prime-agent",
+        reasoningEffort: "high",
+        agentReasoningEffort: "high",
       });
       assertRight(result);
       expect(result.right.agent).toBe("prime-agent");
@@ -201,12 +222,14 @@ describe("benchmark registry", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "terminal_bench",
       model: "anthropic/claude-opus-5",
+      reasoningEffort: "high",
+      agentReasoningEffort: "high",
     });
     assertRight(result);
     if (result.right.benchmarkId !== "terminal_bench") {
       throw new Error("expected terminal_bench config");
     }
-    expect(result.right.agentReasoningEffort).toBe("medium");
+    expect(result.right.agentReasoningEffort).toBe("high");
     expect(result.right.oriChannel).toBe("stable");
     expect(result.right.isolateAgentConfig).toBe(false);
     expect(result.right.systemPrompt).toBeUndefined();
@@ -219,6 +242,7 @@ describe("benchmark registry", () => {
       benchmarkId: "terminal_bench",
       model: "anthropic/claude-opus-5",
       agentReasoningEffort: "max",
+      reasoningEffort: "high",
     });
     assertRight(parsed);
     if (parsed.right.benchmarkId !== "terminal_bench") {
@@ -232,6 +256,7 @@ describe("benchmark registry", () => {
       benchmarkId: "terminal_bench",
       model: "anthropic/claude-opus-5",
       agentReasoningEffort: "none",
+      reasoningEffort: "high",
     });
     assertRight(parsed);
     if (parsed.right.benchmarkId !== "terminal_bench") {
@@ -245,6 +270,7 @@ describe("benchmark registry", () => {
       benchmarkId: "terminal_bench",
       model: "anthropic/claude-opus-5",
       agentReasoningEffort: "off",
+      reasoningEffort: "high",
     });
     assertLeft(result);
   });
@@ -254,6 +280,8 @@ describe("benchmark registry", () => {
       benchmarkId: "terminal_bench",
       model: "anthropic/claude-opus-5",
       allowedTools: ["Bash", "Edit"],
+      reasoningEffort: "high",
+      agentReasoningEffort: "high",
       disallowedTools: ["WebSearch"],
       isolateAgentConfig: true,
       systemPrompt: "terse",
@@ -273,6 +301,8 @@ describe("benchmark registry", () => {
       benchmarkId: "terminal_bench",
       model: "openai/gpt-5.4",
       agent: "codex",
+      reasoningEffort: "high",
+      agentReasoningEffort: "high",
     });
     assertLeft(result);
   });
@@ -287,6 +317,8 @@ describe("benchmark registry", () => {
       const result = parseSchema(BenchmarkRunConfigSchema, {
         benchmarkId,
         model: "anthropic/claude-opus-4.5",
+        reasoningEffort: "high",
+        agentReasoningEffort: "high",
       });
       assertRight(result);
       if (!("agent" in result.right)) {
@@ -301,6 +333,7 @@ describe("benchmark registry", () => {
       benchmarkId: "deep_swe",
       model: "anthropic/claude-opus-5",
       agent: "claude",
+      reasoningEffort: "high",
       agentReasoningEffort: "high",
       isolateAgentConfig: true,
     });
@@ -318,6 +351,8 @@ describe("benchmark registry", () => {
       benchmarkId: "deep_swe",
       model: "anthropic/claude-opus-5",
       agent: "pi",
+      reasoningEffort: "high",
+      agentReasoningEffort: "high",
     });
     assertRight(result);
     if (result.right.benchmarkId !== "deep_swe") {
@@ -331,6 +366,8 @@ describe("benchmark registry", () => {
       benchmarkId: "deep_swe",
       model: "anthropic/claude-opus-5",
       agent: "codex",
+      reasoningEffort: "high",
+      agentReasoningEffort: "high",
     });
     assertLeft(result);
   });
@@ -339,6 +376,7 @@ describe("benchmark registry", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "wandr",
       model: "openai/gpt-5.5",
+      reasoningEffort: "high",
     });
     assertRight(result);
     expect("agent" in result.right).toBe(false);

--- a/src/benchmarks/search/core/benchmark.ts
+++ b/src/benchmarks/search/core/benchmark.ts
@@ -60,9 +60,7 @@ export function searchSolverOptionsFromConfig({
         : Math.min(requestedMaxOutputTokens, maxOutputTokensCeiling),
     temperature: config.temperature ?? temperature,
     ...(config.timeoutMs !== undefined && { timeoutMs: config.timeoutMs }),
-    ...(config.reasoningEffort !== undefined && {
-      reasoningEffort: config.reasoningEffort,
-    }),
+    reasoningEffort: config.reasoningEffort,
     ...(config.endpointId !== undefined && { endpointId: config.endpointId }),
     ...(config.sort !== undefined && { sort: config.sort }),
     ...(config.providerOrder !== undefined && {

--- a/src/benchmarks/search/core/request.ts
+++ b/src/benchmarks/search/core/request.ts
@@ -27,7 +27,7 @@ export interface SearchRequestOptions {
   readonly lane: SearchLaneConfig;
   readonly maxOutputTokens?: number;
   readonly temperature?: number;
-  readonly reasoningEffort?: ReasoningEffort;
+  readonly reasoningEffort: ReasoningEffort;
   readonly sort?: ProviderSort;
   readonly providerOrder?: readonly string[];
   readonly providerOnly?: readonly string[];
@@ -121,9 +121,7 @@ export function buildSearchRequestBody(
     ...definedValues({
       maxOutputTokens: opts.maxOutputTokens,
       temperature: opts.temperature,
-      ...(opts.reasoningEffort !== undefined && {
-        reasoning: { effort: opts.reasoningEffort },
-      }),
+      reasoning: { effort: opts.reasoningEffort },
       provider:
         opts.sort !== undefined ||
         opts.providerOrder !== undefined ||

--- a/src/benchmarks/search/core/solver.ts
+++ b/src/benchmarks/search/core/solver.ts
@@ -49,7 +49,7 @@ export interface SearchSolverOptions {
   readonly timeoutMs?: number;
   readonly maxOutputTokens?: number;
   readonly temperature?: number;
-  readonly reasoningEffort?: ReasoningEffort;
+  readonly reasoningEffort: ReasoningEffort;
   readonly endpointId?: string;
   readonly sort?: ProviderSort;
   readonly providerOrder?: readonly string[];
@@ -94,9 +94,7 @@ export function searchSolver(
         ...(opts.temperature !== undefined && {
           temperature: opts.temperature,
         }),
-        ...(opts.reasoningEffort !== undefined && {
-          reasoningEffort: opts.reasoningEffort,
-        }),
+        reasoningEffort: opts.reasoningEffort,
         ...(sendSort && { sort: opts.sort }),
         ...(opts.providerOrder !== undefined && {
           providerOrder: opts.providerOrder,

--- a/src/benchmarks/search/dsqa/grader.test.ts
+++ b/src/benchmarks/search/dsqa/grader.test.ts
@@ -15,6 +15,7 @@ describe("DSQA grader", () => {
       "9bdd0b9198244de8a78bf256b5332805d00c140e85b713f0e1878b3e4aa605a0"
     );
     expect(DSQA_JUDGE_CONFIG.judgeModel).toBe("google/gemini-2.5-flash");
+    expect(DSQA_JUDGE_CONFIG.reasoningEffort).toBe("low");
   });
   it("renders the benchmark inputs inside the official wrappers", () => {
     const prompt = renderDsqaGraderPrompt({

--- a/src/benchmarks/search/dsqa/grader.ts
+++ b/src/benchmarks/search/dsqa/grader.ts
@@ -4,6 +4,7 @@ import type { JudgeCallSpec, JudgeConfig } from "../../../judge/judge";
 
 export const DSQA_JUDGE_CONFIG = {
   judgeModel: "google/gemini-2.5-flash",
+  reasoningEffort: "low",
 } as const satisfies JudgeConfig;
 
 export const DSQA_JUDGE_PROMPT_ID = "dsqa_judge";

--- a/src/benchmarks/search/grading/answer-equivalence.test.ts
+++ b/src/benchmarks/search/grading/answer-equivalence.test.ts
@@ -3,10 +3,19 @@ import { describe, expect, it } from "bun:test";
 import { assertRight, assertLeft } from "../../../internal/testing";
 import {
   ANSWER_EQUIVALENCE_GRADER_PROMPT,
+  ANSWER_EQUIVALENCE_JUDGE_CONFIG,
   answerEquivalenceJudgeSpec,
   parseAnswerEquivalenceVerdict,
   renderAnswerEquivalenceGraderPrompt,
 } from "./answer-equivalence";
+describe("ANSWER_EQUIVALENCE_JUDGE_CONFIG", () => {
+  it("pins the historical non-reasoning judge configuration", () => {
+    expect(ANSWER_EQUIVALENCE_JUDGE_CONFIG).toMatchObject({
+      judgeModel: "openai/gpt-4.1",
+      reasoningEffort: "none",
+    });
+  });
+});
 describe("renderAnswerEquivalenceGraderPrompt", () => {
   it("interpolates all three fields", () => {
     const rendered = renderAnswerEquivalenceGraderPrompt({

--- a/src/benchmarks/search/grading/answer-equivalence.ts
+++ b/src/benchmarks/search/grading/answer-equivalence.ts
@@ -5,6 +5,7 @@ import type { JudgeCallSpec, JudgeConfig } from "../../../judge/judge";
 export const ANSWER_EQUIVALENCE_JUDGE_CONFIG = {
   judgeModel: "openai/gpt-4.1",
   temperature: 0,
+  reasoningEffort: "none",
 } as const satisfies JudgeConfig;
 
 export const ANSWER_EQUIVALENCE_JUDGE_PROMPT_ID = "answer_equivalence_judge";

--- a/src/benchmarks/search/widesearch/judges.test.ts
+++ b/src/benchmarks/search/widesearch/judges.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from "bun:test";
 
 import { assertLeft, assertRight } from "../../../internal/testing";
-import { alignmentJudgeSpec, cellJudgeSpec } from "./judges";
+import {
+  alignmentJudgeSpec,
+  cellJudgeSpec,
+  WIDESEARCH_JUDGE_CONFIG,
+} from "./judges";
 describe("WideSearch judge specs", () => {
+  it("pins the historical non-reasoning judge configuration", () => {
+    expect(WIDESEARCH_JUDGE_CONFIG).toMatchObject({
+      judgeModel: "openai/gpt-4.1",
+      reasoningEffort: "none",
+    });
+  });
   it("accepts partial, duplicate, and out-of-vocabulary alignments", () => {
     const spec = alignmentJudgeSpec(["Alpha", "Beta"], ["A", "B"]);
     const valid = spec.parseVerdict(

--- a/src/benchmarks/search/widesearch/judges.ts
+++ b/src/benchmarks/search/widesearch/judges.ts
@@ -6,6 +6,7 @@ export const WIDESEARCH_JUDGE_CONFIG = {
   judgeModel: "openai/gpt-4.1",
   temperature: 0,
   timeoutMs: 180000,
+  reasoningEffort: "none",
 } as const satisfies JudgeConfig;
 
 export const WIDESEARCH_ALIGNMENT_PROMPT_ID = "widesearch_alignment";

--- a/src/benchmarks/swe-atlas/solver.test.ts
+++ b/src/benchmarks/swe-atlas/solver.test.ts
@@ -167,6 +167,7 @@ const SOLVER_OPTS = {
   judgeModel: "anthropic/claude-opus-4.5",
   stepLimit: 10,
   endpointId: "ep-pinned",
+  inference: { reasoningEffort: "low" },
 } as const;
 const CLAUDE_STREAM = [
   JSON.stringify({
@@ -289,6 +290,7 @@ describe("swe-atlas claude agent via ori", () => {
         agentCli: {
           model: "anthropic/claude-opus-4.5",
           apiKey: "sk-test",
+          agentReasoningEffort: "low",
           appendSystemPrompt: "Be terse.",
         },
       }
@@ -375,7 +377,7 @@ describe("swe-atlas solver", () => {
     expect(record.configs.length).toBeGreaterThan(0);
     for (const cfg of record.configs) {
       expect(cfg.endpointId).toBe("ep-pinned");
-      expect(cfg.reasoningEffort).toBe("high");
+      expect(cfg.reasoningEffort).toBe("low");
       expect(cfg.instructions).toContain("helpful assistant");
       expect(cfg.tools?.[0]?.name).toBe("bash");
     }

--- a/src/benchmarks/swe-atlas/solver.ts
+++ b/src/benchmarks/swe-atlas/solver.ts
@@ -42,8 +42,6 @@ import { ensureTasksCheckedOut } from "./tasks-source";
 
 const SWE_ATLAS_TEMPERATURE = 1;
 
-const SWE_ATLAS_REASONING_EFFORT = "high" as const;
-
 const PER_COMMAND_TIMEOUT_SEC = {
   qa: 900,
   tw: 1800,
@@ -79,7 +77,7 @@ export interface SweAtlasSolverOpts {
   readonly endpointId?: string;
   readonly judgeModel: string;
   readonly stepLimit: number;
-  readonly inference?: InferenceOverride;
+  readonly inference: InferenceOverride;
   readonly agent?: HarborAgent;
   readonly agentCli?: AgentCliOpts;
 }
@@ -111,6 +109,7 @@ export function makeSweAtlasSolver(
         model: opts.model,
         apiKey: opts.apiKey,
         ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
+        agentReasoningEffort: opts.inference.reasoningEffort,
       };
       const cliOpts: AgentCliOpts = {
         ...baseCliOpts,
@@ -143,10 +142,9 @@ export function makeSweAtlasSolver(
       });
       const genConfig: ResponsesGenerateConfig = {
         temperature: SWE_ATLAS_TEMPERATURE,
-        reasoningEffort: SWE_ATLAS_REASONING_EFFORT,
         tools: [BASH_RESPONSES_TOOL_DEFINITION],
         instructions: MINI_SWE_SYSTEM_MESSAGE,
-        ...definedValues(opts.inference ?? {}),
+        ...definedValues(opts.inference),
         ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
       };
       try {

--- a/src/benchmarks/tau-bench-airline/airline.test.ts
+++ b/src/benchmarks/tau-bench-airline/airline.test.ts
@@ -4,6 +4,9 @@ import { runSync } from "effect/Effect";
 
 import { MessageRole, ScoreValue } from "../../harness/core";
 import { isRecord } from "../../internal/guards";
+import { assertRight } from "../../internal/testing";
+import { parseSchema } from "../../internal/zod";
+import { TauBenchAirlineConfigSchema } from "../benchmark-config";
 import { benchmarkIds, getBenchmark } from "../registry";
 import { compareActionWithToolCall } from "./action-match";
 import { airlineRecordToSample, TAU_BENCH_AIRLINE_ID } from "./benchmark";
@@ -97,6 +100,29 @@ describe("tau_bench_verified_airline registry", () => {
   });
   it("appears in benchmarkIds()", () => {
     expect(benchmarkIds()).toContain("tau_bench_verified_airline");
+  });
+});
+describe("tau_bench_verified_airline config", () => {
+  it("defaults the user simulator reasoning effort independently", () => {
+    const result = parseSchema(TauBenchAirlineConfigSchema, {
+      benchmarkId: "tau_bench_verified_airline",
+      model: "openai/gpt-4o-mini",
+      reasoningEffort: "low",
+    });
+    assertRight(result);
+    expect(result.right.reasoningEffort).toBe("low");
+    expect(result.right.userReasoningEffort).toBe("medium");
+  });
+  it("allows overriding the user simulator reasoning effort", () => {
+    const result = parseSchema(TauBenchAirlineConfigSchema, {
+      benchmarkId: "tau_bench_verified_airline",
+      model: "openai/gpt-4o-mini",
+      reasoningEffort: "low",
+      userReasoningEffort: "high",
+    });
+    assertRight(result);
+    expect(result.right.reasoningEffort).toBe("low");
+    expect(result.right.userReasoningEffort).toBe("high");
   });
 });
 describe("airlineRecordToSample", () => {

--- a/src/benchmarks/tau-bench-airline/benchmark.ts
+++ b/src/benchmarks/tau-bench-airline/benchmark.ts
@@ -102,6 +102,7 @@ function makeAirlineLayer(
       model: benchmarkConfig.userModel,
       ...(input.baseUrl !== undefined && { baseUrl: input.baseUrl }),
       sessionId: input.sessionId,
+      reasoningEffort: benchmarkConfig.userReasoningEffort,
     },
     inference: {
       maxTokens: benchmarkConfig.maxTokens,

--- a/src/benchmarks/tau-bench-airline/solver.ts
+++ b/src/benchmarks/tau-bench-airline/solver.ts
@@ -50,11 +50,11 @@ export function airlineSolver({
   readonly userModel: ResponsesModelService;
   readonly client: HttpClient.HttpClient;
   readonly dataFetchLock: Semaphore;
-  readonly opts?: SolverOpts;
+  readonly opts: SolverOpts;
 }): SolverService {
   return (state) =>
     gen(function* () {
-      const userModelConfig = opts?.userModelConfig;
+      const userModelConfig = opts.userModelConfig;
       if (!userModelConfig) {
         return yield* new SolverError({
           message:
@@ -85,8 +85,8 @@ export function airlineSolver({
       const genConfig: GenerateConfig = {
         temperature: AIRLINE_TEMPERATURE,
         tools: AIRLINE_TOOL_DEFINITIONS,
-        ...definedValues(opts?.inference ?? {}),
-        ...(opts?.endpointId !== undefined && { endpointId: opts.endpointId }),
+        ...definedValues(opts.inference),
+        ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
       };
       let totalGenerationTimeMs = 0;
       const accUsage = {

--- a/src/benchmarks/tau-bench-airline/types.ts
+++ b/src/benchmarks/tau-bench-airline/types.ts
@@ -1,3 +1,4 @@
+import type { ReasoningEffort } from "../../harness/constants";
 import type { ValueOf } from "../../internal/guards";
 import { isDefinedAndNotNull } from "../../internal/guards";
 import { z } from "../../internal/zod";
@@ -187,7 +188,7 @@ export interface AirlineData {
 export interface SolverOpts {
   readonly endpointId?: string;
   readonly userModelConfig?: UserModelConfig;
-  readonly inference?: FixedTemperatureInferenceOverride;
+  readonly inference: FixedTemperatureInferenceOverride;
 }
 
 export interface UserModelConfig {
@@ -195,4 +196,5 @@ export interface UserModelConfig {
   readonly model: string;
   readonly baseUrl?: string;
   readonly sessionId?: string;
+  readonly reasoningEffort: ReasoningEffort;
 }

--- a/src/benchmarks/tau-bench-airline/user-simulator.test.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.test.ts
@@ -13,7 +13,9 @@ const config = {
   apiKey: "sk-test",
   model: "openai/gpt-5",
   sessionId: "session-1",
+  reasoningEffort: "medium",
 } as const;
+const runLevelReasoningEffort = "low";
 
 function modelFor(
   turns: readonly ResponsesTurn[],
@@ -21,8 +23,10 @@ function modelFor(
 ): ResponsesModelService {
   let index = 0;
   return {
-    generate: (input) => {
+    generate: (input, options) => {
       inputs.push([...input]);
+      expect(options.reasoningEffort).toBe(config.reasoningEffort);
+      expect(options.reasoningEffort).not.toBe(runLevelReasoningEffort);
       return succeed(turns[Math.min(index++, turns.length - 1)]!);
     },
   };

--- a/src/benchmarks/tau-bench-airline/user-simulator.ts
+++ b/src/benchmarks/tau-bench-airline/user-simulator.ts
@@ -97,6 +97,7 @@ export class UserSimulator {
       .generate(messagesToResponses(this.messages), {
         model,
         temperature: 0,
+        reasoningEffort: this.config.reasoningEffort,
       })
       .pipe(
         mapError((error) => new UserSimError({ message: error.message })),

--- a/src/benchmarks/tau3-bench-banking/benchmark.test.ts
+++ b/src/benchmarks/tau3-bench-banking/benchmark.test.ts
@@ -28,6 +28,7 @@ describe("tau3_bench_banking registration", () => {
     const result = parseSchema(Tau3BenchBankingConfigSchema, {
       benchmarkId: "tau3_bench_banking",
       model: "openai/gpt-4o-mini",
+      reasoningEffort: "high",
     });
     assertRight(result);
     expect(result.right.userModel).toBe("openai/gpt-5.4-mini");
@@ -38,6 +39,7 @@ describe("tau3_bench_banking registration", () => {
     const result = parseSchema(Tau3BenchBankingConfigSchema, {
       benchmarkId: "tau3_bench_banking",
       model: "openai/gpt-4o-mini",
+      reasoningEffort: "high",
       userModel: "",
     });
     assertRight(result);
@@ -47,6 +49,7 @@ describe("tau3_bench_banking registration", () => {
     const result = parseSchema(Tau3BenchBankingConfigSchema, {
       benchmarkId: "tau3_bench_banking",
       model: "openai/gpt-4o-mini",
+      reasoningEffort: "high",
       userModel: "  \t",
     });
     assertRight(result);
@@ -56,6 +59,7 @@ describe("tau3_bench_banking registration", () => {
     const result = parseSchema(Tau3BenchBankingConfigSchema, {
       benchmarkId: "tau3_bench_banking",
       model: "openai/gpt-4o-mini",
+      reasoningEffort: "high",
       userReasoningEffort: "high",
     });
     assertRight(result);
@@ -65,6 +69,7 @@ describe("tau3_bench_banking registration", () => {
     const result = parseSchema(Tau3BenchBankingConfigSchema, {
       benchmarkId: "tau3_bench_banking",
       model: "openai/gpt-4o-mini",
+      reasoningEffort: "high",
       userModel: "google/gemini-2.5-flash",
       retrievalConfig: "required_docs",
     });
@@ -76,6 +81,7 @@ describe("tau3_bench_banking registration", () => {
     const result = parseSchema(Tau3BenchBankingConfigSchema, {
       benchmarkId: "tau3_bench_banking",
       model: "openai/gpt-4o-mini",
+      reasoningEffort: "high",
       retrievalConfig: "bm25_grep",
     });
     assertRight(result);
@@ -102,6 +108,7 @@ describe("tau3_bench_banking registration", () => {
       benchmarkConfig: {
         benchmarkId: "gpqa_diamond",
         model: "openai/gpt-4o-mini",
+        reasoningEffort: "high",
       },
       sessionId: "test-session",
     });

--- a/src/benchmarks/tau3-bench-banking/solver.ts
+++ b/src/benchmarks/tau3-bench-banking/solver.ts
@@ -127,7 +127,7 @@ export function bankingSolver({
   readonly userModel: ResponsesModelService;
   readonly client: HttpClient.HttpClient;
   readonly dataFetchLock: Semaphore;
-  readonly opts?: SolverOpts;
+  readonly opts: SolverOpts;
 }): SolverService {
   return (state: TaskState) =>
     gen(function* () {
@@ -216,8 +216,8 @@ export function bankingSolver({
       const genConfig: GenerateConfig = {
         temperature: BANKING_TEMPERATURE,
         tools: [...BANKING_TOOL_DEFINITIONS, ...retrievalTools.definitions],
-        ...definedValues(opts?.inference ?? {}),
-        ...(opts?.endpointId !== undefined && { endpointId: opts.endpointId }),
+        ...definedValues(opts.inference),
+        ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
       };
       let totalGenerationTimeMs = 0;
       const accUsage = {

--- a/src/benchmarks/tau3-bench-banking/types.ts
+++ b/src/benchmarks/tau3-bench-banking/types.ts
@@ -162,12 +162,12 @@ export interface UserModelConfig {
   readonly model: string;
   readonly baseUrl?: string;
   readonly sessionId?: string;
-  readonly userReasoningEffort?: ReasoningEffort;
+  readonly userReasoningEffort: ReasoningEffort;
 }
 
 export interface SolverOpts {
   readonly endpointId?: string;
   readonly userModelConfig?: UserModelConfig;
   readonly retrievalConfig?: BankingRetrievalConfig;
-  readonly inference?: InferenceOverride;
+  readonly inference: InferenceOverride;
 }

--- a/src/benchmarks/tau3-bench-banking/user-simulator.ts
+++ b/src/benchmarks/tau3-bench-banking/user-simulator.ts
@@ -124,9 +124,7 @@ export class UserSimulator {
       .generate(messagesToResponses(this.messages), {
         model,
         temperature: 0,
-        ...(this.config.userReasoningEffort !== undefined && {
-          reasoningEffort: this.config.userReasoningEffort,
-        }),
+        reasoningEffort: this.config.userReasoningEffort,
         ...(this.availableTools.length > 0 && {
           tools: this.availableTools.map(toolDefinitionToResponses),
         }),

--- a/src/benchmarks/terminal-bench/ori-solver.test.ts
+++ b/src/benchmarks/terminal-bench/ori-solver.test.ts
@@ -64,6 +64,7 @@ type ExecCalls = NonNullable<
 const SOLVER_OPTS: OriSolverOpts = {
   model: "anthropic/claude-opus-5",
   apiKey: "sk-test",
+  agentReasoningEffort: "medium",
 };
 
 const GENERATION_ID = "gen-1786484980-H6OpVHdz7070QlmacXWO";

--- a/src/benchmarks/terminal-bench/schema.ts
+++ b/src/benchmarks/terminal-bench/schema.ts
@@ -5,7 +5,6 @@ import { ORI_AGENTS } from "../agent-cli/schema";
 export {
   DEFAULT_CLAUDE_PACKAGE,
   DEFAULT_ORI_INSTALL_URL,
-  DEFAULT_ORI_REASONING_EFFORT,
   ORI_AGENTS,
   ORI_REASONING_EFFORTS,
 } from "../agent-cli/schema";

--- a/src/benchmarks/vgi-bench/benchmark.test.ts
+++ b/src/benchmarks/vgi-bench/benchmark.test.ts
@@ -224,6 +224,7 @@ describe("VGI-Bench registry", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "vgi_bench",
       model: "google/gemini-2.5-flash",
+      reasoningEffort: "high",
     });
     assertRight(result);
     expect(result.right.benchmarkId).toBe("vgi_bench");
@@ -234,6 +235,7 @@ describe("VGI-Bench registry", () => {
     const result = parseSchema(BenchmarkRunConfigSchema, {
       benchmarkId: "vgi_bench",
       model: "google/gemini-2.5-flash",
+      reasoningEffort: "high",
       downscaledVideos: true,
       datasetRevision: "v1.0.0",
     });
@@ -247,7 +249,11 @@ describe("VGI-Bench registry", () => {
     const result = await runBenchmarkById({
       benchmarkId: "vgi_bench",
       apiKey: "unused",
-      benchmarkConfig: { benchmarkId: "vgi_bench", model: "test/model" },
+      benchmarkConfig: {
+        benchmarkId: "vgi_bench",
+        model: "test/model",
+        reasoningEffort: "high",
+      },
       epochs: 1,
       maxConcurrency: 1,
       range: { start: 0, end: 1 },

--- a/src/benchmarks/vgi-bench/benchmark.ts
+++ b/src/benchmarks/vgi-bench/benchmark.ts
@@ -194,15 +194,15 @@ function makeVgiBenchDatasetLayer(
 
 function vgiBenchSolver(
   model: ModelService,
-  opts?: {
+  opts: {
     readonly endpointId?: string;
-    readonly inference?: FixedTemperatureInferenceOverride;
+    readonly inference: FixedTemperatureInferenceOverride;
   }
 ): SolverService {
   const config: GenerateConfig = {
     temperature: VGI_BENCH_TEMPERATURE,
-    ...definedValues(opts?.inference ?? {}),
-    ...(opts?.endpointId !== undefined && { endpointId: opts.endpointId }),
+    ...definedValues(opts.inference),
+    ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
   };
   return generate(model, config);
 }

--- a/src/benchmarks/wandr/benchmark.test.ts
+++ b/src/benchmarks/wandr/benchmark.test.ts
@@ -9,6 +9,7 @@ describe("WANDR benchmark configuration", () => {
     const parsed = parseSchema(WandrConfigSchema, {
       benchmarkId: "wandr",
       model: "openai/gpt-5.4",
+      reasoningEffort: "high",
       costTier: "high",
     });
     assertRight(parsed);

--- a/src/benchmarks/wandr/solver.test.ts
+++ b/src/benchmarks/wandr/solver.test.ts
@@ -290,7 +290,7 @@ async function runSolver({
 }: {
   readonly modelLayer: Layer<ResponsesModel>;
   readonly sandboxLayer: Layer<SandboxSession>;
-  readonly inference?: InferenceOverride;
+  readonly inference: InferenceOverride;
   readonly taskId?: string;
   readonly apiKey?: string;
 }): Promise<TaskState> {

--- a/src/benchmarks/wandr/solver.ts
+++ b/src/benchmarks/wandr/solver.ts
@@ -100,7 +100,7 @@ export interface WandrSolverOptions {
   readonly endpointId?: string;
   readonly stepLimit: number;
   readonly serverTools: readonly WandrServerTool[];
-  readonly inference?: InferenceOverride;
+  readonly inference: InferenceOverride;
   readonly sessionId?: string;
 }
 
@@ -220,7 +220,7 @@ export function makeWandrSolver(
           : undefined;
       const generationConfig: ResponsesGenerateConfig = {
         instructions: WANDR_SYSTEM_MESSAGE,
-        ...definedValues(options.inference ?? {}),
+        ...definedValues(options.inference),
         ...(options.endpointId !== undefined && {
           endpointId: options.endpointId,
         }),

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, it } from "bun:test";
 
 import { buildBenchmarkConfig, parseArgs } from ".";
 describe("bench-harness CLI", () => {
+  it("defaults --reasoning-effort to high", () => {
+    expect(parseArgs([]).reasoningEffort).toBe("high");
+  });
+
+  it("accepts an explicit --reasoning-effort", () => {
+    expect(parseArgs(["--reasoning-effort", "low"]).reasoningEffort).toBe(
+      "low"
+    );
+  });
+
+  it("rejects an invalid --reasoning-effort value", () => {
+    expect(() => parseArgs(["--reasoning-effort", "invalid"])).toThrow(
+      "--reasoning-effort must be one of"
+    );
+  });
+
   it("parses and forwards --cost-tier", () => {
     const args = parseArgs([
       "--benchmark",
@@ -20,6 +36,7 @@ describe("bench-harness CLI", () => {
         endpointId: undefined,
         imageDetail: undefined,
         costTier: args.costTier,
+        reasoningEffort: args.reasoningEffort,
       })
     ).toMatchObject({ costTier: "xhigh" });
   });
@@ -28,6 +45,58 @@ describe("bench-harness CLI", () => {
     expect(() => parseArgs(["--cost-tier", "invalid"])).toThrow(
       "--cost-tier must be one of"
     );
+  });
+
+  it("passes reasoning effort to hand-built model benchmark configs", () => {
+    for (const benchmarkId of [
+      "gpqa_diamond",
+      "mmlu_pro",
+      "mmmu_pro_vision",
+      "ifstruct",
+    ] as const) {
+      const config = buildBenchmarkConfig({
+        benchmarkId,
+        model: "openai/gpt-5",
+        panelConfig: undefined,
+        artifactDir: undefined,
+        endpointId: undefined,
+        imageDetail: undefined,
+        reasoningEffort: "low",
+      });
+      expect(config).toMatchObject({ reasoningEffort: "low" });
+    }
+  });
+
+  it("derives agent reasoning effort for ori lanes", () => {
+    const config = buildBenchmarkConfig({
+      benchmarkId: "terminal_bench",
+      model: "anthropic/claude-opus-5",
+      panelConfig: undefined,
+      artifactDir: undefined,
+      endpointId: undefined,
+      imageDetail: undefined,
+      reasoningEffort: "xhigh",
+    });
+    expect(config).toMatchObject({
+      reasoningEffort: "xhigh",
+      agentReasoningEffort: "xhigh",
+    });
+  });
+
+  it("preserves explicit ori agent reasoning effort", () => {
+    const config = buildBenchmarkConfig({
+      benchmarkId: "terminal_bench",
+      model: "anthropic/claude-opus-5",
+      panelConfig: { agentReasoningEffort: "max" },
+      artifactDir: undefined,
+      endpointId: undefined,
+      imageDetail: undefined,
+      reasoningEffort: "low",
+    });
+    expect(config).toMatchObject({
+      reasoningEffort: "low",
+      agentReasoningEffort: "max",
+    });
   });
 
   it("passes tau3 retrieval config through the generic solver config", () => {
@@ -47,6 +116,7 @@ describe("bench-harness CLI", () => {
       artifactDir: undefined,
       endpointId: undefined,
       imageDetail: undefined,
+      reasoningEffort: args.reasoningEffort,
     });
     expect(config).toMatchObject({
       benchmarkId: "tau3_bench_banking",
@@ -71,6 +141,7 @@ describe("bench-harness CLI", () => {
       artifactDir: undefined,
       endpointId: undefined,
       imageDetail: undefined,
+      reasoningEffort: args.reasoningEffort,
     });
     expect(config).toMatchObject({
       benchmarkId: "terminal_bench",
@@ -86,6 +157,7 @@ describe("bench-harness CLI", () => {
       artifactDir: undefined,
       endpointId: undefined,
       imageDetail: undefined,
+      reasoningEffort: "high",
     });
     expect(config).toMatchObject({
       benchmarkId: "terminal_bench",
@@ -93,7 +165,7 @@ describe("bench-harness CLI", () => {
     });
   });
 
-  it("defaults terminal_bench to the unified ori reasoning effort", () => {
+  it("defaults terminal_bench to the CLI reasoning effort", () => {
     const config = buildBenchmarkConfig({
       benchmarkId: "terminal_bench",
       model: "anthropic/claude-opus-5",
@@ -101,10 +173,11 @@ describe("bench-harness CLI", () => {
       artifactDir: undefined,
       endpointId: undefined,
       imageDetail: undefined,
+      reasoningEffort: "high",
     });
     expect(config).toMatchObject({
       benchmarkId: "terminal_bench",
-      agentReasoningEffort: "medium",
+      agentReasoningEffort: "high",
       oriChannel: "stable",
     });
   });
@@ -121,6 +194,7 @@ describe("bench-harness CLI", () => {
           artifactDir: undefined,
           endpointId: undefined,
           imageDetail: undefined,
+          reasoningEffort: "high",
         })
       ).not.toThrow();
     } finally {
@@ -141,6 +215,7 @@ describe("bench-harness CLI", () => {
         artifactDir: undefined,
         endpointId: undefined,
         imageDetail: undefined,
+        reasoningEffort: "high",
       })
     ).toThrow("Unknown terminal_bench solver-config option(s): thinking");
   });
@@ -154,6 +229,7 @@ describe("bench-harness CLI", () => {
         artifactDir: undefined,
         endpointId: undefined,
         imageDetail: undefined,
+        reasoningEffort: "high",
       })
     ).toThrow("agentReasoningEfort");
   });
@@ -175,6 +251,7 @@ describe("bench-harness CLI", () => {
       artifactDir: undefined,
       endpointId: undefined,
       imageDetail: undefined,
+      reasoningEffort: "high",
     });
     expect(config).toMatchObject({
       agent: "claude",
@@ -193,6 +270,7 @@ describe("bench-harness CLI", () => {
         artifactDir: undefined,
         endpointId: undefined,
         imageDetail: undefined,
+        reasoningEffort: "high",
       })
     ).toThrow("Invalid terminal_bench config");
   });
@@ -205,6 +283,7 @@ describe("bench-harness CLI", () => {
       artifactDir: undefined,
       endpointId: undefined,
       imageDetail: undefined,
+      reasoningEffort: "high",
     });
     expect(config).toMatchObject({
       benchmarkId: "tau3_bench_banking",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,17 +9,20 @@ import { getOrNull } from "effect/Option";
 import { isSafeOriSessionId } from "../benchmarks/agent-cli/runner";
 import type { BenchmarkRunConfig } from "../benchmarks/benchmark-config";
 import {
+  BENCHMARK_OPTIONS_SCHEMAS,
   BenchmarkRunConfigSchema,
   isModelBenchmarkId,
   knownBenchmarkOptionKeys,
 } from "../benchmarks/benchmark-config";
 import { DracoPanelConfigSchema } from "../benchmarks/draco/schemas";
 import { benchmarkIds, getBenchmark } from "../benchmarks/registry";
-import type { CostTier } from "../harness/constants";
+import type { CostTier, ReasoningEffort } from "../harness/constants";
 import {
   COST_TIERS,
+  DEFAULT_REASONING_EFFORT,
   ImageDetail,
   IMAGE_DETAIL_VALUES,
+  REASONING_EFFORTS,
 } from "../harness/constants";
 import { makeProgressReporter } from "../harness/progress";
 import { runHarnessPromise } from "../internal/effect-logger";
@@ -43,6 +46,7 @@ interface CliArgs {
   readonly resumeId?: string;
   readonly imageDetail?: ImageDetail;
   readonly costTier?: CostTier;
+  readonly reasoningEffort: ReasoningEffort;
 }
 
 export function parseArgs(argv: readonly string[]): CliArgs {
@@ -68,6 +72,7 @@ export function parseArgs(argv: readonly string[]): CliArgs {
     resumeId: get("--resume-id"),
     imageDetail: validateImageDetail(get("--image-detail")),
     costTier: validateCostTier(get("--cost-tier")),
+    reasoningEffort: validateReasoningEffort(get("--reasoning-effort")),
   };
 }
 
@@ -182,9 +187,10 @@ function main(): Promise<void> {
         endpointId: args.endpointId,
         imageDetail: args.imageDetail,
         costTier: args.costTier,
+        reasoningEffort: args.reasoningEffort,
       });
       process.stderr.write(
-        `Running ${args.benchmark}${args.model !== undefined ? ` on ${args.model}` : ""}${args.solverConfig !== undefined ? ` (solver-config=${args.solverConfig})` : ""}${artifactDir !== undefined ? ` (artifact-dir=${artifactDir})` : ""} (epochs=${epochs}, concurrency=${args.concurrency}${range !== undefined ? `, range=${range.start ?? 0}..${range.end ?? "end"}` : ""}, session=${sessionId})...\n`
+        `Running ${args.benchmark}${args.model !== undefined ? ` on ${args.model}` : ""}${args.solverConfig !== undefined ? ` (solver-config=${args.solverConfig})` : ""}${artifactDir !== undefined ? ` (artifact-dir=${artifactDir})` : ""} (epochs=${epochs}, concurrency=${args.concurrency}, reasoning-effort=${args.reasoningEffort}${range !== undefined ? `, range=${range.start ?? 0}..${range.end ?? "end"}` : ""}, session=${sessionId})...\n`
       );
       const total = yield* promise(() =>
         resolveTotalEvaluations(args.benchmark, range, epochs)
@@ -294,6 +300,18 @@ function validateCostTier(raw: string | undefined): CostTier | undefined {
   return raw;
 }
 
+function validateReasoningEffort(raw: string | undefined): ReasoningEffort {
+  if (raw === undefined) {
+    return DEFAULT_REASONING_EFFORT;
+  }
+  if (!isMember(raw, REASONING_EFFORTS)) {
+    throw new Error(
+      `--reasoning-effort must be one of: ${REASONING_EFFORTS.join(", ")} (got "${raw}")`
+    );
+  }
+  return raw;
+}
+
 function requireModel(benchmarkId: string, model: string | undefined): string {
   if (model === undefined) {
     throw new Error(`${benchmarkId} requires --model`);
@@ -307,13 +325,22 @@ function buildSchemaValidatedConfig(opts: {
   endpointId: string | undefined;
   panelConfig: unknown;
   costTier?: CostTier;
+  reasoningEffort: ReasoningEffort;
 }): BenchmarkRunConfig {
-  const { benchmarkId, model, endpointId, panelConfig, costTier } = opts;
+  const {
+    benchmarkId,
+    model,
+    endpointId,
+    panelConfig,
+    costTier,
+    reasoningEffort,
+  } = opts;
   const merged: Record<string, unknown> = {
     benchmarkId,
     model,
     ...(endpointId !== undefined && { endpointId }),
     ...(costTier !== undefined && { costTier }),
+    reasoningEffort,
   };
   if (typeof panelConfig === "object" && panelConfig !== null) {
     const known = isModelBenchmarkId(benchmarkId)
@@ -332,6 +359,20 @@ function buildSchemaValidatedConfig(opts: {
         merged[k] = v;
       }
     }
+  }
+  const optionsSchema = isModelBenchmarkId(benchmarkId)
+    ? BENCHMARK_OPTIONS_SCHEMAS[benchmarkId]
+    : undefined;
+  if (
+    optionsSchema !== undefined &&
+    Object.hasOwn(optionsSchema.shape, "agentReasoningEffort") &&
+    !(
+      typeof panelConfig === "object" &&
+      panelConfig !== null &&
+      Object.hasOwn(panelConfig, "agentReasoningEffort")
+    )
+  ) {
+    merged.agentReasoningEffort = reasoningEffort;
   }
   const parsed = parseSchema(BenchmarkRunConfigSchema, merged);
   if (Either.isLeft(parsed)) {
@@ -362,9 +403,17 @@ export function buildBenchmarkConfig(opts: {
   endpointId: string | undefined;
   imageDetail: ImageDetail | undefined;
   costTier?: CostTier;
+  reasoningEffort: ReasoningEffort;
 }): BenchmarkRunConfig {
-  const { benchmarkId, model, panelConfig, artifactDir, endpointId, costTier } =
-    opts;
+  const {
+    benchmarkId,
+    model,
+    panelConfig,
+    artifactDir,
+    endpointId,
+    costTier,
+    reasoningEffort,
+  } = opts;
   switch (benchmarkId) {
     case "gpqa_diamond": {
       return {
@@ -372,6 +421,7 @@ export function buildBenchmarkConfig(opts: {
         model: requireModel("gpqa_diamond", model),
         ...(endpointId !== undefined && { endpointId }),
         ...(costTier !== undefined && { costTier }),
+        reasoningEffort,
       };
     }
     case "mmlu_pro": {
@@ -380,6 +430,7 @@ export function buildBenchmarkConfig(opts: {
         model: requireModel("mmlu_pro", model),
         ...(endpointId !== undefined && { endpointId }),
         ...(costTier !== undefined && { costTier }),
+        reasoningEffort,
       };
     }
     case "tau_bench_verified_airline": {
@@ -389,6 +440,7 @@ export function buildBenchmarkConfig(opts: {
         endpointId,
         panelConfig,
         costTier,
+        reasoningEffort,
       });
     }
     case "tau3_bench_banking": {
@@ -398,6 +450,7 @@ export function buildBenchmarkConfig(opts: {
         endpointId,
         panelConfig,
         costTier,
+        reasoningEffort,
       });
     }
     case "terminal_bench": {
@@ -407,6 +460,7 @@ export function buildBenchmarkConfig(opts: {
         endpointId,
         panelConfig,
         costTier,
+        reasoningEffort,
       });
     }
     case "draco": {
@@ -429,6 +483,7 @@ export function buildBenchmarkConfig(opts: {
           imageDetail: opts.imageDetail,
         }),
         ...(costTier !== undefined && { costTier }),
+        reasoningEffort,
       };
     }
     case "ifstruct": {
@@ -437,6 +492,7 @@ export function buildBenchmarkConfig(opts: {
         model: requireModel("ifstruct", model),
         ...(endpointId !== undefined && { endpointId }),
         ...(costTier !== undefined && { costTier }),
+        reasoningEffort,
       };
     }
     case "swe_atlas_qa":
@@ -455,6 +511,7 @@ export function buildBenchmarkConfig(opts: {
         endpointId,
         panelConfig,
         costTier,
+        reasoningEffort,
       });
     }
     default: {

--- a/src/harness/constants.ts
+++ b/src/harness/constants.ts
@@ -11,6 +11,8 @@ export const REASONING_EFFORTS = [
 
 export type ReasoningEffort = ValueOf<typeof REASONING_EFFORTS>;
 
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = "high";
+
 export const COST_TIERS = ["low", "medium", "high", "xhigh", "max"] as const;
 
 export type CostTier = ValueOf<typeof COST_TIERS>;

--- a/src/harness/model.ts
+++ b/src/harness/model.ts
@@ -20,7 +20,7 @@ export interface GenerateConfig {
   readonly maxTokens?: number;
   readonly endpointId?: string;
   readonly tools?: readonly ToolDefinition[];
-  readonly reasoningEffort?: ReasoningEffort;
+  readonly reasoningEffort: ReasoningEffort;
   readonly costTier?: CostTier;
   readonly timeoutMs?: number;
   readonly sort?: ProviderSort;

--- a/src/harness/run.test.ts
+++ b/src/harness/run.test.ts
@@ -157,7 +157,7 @@ describe("runBenchmark", () => {
     );
     const solver = chain(
       systemMessage("You are a helpful assistant."),
-      generate(model.service, { temperature: 0.5 })
+      generate(model.service, { temperature: 0.5, reasoningEffort: "high" })
     );
     const result = await runPromise(
       runBenchmark({ epochs: 3, maxConcurrency: 4 }).pipe(
@@ -176,7 +176,7 @@ describe("runBenchmark", () => {
     const model = fakeModel(() => "Answer: B");
     const solver = chain(
       systemMessage("You are a helpful assistant."),
-      generate(model.service, { temperature: 0.5 })
+      generate(model.service, { temperature: 0.5, reasoningEffort: "high" })
     );
     const layers = mergeAll(
       fakeDatasetLayer(SAMPLES.slice(0, 1)),
@@ -261,7 +261,10 @@ describe("runBenchmark", () => {
   });
   it("respects a sample range (chunk slice)", async () => {
     const model = fakeModel(() => "Answer: B");
-    const solver = generate(model.service, { temperature: 0 });
+    const solver = generate(model.service, {
+      temperature: 0,
+      reasoningEffort: "high",
+    });
     const layers = mergeAll(
       fakeDatasetLayer(SAMPLES),
       layerSucceed(Solver, Solver.of(solver)),
@@ -300,7 +303,10 @@ describe("runBenchmark", () => {
       },
     };
     const model = { service, layer: layerSucceed(Model, Model.of(service)) };
-    const solver = generate(model.service, { temperature: 0 });
+    const solver = generate(model.service, {
+      temperature: 0,
+      reasoningEffort: "high",
+    });
     const layers = mergeAll(
       fakeDatasetLayer(SAMPLES),
       layerSucceed(Solver, Solver.of(solver)),
@@ -339,7 +345,10 @@ describe("runBenchmark", () => {
       },
     };
     const model = { service, layer: layerSucceed(Model, Model.of(service)) };
-    const solver = generate(model.service, { temperature: 0 });
+    const solver = generate(model.service, {
+      temperature: 0,
+      reasoningEffort: "high",
+    });
     const layers = mergeAll(
       fakeDatasetLayer(SAMPLES),
       layerSucceed(Solver, Solver.of(solver)),
@@ -382,7 +391,10 @@ describe("runBenchmark", () => {
         })
       ),
     };
-    const solver = generate(model.service, { temperature: 0 });
+    const solver = generate(model.service, {
+      temperature: 0,
+      reasoningEffort: "high",
+    });
     const layers = mergeAll(
       fakeDatasetLayer(SAMPLES),
       layerSucceed(Solver, Solver.of(solver)),

--- a/src/judge/judge.test.ts
+++ b/src/judge/judge.test.ts
@@ -66,7 +66,15 @@ describe("judgeCall", () => {
       },
     };
     const result = await runPromise(
-      judgeCall(service, { judgeModel: "openai/gpt-4.1", temperature: 0 }, SPEC)
+      judgeCall(
+        service,
+        {
+          judgeModel: "openai/gpt-4.1",
+          temperature: 0,
+          reasoningEffort: "high",
+        },
+        SPEC
+      )
     );
     expect(result.verdict).toEqual({ verdict: "yes" });
     expect(sentModel).toBe("openai/gpt-4.1");
@@ -90,7 +98,7 @@ describe("judgeCall", () => {
     const result = await runPromise(
       judgeCall(
         service,
-        { judgeModel: "openai/gpt-4.1" },
+        { judgeModel: "openai/gpt-4.1", reasoningEffort: "high" },
         {
           ...SPEC,
           jsonSchema: undefined,
@@ -109,7 +117,9 @@ describe("judgeCall", () => {
     };
     const entries = await runPromise(
       resetGenerationIds.pipe(
-        flatMap(() => judgeCall(service, { judgeModel: "j" }, SPEC)),
+        flatMap(() =>
+          judgeCall(service, { judgeModel: "j", reasoningEffort: "high" }, SPEC)
+        ),
         flatMap(() => getCollectedGenerationIdEntries)
       )
     );
@@ -132,7 +142,7 @@ describe("judgeCall", () => {
         }),
     };
     const exit = await runPromiseExit(
-      judgeCall(service, { judgeModel: "j" }, SPEC)
+      judgeCall(service, { judgeModel: "j", reasoningEffort: "high" }, SPEC)
     );
     expect(isFailure(exit)).toBe(true);
     expect(calls).toBe(1);
@@ -153,7 +163,7 @@ describe("judgeCall", () => {
     const result = await runPromise(
       judgeCall(
         service,
-        { judgeModel: "j" },
+        { judgeModel: "j", reasoningEffort: "high" },
         {
           ...SPEC,
           parseFailureFallback: { verdict: "no" } satisfies Verdict,
@@ -185,7 +195,11 @@ describe("judgeCall", () => {
     const result = await runPromise(
       judgeCall(
         service,
-        { judgeModel: "j", retry: { maxRetries: 2, baseDelayMs: 1 } },
+        {
+          judgeModel: "j",
+          reasoningEffort: "high",
+          retry: { maxRetries: 2, baseDelayMs: 1 },
+        },
         SPEC
       )
     );
@@ -210,7 +224,11 @@ describe("judgeCall", () => {
     const exit = await runPromiseExit(
       judgeCall(
         service,
-        { judgeModel: "j", retry: { maxRetries: 3, baseDelayMs: 1 } },
+        {
+          judgeModel: "j",
+          reasoningEffort: "high",
+          retry: { maxRetries: 3, baseDelayMs: 1 },
+        },
         SPEC
       )
     );
@@ -233,7 +251,7 @@ describe("judgeCall usage", () => {
         }),
     };
     const result = await runPromise(
-      judgeCall(service, { judgeModel: "j" }, SPEC)
+      judgeCall(service, { judgeModel: "j", reasoningEffort: "high" }, SPEC)
     );
     expect(result.usage).toEqual({
       inputTokens: 50,

--- a/src/judge/judge.ts
+++ b/src/judge/judge.ts
@@ -21,7 +21,7 @@ import { rateLimitRetrySchedule, retrySalted } from "../runtime/retry";
 export interface JudgeConfig {
   readonly judgeModel: string;
   readonly temperature?: number;
-  readonly reasoningEffort?: ReasoningEffort;
+  readonly reasoningEffort: ReasoningEffort;
   readonly timeoutMs?: number;
   readonly retry?: RetryConfig;
   readonly versionOverride?: string;
@@ -68,9 +68,7 @@ export function judgeCall<T>(
     ...(config.temperature !== undefined && {
       temperature: config.temperature,
     }),
-    ...(config.reasoningEffort !== undefined && {
-      reasoning: { effort: config.reasoningEffort },
-    }),
+    reasoning: { effort: config.reasoningEffort },
   };
   const sendOptions = {
     timeoutMs: config.timeoutMs ?? DEFAULT_JUDGE_TIMEOUT_MS,

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -95,6 +95,7 @@ describe("openrouter-model", () => {
           ],
           {
             temperature: 0,
+            reasoningEffort: "high",
             tools: [
               {
                 type: "function",
@@ -172,6 +173,7 @@ describe("openrouter-model", () => {
         const model = yield* Model;
         return yield* model.generate([{ role: "user", content: "question" }], {
           temperature: 0,
+          reasoningEffort: "high",
         });
       }).pipe(
         provide(

--- a/src/providers/responses-model.test.ts
+++ b/src/providers/responses-model.test.ts
@@ -352,6 +352,7 @@ describe("responses-model", () => {
         return yield* model.generate([], {
           sort: ProviderSort.Price,
           endpointId: "endpoint-1",
+          reasoningEffort: "high",
         });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
@@ -376,6 +377,7 @@ describe("responses-model", () => {
           providerOnly: ["google-vertex"],
           providerIgnore: ["azure"],
           allowFallbacks: false,
+          reasoningEffort: "high",
         });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
@@ -399,7 +401,10 @@ describe("responses-model", () => {
       const exit = await runPromiseExit(
         gen(function* run() {
           const modelService = yield* ResponsesModel;
-          return yield* modelService.generate([], { costTier: "high" });
+          return yield* modelService.generate([], {
+            costTier: "high",
+            reasoningEffort: "high",
+          });
         }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
       );
       assertSuccess(exit);
@@ -423,6 +428,7 @@ describe("responses-model", () => {
         return yield* modelService.generate([], {
           costTier: "medium",
           costQualityTradeoff: 8,
+          reasoningEffort: "high",
         });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
@@ -443,7 +449,7 @@ describe("responses-model", () => {
     const exit = await runPromiseExit(
       gen(function* run() {
         const modelService = yield* ResponsesModel;
-        return yield* modelService.generate([], {});
+        return yield* modelService.generate([], { reasoningEffort: "high" });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
     assertSuccess(exit);
@@ -504,7 +510,7 @@ describe("responses-model", () => {
     const exit = await runPromiseExit(
       gen(function* run() {
         const model = yield* ResponsesModel;
-        return yield* model.generate([], {});
+        return yield* model.generate([], { reasoningEffort: "high" });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
     assertFailure(exit);
@@ -547,7 +553,10 @@ describe("responses-model", () => {
     const exit = await runPromiseExit(
       gen(function* run() {
         const model = yield* ResponsesModel;
-        return yield* model.generate([], { timeoutMs: 50 });
+        return yield* model.generate([], {
+          timeoutMs: 50,
+          reasoningEffort: "high",
+        });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
     assertFailure(exit);
@@ -574,7 +583,7 @@ describe("responses-model", () => {
         const model = yield* ResponsesModel;
         return yield* model.generate(
           [],
-          {},
+          { reasoningEffort: "high" },
           { onStreamEvent: (event) => events.push(event) }
         );
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
@@ -601,7 +610,7 @@ describe("responses-model", () => {
     const exit = await runPromiseExit(
       gen(function* run() {
         const model = yield* ResponsesModel;
-        return yield* model.generate([], {});
+        return yield* model.generate([], { reasoningEffort: "high" });
       }).pipe(provide(layer.pipe(layerProvide(FetchHttpClient.layer))))
     );
     assertFailure(exit);

--- a/src/providers/responses-model.ts
+++ b/src/providers/responses-model.ts
@@ -177,9 +177,7 @@ export function generate(
     }),
     ...(genConfig.tools !== undefined &&
       genConfig.tools.length > 0 && { tools: [...genConfig.tools] }),
-    ...(genConfig.reasoningEffort !== undefined && {
-      reasoning: { effort: genConfig.reasoningEffort },
-    }),
+    reasoning: { effort: genConfig.reasoningEffort },
     ...(genConfig.temperature !== undefined && {
       temperature: genConfig.temperature,
     }),


### PR DESCRIPTION
## TL;DR

Reasoning effort is now a required, explicitly-set value on every client interface in the harness, so a run's effort always comes from the caller instead of a provider default or a benchmark-local hardcode.

## What changed?

- `InferenceOverrideSchema.reasoningEffort` and `GenerateConfig.reasoningEffort` are required. Every client therefore always sends `reasoning.effort` instead of conditionally omitting it — `responses-model` (and `openrouter-model`, which delegates to it), the search request builder, the judge, and the internal-benchmarks solver.
- New `--reasoning-effort` CLI flag, validated against `REASONING_EFFORTS` and defaulting to the new `DEFAULT_REASONING_EFFORT` (`high`), threaded into every branch of `buildBenchmarkConfig` — including `gpqa_diamond`, `mmlu_pro`, `mmmu_pro_vision` and `ifstruct`, which previously had no way to receive it at all — and echoed in the run banner.
- Hardcodes deleted: `SWE_ATLAS_REASONING_EFFORT` and `DEEP_SWE_REASONING_EFFORT` (both pinned `"high"`), and `DEFAULT_ORI_REASONING_EFFORT` (`"medium"`), which the ori runner silently applied whenever `agentReasoningEffort` was absent — so a run launched at `high` actually ran the agent at medium. `agentReasoningEffort` is now required on the terminal-bench and shared agentic options, and the CLI derives it from `--reasoning-effort` unless solver config sets it explicitly.
- Judges and user simulators are the graded environment, not the model under test, so they stay benchmark-fixed — but now explicitly, with regression tests pinning the request shape they have always sent: the two `openai/gpt-4.1` judges at `none`, the DSQA `gemini-2.5-flash` grader at `low`, draco's and tau3 banking's existing defaults unchanged, and a new `userReasoningEffort` (default `medium`, mirroring tau3) for tau-bench airline so its simulated customer no longer drifts with the run-level effort.

## Why?

ECO-3608. Reasoning effort was optional at every layer, so what a benchmark actually ran at depended on which layer happened to fill it in — provider defaults for the search and responses clients, `"high"` for swe-atlas/deep-swe regardless of the request, `"medium"` for ori. That makes runs non-reproducible and cross-model comparisons unsound. `high` is the single top-level default so existing callers keep working; nothing below the entrypoint defaults anymore.

## How to test

```bash
bun run src/cli/index.ts --benchmark gpqa_diamond --model openai/gpt-5.4 --limit 2 --reasoning-effort low
```

The banner echoes `reasoning-effort=low`, and every request body carries `reasoning: { effort: "low" }` — including the four benchmarks above, which previously dropped the value. Omitting the flag yields `high`. An invalid value fails fast with the list of accepted efforts.

For an ori lane (`terminal_bench`, `swe_atlas_*`, `deep_swe`), the agent CLI is invoked with the effort you passed; before this change it ran at `medium` no matter what.

## Benchmark impact

Scores can move for any run that previously relied on an implicit effort:

- swe-atlas and deep-swe no longer force `high`; ori lanes no longer fall back to `medium`. Runs at the same nominal effort as before are unchanged; runs that were silently overridden now honor the request.
- `gpqa_diamond`, `mmlu_pro`, `mmmu_pro_vision` and `ifstruct` now send an effort where they previously sent none, so their default behavior moves from the provider default to `high`.
- Grading is deliberately unchanged: the judge and user-simulator values above reproduce their historical request shape, verified by tests.

## Reviewer focus

- The judge and airline user-simulator values — these are the lines where a wrong choice would quietly change comparability rather than fail.
- Whether making `agentReasoningEffort` required in the agentic options is the right contract versus deriving it inside the runner.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [ ] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/919b4d20f3214b6ca1ab0047e879b5e5
Open in Devin Desktop: https://openrouter.devinenterprise.com/desktop/session/919b4d20f3214b6ca1ab0047e879b5e5?variant=devin
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->