### PR TITLE
feat(agent-cli): add omp (oh-my-pi) ori harness

### DIFF
--- a/src/benchmarks/agent-cli/harness.ts
+++ b/src/benchmarks/agent-cli/harness.ts
@@ -22,6 +22,12 @@ export const DEFAULT_PI_AGENT_PACKAGE =
 export const DEFAULT_PRIME_AGENT_PACKAGE =
   "https://pub-728493de92a943e2a9b2d17b4719f318.r2.dev/releases/v0.9.1/prime-agent-0.9.1.tgz" as const;
 
+export const DEFAULT_OMP_PACKAGE = "@oh-my-pi/pi-coding-agent@18.1.2" as const;
+
+export const OMP_BUN_VERSION = "bun-v1.3.14" as const;
+
+const BUN_INSTALL_URL = "https://bun.sh/install" as const;
+
 export const DEFAULT_AGENT_RUNTIME_URL =
   "https://github.com/OpenRouterTeam/benchmark-harness/releases/download/agent-runtime-v2/agent-runtime-linux-x64-v2.tar.zst" as const;
 
@@ -111,6 +117,16 @@ function buildAgentImageSteps(opts: {
       installCommand: opts.installCommand,
     }),
   });
+}
+
+function buildOmpImageSteps(agentPackage: string): string[] {
+  return [
+    "RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git unzip",
+    "ENV BUN_INSTALL=/root/.bun",
+    `RUN curl -fsSL ${BUN_INSTALL_URL} | bash -s ${OMP_BUN_VERSION} && ln -sf /root/.bun/bin/bun /usr/local/bin/bun`,
+    `RUN bun install -g ${JSON.stringify(agentPackage)} && ln -sf /root/.bun/bin/omp /usr/local/bin/omp`,
+    "RUN omp --version",
+  ];
 }
 
 function buildBootstrapScript(opts: {
@@ -446,14 +462,61 @@ const PRIME_AGENT_HARNESS: OriHarnessDef = {
   parseRun: parseJsonAgentStream,
 };
 
+const OMP_HARNESS: OriHarnessDef = {
+  id: "omp",
+  defaultPackage: DEFAULT_OMP_PACKAGE,
+  binaryName: "omp",
+  remoteLogPath: "/logs/agent/omp.txt",
+  imageBuildSteps: (options) => buildOmpImageSteps(options.agentPackage),
+  buildBootstrapScript: (options) =>
+    buildBootstrapScript({ ...options, binaryName: "omp" }),
+  buildRunScript: (options) =>
+    [
+      "set -euo pipefail",
+      "export HOME=/root",
+      "mkdir -p /logs/agent",
+      ...(options.hasDisallowedTools
+        ? ['echo "omp does not support disallowedTools" >&2', "exit 2"]
+        : []),
+      'ori omp --model "$TB_MODEL" \\',
+      `  --reasoning-effort ${options.reasoningEffort} -- \\`,
+      "  --print --mode json --no-session --yolo \\",
+      ...(options.hasSystemPrompt
+        ? ['  --system-prompt "$TB_SYSTEM_PROMPT" \\']
+        : []),
+      ...(options.hasAppendSystemPrompt
+        ? ['  --append-system-prompt "$TB_APPEND_SYSTEM_PROMPT" \\']
+        : []),
+      ...(options.hasAllowedTools
+        ? [`  --tools "\${TB_ALLOWED_TOOLS// /,}" \\`]
+        : []),
+      ...(options.isolateAgentConfig
+        ? ["  --no-extensions \\", "  --no-skills \\", "  --no-rules \\"]
+        : []),
+      `  "$(cat ${options.instructionPath})" \\`,
+      `  2>&1 </dev/null | grep -v '"type":"message_update"' | stdbuf -oL tee ${options.logPath}`,
+    ].join("\n"),
+  parseRun: parseJsonAgentStream,
+};
+
 export const ORI_HARNESSES: Readonly<Record<OriAgent, OriHarnessDef>> = {
   claude: CLAUDE_HARNESS,
   pi: ORI_PI_HARNESS,
   "prime-agent": PRIME_AGENT_HARNESS,
+  omp: OMP_HARNESS,
 };
 
 export function getOriHarness(agent: OriAgent): OriHarnessDef {
   return ORI_HARNESSES[agent];
+}
+
+function reasoningTokensOf(usage: Record<string, unknown>): number {
+  const reasoning = usage["reasoning"];
+  if (typeof reasoning === "number") {
+    return reasoning;
+  }
+  const reasoningTokens = usage["reasoningTokens"];
+  return typeof reasoningTokens === "number" ? reasoningTokens : 0;
 }
 
 function parseJsonAgentStream(stdout: string): OriAgentRun {
@@ -556,8 +619,7 @@ function parseJsonAgentStream(stdout: string): OriAgentRun {
           eventOutputTokens +
           eventCacheRead +
           eventCacheWrite;
-    reasoningTokens +=
-      typeof usage["reasoning"] === "number" ? usage["reasoning"] : 0;
+    reasoningTokens += reasoningTokensOf(usage);
     const { cost } = usage;
     if (isRecord(cost)) {
       totalCost += typeof cost["total"] === "number" ? cost["total"] : 0;

--- a/src/benchmarks/agent-cli/schema.ts
+++ b/src/benchmarks/agent-cli/schema.ts
@@ -1,6 +1,6 @@
 import type { ValueOf } from "../../internal/guards";
 
-export const ORI_AGENTS = ["pi", "claude", "prime-agent"] as const;
+export const ORI_AGENTS = ["pi", "claude", "prime-agent", "omp"] as const;
 
 export type OriAgent = ValueOf<typeof ORI_AGENTS>;
 

--- a/src/benchmarks/terminal-bench/ori-solver.test.ts
+++ b/src/benchmarks/terminal-bench/ori-solver.test.ts
@@ -44,12 +44,15 @@ import {
 import {
   DEFAULT_AGENT_RUNTIME_SHA256,
   DEFAULT_AGENT_RUNTIME_URL,
+  DEFAULT_OMP_PACKAGE,
   DEFAULT_PI_AGENT_PACKAGE,
   DEFAULT_PRIME_AGENT_PACKAGE,
   getOriHarness,
+  OMP_BUN_VERSION,
   ORI_HARNESSES,
 } from "../agent-cli/harness";
 import type { OriHarnessDef } from "../agent-cli/harness";
+import { ORI_AGENTS } from "../agent-cli/schema";
 import { readTerminalBenchMeta } from "./dataset";
 import type { OriSolverOpts } from "./ori-solver";
 import { oriSolver } from "./ori-solver";
@@ -1439,5 +1442,311 @@ describe("terminal-bench Prime Agent via ori", () => {
     expect(dockerfile).toContain("PRIME_AGENT_BOOTSTRAP_KERNEL_ON_INSTALL=1");
     expect(dockerfile).not.toContain(DEFAULT_AGENT_RUNTIME_URL);
     expect(dockerfile).not.toContain(DEFAULT_AGENT_RUNTIME_SHA256);
+  });
+});
+
+describe("terminal-bench omp via ori", () => {
+  const OMP_GENERATION_ID = "gen-1788309948-omp7Xq2LmN4pRsTuVwYz";
+  const OMP_STREAM = [
+    JSON.stringify({ type: "agent_start" }),
+    JSON.stringify({ type: "turn_start" }),
+    JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "Respond with exactly OK" }],
+      },
+    }),
+    JSON.stringify({
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "OK" }],
+        responseId: "partial-message-id",
+      },
+    }),
+    JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Follow the instruction." },
+          { type: "text", text: "OK" },
+        ],
+        api: "openai-completions",
+        provider: "openrouter",
+        model: "openai/gpt-4.1-mini",
+        usage: {
+          input: 120,
+          output: 7,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 127,
+          reasoningTokens: 4,
+          cost: {
+            input: 0.000048,
+            output: 0.0000056,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0.0000536,
+          },
+        },
+        stopReason: "stop",
+        responseId: OMP_GENERATION_ID,
+      },
+    }),
+    JSON.stringify({
+      type: "tool_execution_end",
+      toolCallId: "tool-1",
+      toolName: "bash",
+      result: { content: [{ type: "text", text: "done" }] },
+      isError: false,
+    }),
+    JSON.stringify({ type: "turn_end" }),
+    JSON.stringify({ type: "agent_end", messages: [] }),
+  ].join("\n");
+
+  async function runOmp(
+    opts?: Partial<OriSolverOpts>,
+    execCalls?: ExecCalls
+  ): Promise<TaskState> {
+    const layer = makeTerminalBenchFakeSandboxLayer({
+      reward: 1,
+      testOutput: "1 passed",
+      agentEventStream: OMP_STREAM,
+      agentExitCode: 0,
+      ...(execCalls !== undefined && { execCalls }),
+    });
+    const solverLayer = layerEffect(Solver)(
+      gen(function* () {
+        const sessionFactory = yield* SandboxSession;
+        return Solver.of(
+          oriSolver(
+            sessionFactory,
+            { ...SOLVER_OPTS, ...opts },
+            getOriHarness("omp")
+          )
+        );
+      })
+    );
+    return runPromise(
+      gen(function* () {
+        const solver = yield* Solver;
+        return yield* solver(sampleState());
+      }).pipe(
+        provide(
+          layerMergeAll(
+            solverLayer.pipe(layerProvide(layer)),
+            noopProgressLayer,
+            noopCheckpointLayer
+          )
+        )
+      )
+    );
+  }
+
+  it("is registered as an ori agent", () => {
+    expect(ORI_AGENTS).toContain("omp");
+    expect(getOriHarness("omp").binaryName).toBe("omp");
+    expect(getOriHarness("omp").defaultPackage).toBe(DEFAULT_OMP_PACKAGE);
+    expect(getOriHarness("omp").remoteLogPath).toBe("/logs/agent/omp.txt");
+  });
+
+  it("parses usage, cost, generation IDs, messages, turns and tool calls", async () => {
+    const finalState = await runOmp();
+    expect(finalState.output?.completion).toBe("OK");
+    expect(finalState.output?.usage).toEqual({
+      inputTokens: 120,
+      outputTokens: 7,
+      totalTokens: 127,
+      reasoningTokens: 4,
+      totalCost: 0.0000536,
+    });
+    expect(finalState.sample.metadata?.["generationIds"]).toEqual([
+      OMP_GENERATION_ID,
+    ]);
+    const collectedGenerationIds = await runAndCollectGenerationIds(
+      makeTerminalBenchFakeSandboxLayer({
+        reward: 1,
+        testOutput: "1 passed",
+        agentEventStream: OMP_STREAM,
+        agentExitCode: 0,
+      }),
+      getOriHarness("omp")
+    );
+    expect(collectedGenerationIds).toEqual([OMP_GENERATION_ID]);
+    expect(finalState.sample.metadata?.["agent"]).toBe("omp");
+    expect(finalState.sample.metadata?.["agentTurns"]).toBe(1);
+    expect(finalState.sample.metadata?.["agentToolCalls"]).toBe(1);
+    expect(finalState.messages.at(-1)).toEqual({
+      role: "assistant",
+      content: "OK",
+      reasoning: "Follow the instruction.",
+      model: "openai/gpt-4.1-mini",
+    });
+  });
+
+  it("launches omp with JSON output and isolated configuration", async () => {
+    const execCalls: ExecCalls = [];
+    await runOmp(
+      {
+        model: "openai/gpt-4.1-mini",
+        agentReasoningEffort: "high",
+        systemPrompt: "Use tools carefully.",
+        appendSystemPrompt: "Return a concise result.",
+        allowedTools: ["bash", "edit"],
+        isolateAgentConfig: true,
+      },
+      execCalls
+    );
+    const agentCall = execCalls.find((call) =>
+      call.argv[2]?.includes("ori omp")
+    );
+    const script = agentCall?.argv[2] ?? "";
+    expect(agentCall?.env["TB_MODEL"]).toBe("openai/gpt-4.1-mini");
+    expect(agentCall?.env["TB_ALLOWED_TOOLS"]).toBe("bash edit");
+    expect(script).toContain('ori omp --model "$TB_MODEL"');
+    expect(script).toContain("--reasoning-effort high --");
+    expect(script).toContain("--print --mode json --no-session --yolo");
+    expect(script).toContain('--system-prompt "$TB_SYSTEM_PROMPT"');
+    expect(script).toContain(
+      '--append-system-prompt "$TB_APPEND_SYSTEM_PROMPT"'
+    );
+    expect(script).toContain(`--tools "\${TB_ALLOWED_TOOLS// /,}"`);
+    expect(script).toContain("--no-extensions");
+    expect(script).toContain("--no-skills");
+    expect(script).toContain("--no-rules");
+    expect(script).not.toContain("--no-prompt-templates");
+    expect(script).not.toContain("--no-context-files");
+  });
+
+  it("omits optional omp arguments when they are not configured", () => {
+    const script = ORI_HARNESSES.omp.buildRunScript({
+      instructionPath: "/instruction.txt",
+      logPath: "/logs/agent/omp.txt",
+      reasoningEffort: "medium",
+      hasSystemPrompt: false,
+      hasAppendSystemPrompt: false,
+      hasAllowedTools: false,
+      hasDisallowedTools: false,
+      isolateAgentConfig: false,
+    });
+    expect(script).toBe(
+      [
+        "set -euo pipefail",
+        "export HOME=/root",
+        "mkdir -p /logs/agent",
+        'ori omp --model "$TB_MODEL" \\',
+        "  --reasoning-effort medium -- \\",
+        "  --print --mode json --no-session --yolo \\",
+        '  "$(cat /instruction.txt)" \\',
+        `  2>&1 </dev/null | grep -v '"type":"message_update"' | stdbuf -oL tee /logs/agent/omp.txt`,
+      ].join("\n")
+    );
+  });
+
+  it("fails before launch when a disallowed tool list is configured", () => {
+    const script = ORI_HARNESSES.omp.buildRunScript({
+      instructionPath: "/instruction.txt",
+      logPath: "/logs/agent/omp.txt",
+      reasoningEffort: "medium",
+      hasSystemPrompt: false,
+      hasAppendSystemPrompt: false,
+      hasAllowedTools: false,
+      hasDisallowedTools: true,
+      isolateAgentConfig: false,
+    });
+    expect(script).toContain(
+      'echo "omp does not support disallowedTools" >&2\nexit 2'
+    );
+    expect(script.indexOf("exit 2")).toBeLessThan(script.indexOf("ori omp"));
+  });
+
+  it("deduplicates repeated omp response IDs and skips non-assistant events", () => {
+    const parsed = ORI_HARNESSES.omp.parseRun(
+      [
+        JSON.stringify({
+          type: "message_end",
+          message: { role: "user", content: [], responseId: "user-id" },
+        }),
+        JSON.stringify({
+          type: "message_end",
+          message: {
+            role: "assistant",
+            content: [],
+            stopReason: "toolUse",
+            responseId: "gen-a",
+          },
+        }),
+        JSON.stringify({
+          type: "message_end",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+            stopReason: "stop",
+            responseId: "gen-a",
+          },
+        }),
+        JSON.stringify({
+          type: "message_end",
+          message: {
+            role: "assistant",
+            content: [],
+            stopReason: "stop",
+            responseId: "gen-b",
+          },
+        }),
+      ].join("\n")
+    );
+    expect(parsed.generationIds).toEqual(["gen-a", "gen-b"]);
+    expect(parsed.isError).toBe(false);
+  });
+
+  it("marks omp error messages as failed runs", () => {
+    const parsed = ORI_HARNESSES.omp.parseRun(
+      JSON.stringify({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "rate_limit",
+        },
+      })
+    );
+    expect(parsed.isError).toBe(true);
+    expect(parsed.apiErrorStatus).toBe("rate_limit");
+    expect(parsed.generationIds).toEqual([]);
+  });
+
+  it("installs bun and the omp package into the image", () => {
+    const steps = ORI_HARNESSES.omp.imageBuildSteps({
+      agentPackage: DEFAULT_OMP_PACKAGE,
+    });
+    const dockerfile = steps.join("\n");
+    expect(dockerfile).toContain("https://bun.sh/install");
+    expect(dockerfile).toContain(`bash -s ${OMP_BUN_VERSION}`);
+    expect(dockerfile).toContain(
+      `bun install -g ${JSON.stringify(DEFAULT_OMP_PACKAGE)}`
+    );
+    expect(dockerfile).toContain(
+      "ln -sf /root/.bun/bin/omp /usr/local/bin/omp"
+    );
+    expect(dockerfile).not.toContain(DEFAULT_AGENT_RUNTIME_URL);
+    expect(dockerfile).not.toContain("npm install");
+    expect(steps.at(-1)).toBe("RUN omp --version");
+    expect(
+      ORI_HARNESSES.omp.buildBootstrapScript({
+        oriInstallUrl: "https://openrouter.ai/labs/ori/install.sh",
+        oriChannel: "stable",
+      })
+    ).toContain("ori --version && omp --version");
+  });
+
+  it("preserves a custom omp package override", () => {
+    const steps = ORI_HARNESSES.omp.imageBuildSteps({
+      agentPackage: "file:///opt/omp.tgz",
+    });
+    expect(steps.join("\n")).toContain('bun install -g "file:///opt/omp.tgz"');
   });
 });

