### PR TITLE
fix(agent-cli): validate agentPackage and checksum-pin bun/nvm installers

### DIFF
--- a/src/benchmarks/agent-cli/harness.ts
+++ b/src/benchmarks/agent-cli/harness.ts
@@ -7,12 +7,15 @@ import { MessageRole } from "../../harness/core";
 import { Either } from "../../internal/either";
 import { isRecord } from "../../internal/guards";
 import type { OriAgent, OriChannel, OriReasoningEffort } from "./schema";
-import { DEFAULT_CLAUDE_PACKAGE } from "./schema";
+import { assertValidAgentPackage, DEFAULT_CLAUDE_PACKAGE } from "./schema";
 
 const NODE_VERSION = "22" as const;
 
-const NVM_INSTALL_URL =
+export const NVM_INSTALL_URL =
   "https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh" as const;
+
+export const NVM_INSTALL_SHA256 =
+  "a909fdd01765379ebc5983674adafb8bc9de6d928bfa188761309d4a0c36be0f" as const;
 
 export const ORI_INSTALL_DIR = "/usr/local/bin" as const;
 
@@ -26,7 +29,15 @@ export const DEFAULT_OMP_PACKAGE = "@oh-my-pi/pi-coding-agent@18.1.2" as const;
 
 export const OMP_BUN_VERSION = "bun-v1.3.14" as const;
 
-const BUN_INSTALL_URL = "https://bun.sh/install" as const;
+export const BUN_RELEASE_URL =
+  `https://github.com/oven-sh/bun/releases/download/${OMP_BUN_VERSION}/bun-linux-x64.zip` as const;
+
+export const BUN_RELEASE_SHA256 =
+  "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f" as const;
+
+function verifiedDownload(url: string, sha256: string, dest: string): string {
+  return `curl -fsSL ${JSON.stringify(url)} -o ${dest} && echo "${sha256}  ${dest}" | sha256sum -c -`;
+}
 
 export const DEFAULT_AGENT_RUNTIME_URL =
   "https://github.com/OpenRouterTeam/benchmark-harness/releases/download/agent-runtime-v2/agent-runtime-linux-x64-v2.tar.zst" as const;
