### PR TITLE
test(tau3): replace single-type assertions with real objects and typed access

### DIFF
--- a/src/benchmarks/tau3-bench-banking/dataset.test.ts
+++ b/src/benchmarks/tau3-bench-banking/dataset.test.ts
@@ -4,11 +4,16 @@ import { flatMap, provide, runPromise } from "effect/Effect";
 
 import { Dataset } from "../../harness/dataset";
 import { bankingRecordToSample, makeBankingDatasetLayer } from "./dataset";
-import { seedBankingCache, seedBankingTasksRawCache } from "./environment";
+import {
+  makeEmptyBankingData,
+  seedBankingCache,
+  seedBankingTasksRawCache,
+} from "./environment";
 import type { BankingData, Tau3Task } from "./types";
 describe("tau3-bench-banking dataset", () => {
   let originalFetch: typeof global.fetch;
-  const fixtureDb: Partial<BankingData> = {
+  const fixtureDb: BankingData = {
+    ...makeEmptyBankingData(),
     users: { data: { "1": { name: "Test" } } },
   };
   const fixtureTasks: Tau3Task[] = [
@@ -39,7 +44,7 @@ describe("tau3-bench-banking dataset", () => {
   ];
   beforeEach(() => {
     originalFetch = global.fetch;
-    seedBankingCache(fixtureDb as BankingData, fixtureTasks);
+    seedBankingCache(fixtureDb, fixtureTasks);
   });
   afterEach(() => {
     global.fetch = originalFetch;

--- a/src/benchmarks/tau3-bench-banking/environment.test.ts
+++ b/src/benchmarks/tau3-bench-banking/environment.test.ts
@@ -303,8 +303,7 @@ describe("tau3-bench-banking environment", () => {
       const hash1 = dbHash(data1);
       const data2 = loadBankingData();
       if (data2.task_config) {
-        (data2.task_config.data as Record<string, unknown>).test_key =
-          "test_value";
+        data2.task_config.data.test_key = { value: "test_value" };
       }
       const hash2 = dbHash(data2);
       expect(hash1).not.toBe(hash2);

--- a/src/benchmarks/tau3-bench-banking/tools/handlers-accounts.test.ts
+++ b/src/benchmarks/tau3-bench-banking/tools/handlers-accounts.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "bun:test";
+import assert from "node:assert";
 
 import { makeEmptyBankingData } from "../environment";
 import type { BankingData } from "../types";
@@ -205,8 +206,10 @@ describe("handlers-accounts", () => {
       expect(result).toContain("Amount: $100.00");
       expect(result).toContain("new balance: $900.00");
       expect(result).toContain("new balance: $600.00");
-      const source = db.accounts.data["acc_001"] as Record<string, unknown>;
-      const dest = db.accounts.data["acc_002"] as Record<string, unknown>;
+      const source = db.accounts.data["acc_001"];
+      assert(source);
+      const dest = db.accounts.data["acc_002"];
+      assert(dest);
       expect(source.current_holdings).toBe("$900.00");
       expect(dest.current_holdings).toBe("$600.00");
     });
@@ -301,7 +304,8 @@ describe("handlers-accounts", () => {
       expect(result).toContain("Amount: $50.00");
       expect(result).toContain("Previous Balance: $1000.00");
       expect(result).toContain("New Balance: $1050.00");
-      const account = db.accounts.data["acc_001"] as Record<string, unknown>;
+      const account = db.accounts.data["acc_001"];
+      assert(account);
       expect(account.current_holdings).toBe("$1050.00");
       const txnKeys = Object.keys(db.bank_account_transaction_history.data);
       expect(txnKeys.length).toBeGreaterThan(0);
@@ -309,10 +313,8 @@ describe("handlers-accounts", () => {
       if (!txnId) {
         throw new Error("Expected transaction ID");
       }
-      const txn = db.bank_account_transaction_history.data[txnId] as Record<
-        string,
-        unknown
-      >;
+      const txn = db.bank_account_transaction_history.data[txnId];
+      assert(txn);
       expect(txn.account_id).toBe("acc_001");
       expect(txn.type).toBe("rebate_credit");
     });
@@ -347,7 +349,8 @@ describe("handlers-accounts", () => {
         credit_type: "rebate_credit",
       });
       expect(result).toBe("Error: Invalid credit amount. Must be a number.");
-      const account = db.accounts.data["acc_001"] as Record<string, unknown>;
+      const account = db.accounts.data["acc_001"];
+      assert(account);
       expect(account.current_holdings).toBe("1000.00");
     });
     it("should reject credit on non-checking account", () => {
@@ -384,7 +387,8 @@ describe("handlers-accounts", () => {
         credit_type: "interest_correction",
       });
       expect(result).toBe("Error: Invalid credit amount. Must be a number.");
-      const account = db.accounts.data["acc_002"] as Record<string, unknown>;
+      const account = db.accounts.data["acc_002"];
+      assert(account);
       expect(account.current_holdings).toBe("500.00");
     });
     it("should apply savings credit successfully", () => {
@@ -406,7 +410,8 @@ describe("handlers-accounts", () => {
       expect(result).toContain("Amount: $25.50");
       expect(result).toContain("Previous Balance: $500.00");
       expect(result).toContain("New Balance: $525.50");
-      const account = db.accounts.data["acc_002"] as Record<string, unknown>;
+      const account = db.accounts.data["acc_002"];
+      assert(account);
       expect(account.current_holdings).toBe("525.50");
     });
     it("should reject positive amount requirement", () => {
@@ -527,9 +532,9 @@ describe("handlers-accounts", () => {
     it("should close account with zero balance successfully", () => {
       const db = createTestDb();
       const state = makeBankingEnvState(db);
-      (
-        db.accounts.data["acc_001"] as Record<string, unknown>
-      ).current_holdings = "0.00";
+      const openAccount = db.accounts.data["acc_001"];
+      assert(openAccount);
+      openAccount.current_holdings = "0.00";
       const handler = DISCOVERABLE_AGENT_TOOLS.get(
         "close_bank_account_7392"
       )?.handler;
@@ -544,14 +549,16 @@ describe("handlers-accounts", () => {
       expect(result).toContain("Bank account closed successfully!");
       expect(result).toContain("Status: CLOSED");
       expect(result).toContain("Early Closure Fee Waived: Yes");
-      const account = db.accounts.data["acc_001"] as Record<string, unknown>;
+      const account = db.accounts.data["acc_001"];
+      assert(account);
       expect(account.status).toBe("CLOSED");
     });
     it("should reject closing already-closed account", () => {
       const db = createTestDb();
       const state = makeBankingEnvState(db);
-      (db.accounts.data["acc_001"] as Record<string, unknown>).status =
-        "CLOSED";
+      const closedAccount = db.accounts.data["acc_001"];
+      assert(closedAccount);
+      closedAccount.status = "CLOSED";
       const handler = DISCOVERABLE_AGENT_TOOLS.get(
         "close_bank_account_7392"
       )?.handler;

--- a/src/benchmarks/tau3-bench-banking/tools/handlers-credit.test.ts
+++ b/src/benchmarks/tau3-bench-banking/tools/handlers-credit.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from "bun:test";
+import assert from "node:assert";
 
 import { makeEmptyBankingData } from "../environment";
 import type { BankingData } from "../types";
@@ -89,9 +90,8 @@ describe("handlers-credit", () => {
       expect(result).toContain("Expected Delivery: 7-10 business days");
       const ordersCount = Object.keys(state.db.credit_card_orders.data).length;
       expect(ordersCount).toBe(1);
-      const order = Object.values(
-        state.db.credit_card_orders.data
-      )[0] as Record<string, unknown>;
+      const order = Object.values(state.db.credit_card_orders.data)[0];
+      assert(order);
       expect(order.status).toBe("ORDERED");
       expect(order.reason).toBe("lost");
     });
@@ -108,10 +108,8 @@ describe("handlers-credit", () => {
         shipping_address: "123 Main St",
         reason: "stolen",
       });
-      const ccAccount = state.db.credit_card_accounts.data.cc_001 as Record<
-        string,
-        unknown
-      >;
+      const ccAccount = state.db.credit_card_accounts.data.cc_001;
+      assert(ccAccount);
       expect(ccAccount.status).toBe("CLOSED");
       expect(ccAccount.closed_date).toBe("11/14/2025");
     });
@@ -231,7 +229,8 @@ describe("handlers-credit", () => {
       expect(reasonsCount).toBe(1);
       const reason = Object.values(
         state.db.credit_card_closure_reasons.data
-      )[0] as Record<string, unknown>;
+      )[0];
+      assert(reason);
       expect(reason.closure_reason).toBe("annual_fee");
       expect(reason.status).toBe("LOGGED");
     });
@@ -264,10 +263,8 @@ describe("handlers-credit", () => {
       });
       expect(result).toContain("Credit card account closed successfully");
       expect(result).toContain("cc_001");
-      const ccAccount = state.db.credit_card_accounts.data.cc_001 as Record<
-        string,
-        unknown
-      >;
+      const ccAccount = state.db.credit_card_accounts.data.cc_001;
+      assert(ccAccount);
       expect(ccAccount.status).toBe("CLOSED");
       expect(ccAccount.closed_date).toBe("11/14/2025");
       expect(ccAccount.closed_by).toBe("user_123");
@@ -306,15 +303,11 @@ describe("handlers-credit", () => {
       expect(result).toContain("$500.00");
       expect(result).toContain("$4500.00");
       expect(result).toContain("$1000.00");
-      const checkingAccount = state.db.accounts.data.checking_001 as Record<
-        string,
-        unknown
-      >;
+      const checkingAccount = state.db.accounts.data.checking_001;
+      assert(checkingAccount);
       expect(checkingAccount.current_holdings).toBe("4500.00");
-      const ccAccount = state.db.credit_card_accounts.data.cc_001 as Record<
-        string,
-        unknown
-      >;
+      const ccAccount = state.db.credit_card_accounts.data.cc_001;
+      assert(ccAccount);
       expect(ccAccount.current_balance).toBe("$1000.00");
     });
     it("should reject a non-numeric amount", () => {
@@ -407,7 +400,8 @@ describe("handlers-credit", () => {
       expect(requestsCount).toBe(1);
       const request = Object.values(
         state.db.credit_limit_increase_requests.data
-      )[0] as Record<string, unknown>;
+      )[0];
+      assert(request);
       expect(request.status).toBe("PENDING");
       expect(request.requested_increase_amount).toBe(2500);
     });
@@ -543,10 +537,8 @@ describe("handlers-credit", () => {
       });
       expect(result).toContain("Credit limit increase approved!");
       expect(result).toContain("$8000.00");
-      const ccAccount = state.db.credit_card_accounts.data.cc_001 as Record<
-        string,
-        unknown
-      >;
+      const ccAccount = state.db.credit_card_accounts.data.cc_001;
+      assert(ccAccount);
       expect(ccAccount.credit_limit).toBe("$8000.00");
     });
     it("should reject if pending disputes exist", () => {
@@ -571,10 +563,8 @@ describe("handlers-credit", () => {
       );
     });
     it("should reject if account is CLOSED", () => {
-      const ccAccount = state.db.credit_card_accounts.data.cc_001 as Record<
-        string,
-        unknown
-      >;
+      const ccAccount = state.db.credit_card_accounts.data.cc_001;
+      assert(ccAccount);
       ccAccount.account_status = "CLOSED";
       const tool = DISCOVERABLE_AGENT_TOOLS.get(
         "approve_credit_limit_increase_5847"
@@ -613,7 +603,8 @@ describe("handlers-credit", () => {
       expect(requestsCount).toBe(1);
       const request = Object.values(
         state.db.credit_limit_increase_requests.data
-      )[0] as Record<string, unknown>;
+      )[0];
+      assert(request);
       expect(request.status).toBe("DENIED");
       expect(request.denial_reason).toBe("insufficient_account_age");
     });
@@ -653,7 +644,8 @@ describe("handlers-credit", () => {
       expect(historyCount).toBe(1);
       const credit = Object.values(
         state.db.credit_card_transaction_history.data
-      )[0] as Record<string, unknown>;
+      )[0];
+      assert(credit);
       expect(credit.credit_reason).toBe("goodwill_adjustment");
       expect(credit.status).toBe("COMPLETED");
     });
@@ -708,9 +700,8 @@ describe("handlers-credit", () => {
         state.db.credit_card_account_flags.data
       ).length;
       expect(flagsCount).toBe(1);
-      const flag = Object.values(
-        state.db.credit_card_account_flags.data
-      )[0] as Record<string, unknown>;
+      const flag = Object.values(state.db.credit_card_account_flags.data)[0];
+      assert(flag);
       expect(flag.flag_type).toBe("annual_fee_waived");
       expect(flag.reason).toBe("retention_offer");
       expect(flag.status).toBe("ACTIVE");

--- a/src/providers/openrouter-model.test.ts
+++ b/src/providers/openrouter-model.test.ts
@@ -120,10 +120,7 @@ describe("openrouter-model", () => {
     );
     assertSuccess(exit);
     expect(request?.url).toBe("https://example.test/api/v1/responses");
-    const body = JSON.parse(await request!.clone().text()) as Record<
-      string,
-      unknown
-    >;
+    const body: unknown = JSON.parse(await request!.clone().text());
     expect(body).toMatchObject({
       input: [
         { type: "message", role: "system", content: "rules" },

--- a/src/runtime/generation-resolver.test.ts
+++ b/src/runtime/generation-resolver.test.ts
@@ -34,11 +34,11 @@ function mockFetch(
   handler: (url: string) => Response
 ): () => readonly string[] {
   const calls: string[] = [];
-  globalThis.fetch = ((input: string | URL | Request) => {
+  globalThis.fetch = (input) => {
     const url = typeof input === "string" ? input : new Request(input).url;
     calls.push(url);
     return Promise.resolve(handler(url));
-  }) as typeof fetch;
+  };
   return () => calls;
 }
 
@@ -229,12 +229,12 @@ describe("makeOpenRouterGenerationResolver", () => {
   });
   it("sends filtered trace headers on the lookup without touching auth", async () => {
     let request: Request | undefined;
-    globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    globalThis.fetch = (input, init) => {
       request = input instanceof Request ? input : new Request(input, init);
       return Promise.resolve(
         jsonResponse({ data: { response_cache_source_id: "gen-original" } })
       );
-    }) as typeof fetch;
+    };
     const traceparent =
       "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
     const resolver = makeOpenRouterGenerationResolver({


### PR DESCRIPTION
## TL;DR

Removes all 27 single-type assertions (`expr as T`) from six test files by using real builders, typed indexed access with `assert(...)`, and contextual typing — no production changes.

## What changed?

- `tau3-bench-banking/tools/handlers-{accounts,credit}.test.ts` — 24× `as Record<string, unknown>`. `BankingTable.data` is already `Record<string, Record<string, unknown>>`; the casts only hid `noUncheckedIndexedAccess`. Replaced with `const row = db.x.data['id']; assert(row);` so a missing row fails at the lookup instead of at a downstream `toBe` on `undefined`.
- `tau3-bench-banking/dataset.test.ts` — `Partial<BankingData> as BankingData` → `{ ...makeEmptyBankingData(), users: … }` (real builder from `environment.ts`).
- `tau3-bench-banking/environment.test.ts` — `(data as Record<string, unknown>).test_key = 'test_value'` → `data.test_key = { value: 'test_value' }` (row-shaped value; the hash-change assertion is unchanged).
- `runtime/generation-resolver.test.ts` — 2× `as typeof fetch` → contextually typed `globalThis.fetch = (input, init) => …` (same pattern as `mmlu-pro-dataset.test.ts`).
- `providers/openrouter-model.test.ts` — `JSON.parse(...) as Record<…>` → `const body: unknown`; existing `toMatchObject` assertions validate the shape.

## Why?

Casts in fixtures hide drift between what a test builds and what the code under test consumes. This is the bench-harness half of the openrouter-web sweep ([openrouter-web#39474](https://github.com/OpenRouterTeam/openrouter-web/pull/39474)), which could not carry these edits because `packages/bench-harness` is a vendored subtree whose integrity check rejects in-repo changes. Once merged, run `scripts/subtree-pull-bench-harness.sh` in openrouter-web to vendor it.

## How to test

- In `handlers-accounts.test.ts`, change `'acc_001'` to `'acc_999'` in any `db.accounts.data[...]` lookup — the test now fails at `assert(...)` with a clear message rather than at a later `expect` on `undefined`.
- `bun test src/benchmarks/tau3-bench-banking src/providers/openrouter-model.test.ts src/runtime/generation-resolver.test.ts` → 399 pass, 0 fail, 785 expect() calls (unchanged count: no assertions were weakened or removed).

## Reviewer focus

- `handlers-credit.test.ts`: confirm each replaced `as Record` block still asserts the same field/value pairs.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [ ] Benchmark changes document dataset provenance and licensing (n/a — tests only)
- [x] No credentials, private results, or restricted dataset contents are included
- [ ] Documentation is updated where needed (n/a)


Link to Devin session: https://openrouter.devinenterprise.com/sessions/9ad818319cfe4db38aa9a914c2b6ac29
Open in Devin Desktop: https://openrouter.devinenterprise.com/desktop/session/9ad818319cfe4db38aa9a914c2b6ac29?variant=devin
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->