--- a/test/helpers/terminal-bench-sandbox.ts
+++ b/test/helpers/terminal-bench-sandbox.ts
@@ -34,6 +34,7 @@ const AGENT_COMMAND_MARKERS = [
   "pi ",
   "ori claude",
   "ori prime-agent",
+  "ori omp",
 ] as const;
 
 const ORI_INSTALL_MARKER = "ORI_INSTALL_DIR=" as const;


### PR DESCRIPTION
## TL;DR

Adds `omp` (oh-my-pi, `@oh-my-pi/pi-coding-agent@18.1.2`) as a fourth ori agent so terminal-bench runs can attribute OpenRouter generation ids from omp's JSON `message_end` events.

## What changed?

- `ORI_AGENTS` gains `"omp"` (also flows into `HARBOR_AGENTS`).
- New `OMP_HARNESS` in `src/benchmarks/agent-cli/harness.ts`:
  - run script: `ori omp --model "$TB_MODEL" --reasoning-effort <effort> -- --print --mode json --no-session --yolo [--system-prompt] [--append-system-prompt] [--tools a,b] [--no-extensions --no-skills --no-rules] "<instruction>"`, filtered through the same `message_update` grep and `tee` as pi/prime-agent
  - `disallowedTools` fails before launch (omp has no exclude flag), same as prime-agent
  - image steps install bun (`bun-v1.3.14`, pinned, matches omp's `engines.bun >= 1.3.14`) then `bun install -g <package>`, since omp's `dist/cli.js` has a `#!/usr/bin/env bun` shebang and is not in the prebuilt agent-runtime archive
  - reuses `parseJsonAgentStream` (reads `message.responseId` on assistant `message_end`)
- `parseJsonAgentStream` now also accepts omp's `usage.reasoningTokens` alongside pi's `usage.reasoning`.
- Fake terminal-bench sandbox recognises `ori omp` as an agent command.
- Tests: new `terminal-bench omp via ori` describe block (registration, end-to-end solver run with generation-id collection, run-script shape, isolation flags, disallowed-tools guard, response-id dedup, error handling, image/bootstrap steps, package override).

## Why?

We need more ori harnesses whose headless output exposes the OpenRouter generation id. omp is a pi fork and its assistant messages carry `responseId` (documented in the package as the canonical provider-side id), so it fits the existing parser with no new parsing code.

## How to test

```bash
bun install
bun test src/benchmarks/terminal-bench/ori-solver.test.ts   # 57 pass, 9 new omp tests
bun run format:check && bun run check && bun run typecheck && bun test && bun run build
```

Manual (not run in this PR): launch a terminal-bench run with `agent: "omp"` and confirm `sample.metadata.generationIds` is populated with `gen-...` ids.

## Benchmark impact

No change to existing agents' scripts, parsing, or scores. Adds an opt-in agent only.

## Reviewer focus

- omp flag mapping: `--thinking` is set by `ori omp` from `--reasoning-effort`, `--tools` takes a comma list, `--no-rules` replaces pi's `--no-prompt-templates/--no-context-files`. `--yolo` is explicit even though omp defaults to yolo.
- Image build uses the bun install script from `bun.sh` (network at build time, like the nvm path for custom pi packages). No checksum pinning beyond the version tag.
- The new harness has not been exercised end to end against a real sandbox yet.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [ ] Benchmark changes document dataset provenance and licensing (n/a)
- [x] No credentials, private results, or restricted dataset contents are included
- [ ] Documentation is updated where needed (no docs enumerate agents)


Link to Devin session: https://openrouter.devinenterprise.com/sessions/ee6c2bd8bc4049858354fabce2a1ed9b
Open in Devin Desktop: https://openrouter.devinenterprise.com/desktop/session/ee6c2bd8bc4049858354fabce2a1ed9b?variant=devin
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->