@@ -83,12 +94,14 @@ function buildImageSteps(opts: {
   binaryName: string;
   installCommand?: string;
 }): string[] {
+  assertValidAgentPackage(opts.agentPackage);
   const installCommand =
     opts.installCommand ?? `npm install -g ${opts.agentPackage}`;
+  const nvmScript = "/tmp/nvm-install.sh";
   return [
     "RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git",
     "ENV NVM_DIR=/root/.nvm",
-    `RUN curl -o- ${NVM_INSTALL_URL} | bash`,
+    `RUN ${verifiedDownload(NVM_INSTALL_URL, NVM_INSTALL_SHA256, nvmScript)} && bash ${nvmScript} && rm -f ${nvmScript}`,
     `RUN . /root/.nvm/nvm.sh && nvm install ${NODE_VERSION} && ${installCommand} && ln -sf $(which ${opts.binaryName}) /usr/local/bin/${opts.binaryName} && ln -sf $(which node) /usr/local/bin/node && ln -sf $(which npm) /usr/local/bin/npm`,
     `RUN ${opts.binaryName} --version`,
   ];
@@ -104,7 +117,7 @@ function buildAgentImageSteps(opts: {
     const archivePath = "/tmp/agent-runtime.tar.zst";
     return [
       "RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git zstd",
-      `RUN curl -fsSL ${JSON.stringify(DEFAULT_AGENT_RUNTIME_URL)} -o ${archivePath} && echo "${DEFAULT_AGENT_RUNTIME_SHA256}  ${archivePath}" | sha256sum -c - && zstd -dc ${archivePath} | tar -x -C / && rm -f ${archivePath}`,
+      `RUN ${verifiedDownload(DEFAULT_AGENT_RUNTIME_URL, DEFAULT_AGENT_RUNTIME_SHA256, archivePath)} && zstd -dc ${archivePath} | tar -x -C / && rm -f ${archivePath}`,
       'ENV PATH="/root/.local/bin:$PATH"',
       "RUN ln -sf /opt/agent-runtime/app/node_modules/.bin/claude /usr/local/bin/claude && ln -sf /opt/agent-runtime/app/node_modules/.bin/pi /usr/local/bin/pi && ln -sf /opt/agent-runtime/app/node_modules/.bin/prime-agent /usr/local/bin/prime-agent && ln -sf /opt/agent-runtime/node/bin/node /usr/local/bin/node && ln -sf /opt/agent-runtime/node/bin/npm /usr/local/bin/npm && ln -sf /opt/agent-runtime/node/bin/npx /usr/local/bin/npx",
       `RUN ${opts.binaryName} --version`,
@@ -120,10 +133,12 @@ function buildAgentImageSteps(opts: {
 }
 
 function buildOmpImageSteps(agentPackage: string): string[] {
+  assertValidAgentPackage(agentPackage);
+  const bunZip = "/tmp/bun.zip";
   return [
     "RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git unzip",
     "ENV BUN_INSTALL=/root/.bun",
-    `RUN curl -fsSL ${BUN_INSTALL_URL} | bash -s ${OMP_BUN_VERSION} && ln -sf /root/.bun/bin/bun /usr/local/bin/bun`,
+    `RUN ${verifiedDownload(BUN_RELEASE_URL, BUN_RELEASE_SHA256, bunZip)} && unzip -q ${bunZip} -d /tmp && install -m 0755 /tmp/bun-linux-x64/bun /usr/local/bin/bun && rm -rf ${bunZip} /tmp/bun-linux-x64`,
     `RUN bun install -g ${JSON.stringify(agentPackage)} && ln -sf /root/.bun/bin/omp /usr/local/bin/omp`,
     "RUN omp --version",
   ];

--- a/src/benchmarks/agent-cli/harness.ts
+++ b/src/benchmarks/agent-cli/harness.ts
@@ -96,7 +96,8 @@ function buildImageSteps(opts: {
 }): string[] {
   assertValidAgentPackage(opts.agentPackage);
   const installCommand =
-    opts.installCommand ?? `npm install -g ${opts.agentPackage}`;
+    opts.installCommand ??
+    `npm install -g ${JSON.stringify(opts.agentPackage)}`;
   const nvmScript = "/tmp/nvm-install.sh";
   return [
     "RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git",

--- a/src/benchmarks/agent-cli/schema.ts
+++ b/src/benchmarks/agent-cli/schema.ts
@@ -22,6 +22,21 @@ export const ORI_REASONING_EFFORTS = [
 
 export type OriReasoningEffort = ValueOf<typeof ORI_REASONING_EFFORTS>;
 
+export const AGENT_PACKAGE_PATTERN = /^[A-Za-z0-9@/:._~^<>=|*+-]+$/;
+
+export function isValidAgentPackage(value: string): boolean {
+  return AGENT_PACKAGE_PATTERN.test(value);
+}
+
+export function assertValidAgentPackage(value: string): string {
+  if (!isValidAgentPackage(value)) {
+    throw new Error(
+      `invalid agentPackage ${JSON.stringify(value)}: only [A-Za-z0-9@/:._~^<>=|*+-] are allowed`
+    );
+  }
+  return value;
+}
+
 export const DEFAULT_CLAUDE_PACKAGE =
   "@anthropic-ai/claude-code@2.1.235" as const;
 

--- a/src/benchmarks/agent-cli/schema.ts
+++ b/src/benchmarks/agent-cli/schema.ts
@@ -22,7 +22,7 @@ export const ORI_REASONING_EFFORTS = [
 
 export type OriReasoningEffort = ValueOf<typeof ORI_REASONING_EFFORTS>;
 
-export const AGENT_PACKAGE_PATTERN = /^[A-Za-z0-9@/:._~^<>=|*+-]+$/;
+export const AGENT_PACKAGE_PATTERN = /^[A-Za-z0-9@/:._^=+-]+$/;
 
 export function isValidAgentPackage(value: string): boolean {
   return AGENT_PACKAGE_PATTERN.test(value);
@@ -31,7 +31,7 @@ export function isValidAgentPackage(value: string): boolean {
 export function assertValidAgentPackage(value: string): string {
   if (!isValidAgentPackage(value)) {
     throw new Error(
-      `invalid agentPackage ${JSON.stringify(value)}: only [A-Za-z0-9@/:._~^<>=|*+-] are allowed`
+      `invalid agentPackage ${JSON.stringify(value)}: only [A-Za-z0-9@/:._^=+-] are allowed`
     );
   }
   return value;

--- a/src/benchmarks/benchmark-config.ts
+++ b/src/benchmarks/benchmark-config.ts
@@ -7,6 +7,7 @@ import { ProviderSort } from "../internal/enums";
 import type { ValueOf } from "../internal/guards";
 import { z, zDefaultedText, zInt } from "../internal/zod";
 import {
+  AGENT_PACKAGE_PATTERN,
   DEFAULT_HARBOR_AGENT,
   DEFAULT_ORI_CHANNEL,
   DEFAULT_ORI_INSTALL_URL,
@@ -138,13 +139,17 @@ export type MmmuProVisionBenchmarkConfig = z.infer<
   typeof MmmuProVisionBenchmarkConfigSchema
 >;
 
+const AgentPackageSchema = z
+  .string()
+  .regex(AGENT_PACKAGE_PATTERN, "agentPackage contains disallowed characters");
+
 export const TerminalBenchOptionsSchema = z.object({
   maxAgentTimeoutSec: z.number().positive().optional(),
   taskSubset: z.array(z.string()).optional(),
   modalEnv: z.string().default("main"),
   appendSystemPrompt: z.string().optional(),
   agent: z.enum(TERMINAL_BENCH_AGENTS).default(DEFAULT_TERMINAL_BENCH_AGENT),
-  agentPackage: z.string().optional(),
+  agentPackage: AgentPackageSchema.optional(),
   oriInstallUrl: z.string().default(DEFAULT_ORI_INSTALL_URL),
   agentReasoningEffort: z.enum(ORI_REASONING_EFFORTS),
   oriChannel: z.enum(ORI_CHANNELS).default(DEFAULT_ORI_CHANNEL),
@@ -188,7 +193,7 @@ const AgenticOptionsSchema = z.object({
   maxAgentTimeoutSec: z.number().positive().optional(),
   modalEnv: z.string().default("main"),
   agent: z.enum(HARBOR_AGENTS).default(DEFAULT_HARBOR_AGENT),
-  agentPackage: z.string().optional(),
+  agentPackage: AgentPackageSchema.optional(),
   oriInstallUrl: z.string().default(DEFAULT_ORI_INSTALL_URL),
   agentReasoningEffort: z.enum(ORI_REASONING_EFFORTS),
   oriChannel: z.enum(ORI_CHANNELS).default(DEFAULT_ORI_CHANNEL),

--- a/src/benchmarks/terminal-bench/ori-solver.test.ts
+++ b/src/benchmarks/terminal-bench/ori-solver.test.ts
@@ -1039,6 +1039,11 @@ describe("terminal-bench pi via ori", () => {
       "foo bar",
       'foo"bar',
       "foo'bar",
+      "foo|id",
+      "foo>x",
+      "foo<x",
+      "foo*",
+      "~root/foo",
     ]) {
       expect(() => ORI_HARNESSES.pi.imageBuildSteps({ agentPackage })).toThrow(
         /invalid agentPackage/
@@ -1055,7 +1060,7 @@ describe("terminal-bench pi via ori", () => {
       DEFAULT_PRIME_AGENT_PACKAGE,
       DEFAULT_OMP_PACKAGE,
       "@scope/name@^1.2.3",
-      "name@>=1.0.0||<2.0.0",
+      "name@=1.2.3",
       "file:///opt/omp.tgz",
     ]) {
       expect(() =>

--- a/src/benchmarks/terminal-bench/ori-solver.test.ts
+++ b/src/benchmarks/terminal-bench/ori-solver.test.ts
@@ -42,12 +42,16 @@ import {
   resetGenerationIds,
 } from "../../runtime/generation-ids";
 import {
+  BUN_RELEASE_SHA256,
+  BUN_RELEASE_URL,
   DEFAULT_AGENT_RUNTIME_SHA256,
   DEFAULT_AGENT_RUNTIME_URL,
   DEFAULT_OMP_PACKAGE,
   DEFAULT_PI_AGENT_PACKAGE,
   DEFAULT_PRIME_AGENT_PACKAGE,
   getOriHarness,
+  NVM_INSTALL_SHA256,
+  NVM_INSTALL_URL,
   OMP_BUN_VERSION,
   ORI_HARNESSES,
 } from "../agent-cli/harness";
@@ -1014,6 +1018,52 @@ describe("terminal-bench pi via ori", () => {
     expect(dockerfile).not.toContain(DEFAULT_AGENT_RUNTIME_SHA256);
   });
 
+  it("verifies the nvm installer checksum before running it", () => {
+    const dockerfile = ORI_HARNESSES.pi
+      .imageBuildSteps({
+        agentPackage: "@earendil-works/pi-coding-agent@0.80.0",
+      })
+      .join("\n");
+    expect(dockerfile).toContain(JSON.stringify(NVM_INSTALL_URL));
+    expect(dockerfile).toContain(`${NVM_INSTALL_SHA256}  /tmp/nvm-install.sh`);
+    expect(dockerfile).toContain("sha256sum -c -");
+    expect(dockerfile).not.toContain("| bash");
+  });
+
+  it("rejects agent package overrides containing shell metacharacters", () => {
+    for (const agentPackage of [
+      "foo$(id)",
+      "foo`id`",
+      "foo; id",
+      "foo && id",
+      "foo bar",
+      'foo"bar',
+      "foo'bar",
+    ]) {
+      expect(() => ORI_HARNESSES.pi.imageBuildSteps({ agentPackage })).toThrow(
+        /invalid agentPackage/
+      );
+      expect(() => ORI_HARNESSES.omp.imageBuildSteps({ agentPackage })).toThrow(
+        /invalid agentPackage/
+      );
+    }
+  });
+
+  it("accepts npm specs, tarball URLs and file paths as agent packages", () => {
+    for (const agentPackage of [
+      DEFAULT_PI_AGENT_PACKAGE,
+      DEFAULT_PRIME_AGENT_PACKAGE,
+      DEFAULT_OMP_PACKAGE,
+      "@scope/name@^1.2.3",
+      "name@>=1.0.0||<2.0.0",
+      "file:///opt/omp.tgz",
+    ]) {
+      expect(() =>
+        ORI_HARNESSES.omp.imageBuildSteps({ agentPackage })
+      ).not.toThrow();
+    }
+  });
+
   it("can install ori from the alpha channel when asked", () => {
     const script = ORI_HARNESSES.pi.buildBootstrapScript({
       oriInstallUrl: "https://openrouter.ai/labs/ori/install.sh",
@@ -1724,8 +1774,15 @@ describe("terminal-bench omp via ori", () => {
       agentPackage: DEFAULT_OMP_PACKAGE,
     });
     const dockerfile = steps.join("\n");
-    expect(dockerfile).toContain("https://bun.sh/install");
-    expect(dockerfile).toContain(`bash -s ${OMP_BUN_VERSION}`);
+    expect(BUN_RELEASE_URL).toContain(OMP_BUN_VERSION);
+    expect(dockerfile).toContain(JSON.stringify(BUN_RELEASE_URL));
+    expect(dockerfile).toContain(`${BUN_RELEASE_SHA256}  /tmp/bun.zip`);
+    expect(dockerfile).toContain("sha256sum -c -");
+    expect(dockerfile).toContain(
+      "install -m 0755 /tmp/bun-linux-x64/bun /usr/local/bin/bun"
+    );
+    expect(dockerfile).not.toContain("bun.sh/install");
+    expect(dockerfile).not.toContain("| bash");
     expect(dockerfile).toContain(
       `bun install -g ${JSON.stringify(DEFAULT_OMP_PACKAGE)}`
     );


### PR DESCRIPTION
## TL;DR

Closes the two security flags Devin Review raised on [openrouter-web#39464](https://github.com/OpenRouterTeam/openrouter-web/pull/39464): `agentPackage` can no longer inject shell into Dockerfile `RUN` lines, and the bun and nvm installers are downloaded to a file and sha256-verified instead of `curl | bash`.

## What changed?

- `AGENT_PACKAGE_PATTERN = /^[A-Za-z0-9@/:._^=+-]+$/` in `agent-cli/schema.ts` (no whitespace, quotes, `$`, backticks, `;`, `&`, `|`, `<`, `>`, `*`, `~`, `#`, `?`, parentheses). Enforced twice: as a zod `.regex()` on `agentPackage` in both `TerminalBenchOptionsSchema` and `AgenticOptionsSchema`, and as `assertValidAgentPackage` at the top of every image-step builder (`buildImageSteps`, `buildOmpImageSteps`) so the harness functions are safe even when called outside the config schema. The npm interpolation is now quoted as well.
- bun: `https://bun.sh/install | bash -s bun-v1.3.14` replaced by downloading `github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip`, `sha256sum -c`, `unzip`, `install` to `/usr/local/bin/bun`. `BUN_INSTALL=/root/.bun` is kept so `bun install -g` still lands in `/root/.bun/bin`.
- nvm: `curl -o- .../v0.40.2/install.sh | bash` replaced by download + `sha256sum -c` + `bash /tmp/nvm-install.sh`.
- Shared `verifiedDownload(url, sha, dest)` helper, also used by the existing agent-runtime archive step (no behaviour change there).
- Not changed: the `ori` bootstrap installer (`openrouter.ai/labs/ori/install.sh`). It is intentionally channel-tracking (`stable`/`alpha`) and runs at sandbox boot, not image build, so a fixed checksum would defeat its purpose. Pinning it would need an `oriVersion` option in ori's installer first.

## Why?

`agentPackage` is operator-supplied config and was interpolated unquoted (`npm install -g ${agentPackage}`) or double-quoted (`bun install -g "${agentPackage}"`); either lets `$(...)` run during image build. The installers pulled mutable remote scripts, so an upstream compromise would gain code execution in every image build.

## How to test

```sh
bun test src/benchmarks/terminal-bench/ori-solver.test.ts
# new: rejects `foo$(id)`, `foo; id`, `foo|id`, `foo>x`, `foo*`, quotes, whitespace; accepts npm specs, tarball URLs, file: paths

# Prove the pinned installers actually build
bun -e 'import {ORI_HARNESSES,DEFAULT_OMP_PACKAGE} from "./src/benchmarks/agent-cli/harness"; console.log(["FROM ubuntu:24.04",...ORI_HARNESSES.omp.imageBuildSteps({agentPackage:DEFAULT_OMP_PACKAGE})].join("\n"))' > /tmp/Dockerfile.omp
docker build -f /tmp/Dockerfile.omp -t omp-pinned /tmp && docker run --rm omp-pinned sh -c 'bun --version && omp --version'
# expect: 1.3.14 / omp/18.1.2
```

Same with `ORI_HARNESSES.pi.imageBuildSteps({agentPackage:"@earendil-works/pi-coding-agent@0.84.1"})` for the nvm path; expect `v22.x` and `0.84.1`. Both were run locally on this branch.

Checksum provenance: `BUN_RELEASE_SHA256` matches `SHASUMS256.txt` in the bun-v1.3.14 GitHub release; `NVM_INSTALL_SHA256` is `sha256sum` of the v0.40.2 tagged `install.sh`.

## Reviewer focus

- Allowlist trade-off: npm range specs using `>=`, `<`, `||`, `*` or `~` are no longer valid `agentPackage` overrides. Exact versions, `^`, `=`, HTTPS tarballs and `file:` paths still are. `git+https://…#sha` is rejected because of `#`; say so if that is needed.
- Bumping `OMP_BUN_VERSION` now also requires updating `BUN_RELEASE_SHA256`.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] No credentials, private results, or restricted dataset contents are included


Link to Devin session: https://openrouter.devinenterprise.com/sessions/ee6c2bd8bc4049858354fabce2a1ed9b
Open in Devin Desktop: https://openrouter.devinenterprise.com/desktop/session/ee6c2bd8bc4049858354fabce2a1ed9b?variant=devin
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->