### PR TITLE
feat(vgi-bench): add videoProcessing option to request Gemini media processing

### DIFF
--- a/src/benchmarks/benchmark-config.ts
+++ b/src/benchmarks/benchmark-config.ts
@@ -2,6 +2,7 @@ import {
   COST_TIERS,
   IMAGE_DETAIL_VALUES,
   REASONING_EFFORTS,
+  VIDEO_PROCESSING_MODES,
 } from "../harness/constants";
 import { ProviderSort } from "../internal/enums";
 import type { ValueOf } from "../internal/guards";
@@ -302,6 +303,7 @@ export type WideSearchBenchmarkConfig = z.infer<
 
 export const VgiBenchOptionsSchema = z.object({
   downscaledVideos: z.boolean().default(false),
+  videoProcessing: z.enum(VIDEO_PROCESSING_MODES).optional(),
   datasetRevision: z.string().optional(),
 });
 

--- a/src/benchmarks/vgi-bench/README.md
+++ b/src/benchmarks/vgi-bench/README.md
@@ -24,6 +24,7 @@ Adapts the official public-split protocol (`vgibench/prompts.py`, `vgibench/run.
 | --- | --- | --- | --- |
 | `downscaledVideos` | boolean | `false` | Substitute `<name>_proxy_v2.mp4` re-encodes (≤ ~50 MB, 256 frames / 1280 px) where they exist. Only affects URLs when the media manifest is not in effect (i.e. `datasetRevision` differs from the manifest revision), in which case `downscaled_videos: true` is recorded in sample metadata. Under the manifest the mirror's files are used as-is and the inert request is recorded as `downscaled_videos_requested: true` instead. |
 | `datasetRevision` | string | `v1.0.1` | Override the pinned HF dataset tag. |
+| `videoProcessing` | `"agentic"` \| `"static"` | unset | Sets `video_url.processing` on every sample's video part and records it as `video_processing` in sample metadata. Only Gemini models that support media processing (currently `google/gemini-3.7-flash` and newer) act on it; the OpenRouter API drops the field for other models, so a run with it set is only comparable to other runs with the same value on a supporting model. |
 
 ## Video ingestion caveat
 

--- a/src/benchmarks/vgi-bench/benchmark.test.ts
+++ b/src/benchmarks/vgi-bench/benchmark.test.ts
@@ -110,6 +110,30 @@ describe("vgiBenchRecordToSample", () => {
     expect(sample.metadata?.["downscaled_videos"]).toBe(true);
   });
 
+  it("requests agentic video processing on the video part when configured", () => {
+    const sample = vgiBenchRecordToSample(VGI_RECORD, 0, {
+      mediaManifest: TEST_MANIFEST,
+      videoProcessing: "agentic",
+    });
+    expect(sample.contentParts![0]).toEqual({
+      type: "video_url",
+      videoUrl: {
+        url: "https://mirror.example.com/clip_007.mp4",
+        processing: "agentic",
+      },
+    });
+    expect(sample.metadata?.["video_processing"]).toBe("agentic");
+  });
+
+  it("omits processing from the video part and metadata when not configured", () => {
+    const sample = vgiBenchRecordToSample(VGI_RECORD, 0);
+    expect(sample.contentParts![0]).toEqual({
+      type: "video_url",
+      videoUrl: { url: "https://cdn.seldon.global/videos/clip_007.mp4" },
+    });
+    expect(sample.metadata).not.toHaveProperty("video_processing");
+  });
+
   it("resolves the video through the media manifest when provided", () => {
     const sample = vgiBenchRecordToSample(VGI_RECORD, 0, {
       downscaledVideos: true,
@@ -242,6 +266,27 @@ describe("VGI-Bench registry", () => {
     assertRight(result);
     expect(result.right.downscaledVideos).toBe(true);
     expect(result.right.datasetRevision).toBe("v1.0.0");
+  });
+
+  it("parses vgi_bench config with a videoProcessing mode", () => {
+    const result = parseSchema(BenchmarkRunConfigSchema, {
+      benchmarkId: "vgi_bench",
+      model: "google/gemini-3.8-flash",
+      reasoningEffort: "high",
+      videoProcessing: "agentic",
+    });
+    assertRight(result);
+    expect(result.right.videoProcessing).toBe("agentic");
+  });
+
+  it("rejects an unknown videoProcessing mode", () => {
+    const result = parseSchema(BenchmarkRunConfigSchema, {
+      benchmarkId: "vgi_bench",
+      model: "google/gemini-3.8-flash",
+      reasoningEffort: "high",
+      videoProcessing: "fast",
+    });
+    assertLeft(result);
   });
 
   it("dispatches runBenchmarkById through the registry entry (network blocked)", async () => {

--- a/src/benchmarks/vgi-bench/benchmark.ts
+++ b/src/benchmarks/vgi-bench/benchmark.ts
@@ -2,6 +2,7 @@ import type { Layer } from "effect/Layer";
 
 import type { HfDatasetConfig } from "../../datasets/huggingface";
 import { makeHfDatasetLayer } from "../../datasets/huggingface";
+import type { VideoProcessingMode } from "../../harness/constants";
 import type { ContentPart, Sample } from "../../harness/core";
 import type { Dataset as DatasetTag } from "../../harness/dataset";
 import type { SampleScore } from "../../harness/metric";
@@ -98,6 +99,7 @@ export function downscaledVideoUrl(url: string): string {
 export interface VgiBenchRecordToSampleOptions {
   readonly downscaledVideos?: boolean;
   readonly mediaManifest?: VgiBenchMediaManifest;
+  readonly videoProcessing?: VideoProcessingMode;
 }
 
 export function vgiBenchRecordToSample(
@@ -131,7 +133,15 @@ export function vgiBenchRecordToSample(
   }
   const prompt = buildVgiBenchPrompt(question, answers);
   const contentParts: ContentPart[] = [
-    { type: "video_url", videoUrl: { url: videoUrl } },
+    {
+      type: "video_url",
+      videoUrl: {
+        url: videoUrl,
+        ...(opts?.videoProcessing !== undefined && {
+          processing: opts.videoProcessing,
+        }),
+      },
+    },
     { type: "text", text: prompt },
   ];
   const family = questionType.includes("/")
@@ -149,6 +159,9 @@ export function vgiBenchRecordToSample(
       family,
       ...(manifest !== undefined && {
         media_manifest_hash: manifest.manifestHash,
+      }),
+      ...(opts?.videoProcessing !== undefined && {
+        video_processing: opts.videoProcessing,
       }),
       ...(manifest === undefined &&
         opts?.downscaledVideos === true && {
@@ -184,6 +197,9 @@ function makeVgiBenchDatasetLayer(
         ...(mediaManifest !== undefined && { mediaManifest }),
         ...(opts?.downscaledVideos !== undefined && {
           downscaledVideos: opts.downscaledVideos,
+        }),
+        ...(opts?.videoProcessing !== undefined && {
+          videoProcessing: opts.videoProcessing,
         }),
       }),
     revision,
@@ -290,6 +306,9 @@ const VGI_BENCH_SINGLE_TURN_BENCHMARK = defineSingleTurnBenchmark({
   makeDatasetLayerForConfig: (config, retryConfig) =>
     makeVgiBenchDatasetLayer({
       downscaledVideos: config.downscaledVideos,
+      ...(config.videoProcessing !== undefined && {
+        videoProcessing: config.videoProcessing,
+      }),
       ...(config.datasetRevision !== undefined
         ? { revision: config.datasetRevision }
         : { revision: VGI_BENCH_DEFAULT_REVISION }),

--- a/src/benchmarks/vgi-bench/benchmark.ts
+++ b/src/benchmarks/vgi-bench/benchmark.ts
@@ -197,7 +197,9 @@ function makeVgiBenchDatasetLayer(
         })
       ),
     revision,
-    ...(opts?.retry !== undefined && { retry: opts.retry }),
+    ...definedValues({
+      retry: opts?.retry,
+    }),
   };
   return makeHfDatasetLayer(config);
 }
@@ -212,7 +214,9 @@ function vgiBenchSolver(
   const config: GenerateConfig = {
     temperature: VGI_BENCH_TEMPERATURE,
     ...definedValues(opts.inference),
-    ...(opts.endpointId !== undefined && { endpointId: opts.endpointId }),
+    ...definedValues({
+      endpointId: opts.endpointId,
+    }),
   };
   return generate(model, config);
 }
@@ -308,21 +312,24 @@ const VGI_BENCH_SINGLE_TURN_BENCHMARK = defineSingleTurnBenchmark({
     ),
   scorer: mcqScorer,
   makeSolver: (model, config) =>
-    vgiBenchSolver(model, {
-      ...(config.endpointId !== undefined && { endpointId: config.endpointId }),
-      inference: {
-        maxTokens: config.maxTokens,
-        reasoningEffort: config.reasoningEffort,
-        timeoutMs: config.timeoutMs,
-        sort: config.sort,
-        providerOnly: config.providerOnly,
-        providerIgnore: config.providerIgnore,
-        allowFallbacks: config.allowFallbacks,
-        cloudflareVersion: config.cloudflareVersion,
-        costTier: config.costTier,
-        costQualityTradeoff: config.costQualityTradeoff,
-      },
-    }),
+    vgiBenchSolver(
+      model,
+      definedValues({
+        endpointId: config.endpointId,
+        inference: {
+          maxTokens: config.maxTokens,
+          reasoningEffort: config.reasoningEffort,
+          timeoutMs: config.timeoutMs,
+          sort: config.sort,
+          providerOnly: config.providerOnly,
+          providerIgnore: config.providerIgnore,
+          allowFallbacks: config.allowFallbacks,
+          cloudflareVersion: config.cloudflareVersion,
+          costTier: config.costTier,
+          costQualityTradeoff: config.costQualityTradeoff,
+        },
+      })
+    ),
 });
 
 export const VGI_BENCH_BENCHMARK: Benchmark = {

--- a/src/benchmarks/vgi-bench/benchmark.ts
+++ b/src/benchmarks/vgi-bench/benchmark.ts
@@ -150,24 +150,22 @@ export function vgiBenchRecordToSample(
     input: prompt,
     target: { text: LETTERS[correctAnswer]! },
     contentParts,
-    metadata: {
+    metadata: definedValues({
       question_id: questionId,
       video_id: videoId,
       question_type: questionType,
       family,
-      ...(manifest !== undefined && {
-        media_manifest_hash: manifest.manifestHash,
-      }),
-      ...definedValues({ video_processing: opts?.videoProcessing }),
-      ...(manifest === undefined &&
-        opts?.downscaledVideos === true && {
-          downscaled_videos: true,
-        }),
-      ...(manifest !== undefined &&
-        opts?.downscaledVideos === true && {
-          downscaled_videos_requested: true,
-        }),
-    },
+      media_manifest_hash: manifest?.manifestHash,
+      video_processing: opts?.videoProcessing,
+      downscaled_videos:
+        manifest === undefined && opts?.downscaledVideos === true
+          ? true
+          : undefined,
+      downscaled_videos_requested:
+        manifest !== undefined && opts?.downscaledVideos === true
+          ? true
+          : undefined,
+    }),
   };
 }
 
@@ -189,13 +187,15 @@ function makeVgiBenchDatasetLayer(
     config: VGI_BENCH_CONFIG,
     split: VGI_BENCH_SPLIT,
     recordToSample: (record, idx) =>
-      vgiBenchRecordToSample(record, idx, {
-        ...(mediaManifest !== undefined && { mediaManifest }),
-        ...definedValues({
+      vgiBenchRecordToSample(
+        record,
+        idx,
+        definedValues({
+          mediaManifest,
           downscaledVideos: opts?.downscaledVideos,
           videoProcessing: opts?.videoProcessing,
-        }),
-      }),
+        })
+      ),
     revision,
     ...(opts?.retry !== undefined && { retry: opts.retry }),
   };
@@ -298,14 +298,14 @@ const VGI_BENCH_SINGLE_TURN_BENCHMARK = defineSingleTurnBenchmark({
         : { revision: VGI_BENCH_DEFAULT_REVISION }
     ),
   makeDatasetLayerForConfig: (config, retryConfig) =>
-    makeVgiBenchDatasetLayer({
-      downscaledVideos: config.downscaledVideos,
-      ...definedValues({ videoProcessing: config.videoProcessing }),
-      ...(config.datasetRevision !== undefined
-        ? { revision: config.datasetRevision }
-        : { revision: VGI_BENCH_DEFAULT_REVISION }),
-      ...(retryConfig !== undefined && { retry: retryConfig }),
-    }),
+    makeVgiBenchDatasetLayer(
+      definedValues({
+        downscaledVideos: config.downscaledVideos,
+        videoProcessing: config.videoProcessing,
+        revision: config.datasetRevision ?? VGI_BENCH_DEFAULT_REVISION,
+        retry: retryConfig,
+      })
+    ),
   scorer: mcqScorer,
   makeSolver: (model, config) =>
     vgiBenchSolver(model, {

--- a/src/benchmarks/vgi-bench/benchmark.ts
+++ b/src/benchmarks/vgi-bench/benchmark.ts
@@ -135,12 +135,10 @@ export function vgiBenchRecordToSample(
   const contentParts: ContentPart[] = [
     {
       type: "video_url",
-      videoUrl: {
+      videoUrl: definedValues({
         url: videoUrl,
-        ...(opts?.videoProcessing !== undefined && {
-          processing: opts.videoProcessing,
-        }),
-      },
+        processing: opts?.videoProcessing,
+      }),
     },
     { type: "text", text: prompt },
   ];
@@ -160,9 +158,7 @@ export function vgiBenchRecordToSample(
       ...(manifest !== undefined && {
         media_manifest_hash: manifest.manifestHash,
       }),
-      ...(opts?.videoProcessing !== undefined && {
-        video_processing: opts.videoProcessing,
-      }),
+      ...definedValues({ video_processing: opts?.videoProcessing }),
       ...(manifest === undefined &&
         opts?.downscaledVideos === true && {
           downscaled_videos: true,
@@ -195,11 +191,9 @@ function makeVgiBenchDatasetLayer(
     recordToSample: (record, idx) =>
       vgiBenchRecordToSample(record, idx, {
         ...(mediaManifest !== undefined && { mediaManifest }),
-        ...(opts?.downscaledVideos !== undefined && {
-          downscaledVideos: opts.downscaledVideos,
-        }),
-        ...(opts?.videoProcessing !== undefined && {
-          videoProcessing: opts.videoProcessing,
+        ...definedValues({
+          downscaledVideos: opts?.downscaledVideos,
+          videoProcessing: opts?.videoProcessing,
         }),
       }),
     revision,
@@ -306,9 +300,7 @@ const VGI_BENCH_SINGLE_TURN_BENCHMARK = defineSingleTurnBenchmark({
   makeDatasetLayerForConfig: (config, retryConfig) =>
     makeVgiBenchDatasetLayer({
       downscaledVideos: config.downscaledVideos,
-      ...(config.videoProcessing !== undefined && {
-        videoProcessing: config.videoProcessing,
-      }),
+      ...definedValues({ videoProcessing: config.videoProcessing }),
       ...(config.datasetRevision !== undefined
         ? { revision: config.datasetRevision }
         : { revision: VGI_BENCH_DEFAULT_REVISION }),

--- a/src/harness/constants.ts
+++ b/src/harness/constants.ts
@@ -30,3 +30,15 @@ export const IMAGE_DETAIL_VALUES = [
 ] as const;
 
 export type ImageDetail = ValueOf<typeof IMAGE_DETAIL_VALUES>;
+
+export const VideoProcessingMode = {
+  Agentic: "agentic",
+  Static: "static",
+} as const;
+
+export const VIDEO_PROCESSING_MODES = [
+  VideoProcessingMode.Agentic,
+  VideoProcessingMode.Static,
+] as const;
+
+export type VideoProcessingMode = ValueOf<typeof VIDEO_PROCESSING_MODES>;

--- a/src/harness/core.ts
+++ b/src/harness/core.ts
@@ -5,8 +5,8 @@ import { TaggedError } from "effect/Data";
 import type { ValueOf } from "../internal/guards";
 import { z } from "../internal/zod";
 import type { ModelErrorIdentifiers } from "../providers/request-identifiers";
-import type { ImageDetail } from "./constants";
-import { IMAGE_DETAIL_VALUES } from "./constants";
+import type { ImageDetail, VideoProcessingMode } from "./constants";
+import { IMAGE_DETAIL_VALUES, VIDEO_PROCESSING_MODES } from "./constants";
 import { ReasoningDetailsSchema } from "./reasoning-details";
 
 export const MessageRole = {
@@ -59,6 +59,7 @@ export const VideoContentPartSchema = z.object({
   type: z.literal("video_url"),
   videoUrl: z.object({
     url: z.string(),
+    processing: z.enum(VIDEO_PROCESSING_MODES).optional(),
   }),
 });
 
@@ -110,6 +111,7 @@ export interface VideoContentPart {
   readonly type: "video_url";
   readonly videoUrl: {
     readonly url: string;
+    readonly processing?: VideoProcessingMode;
   };
 }
 

--- a/src/providers/messages-to-responses.test.ts
+++ b/src/providers/messages-to-responses.test.ts
@@ -32,6 +32,10 @@ describe("messages-to-responses", () => {
             { type: "image_url", imageUrl: { url: "a.png" } },
             { type: "image_url", imageUrl: { url: "b.png", detail: "high" } },
             { type: "video_url", videoUrl: { url: "v.mp4" } },
+            {
+              type: "video_url",
+              videoUrl: { url: "w.mp4", processing: "agentic" },
+            },
           ],
         },
       ])
@@ -44,6 +48,7 @@ describe("messages-to-responses", () => {
           { type: "input_image", image_url: "a.png", detail: "auto" },
           { type: "input_image", image_url: "b.png", detail: "high" },
           { type: "input_video", video_url: "v.mp4" },
+          { type: "input_video", video_url: "w.mp4", processing: "agentic" },
         ],
       },
     ]);

--- a/src/providers/messages-to-responses.ts
+++ b/src/providers/messages-to-responses.ts
@@ -5,6 +5,7 @@ import type {
   ToolDefinition,
 } from "../harness/core";
 import { MessageRole } from "../harness/core";
+import { definedValues } from "../internal/guards";
 import type {
   ResponsesFunctionTool,
   ResponsesInputItem,
@@ -83,13 +84,11 @@ function contentPartToResponses(part: ContentPart): ResponsesInputItem {
       };
     }
     case "video_url": {
-      return {
+      return definedValues({
         type: "input_video",
         video_url: part.videoUrl.url,
-        ...(part.videoUrl.processing !== undefined && {
-          processing: part.videoUrl.processing,
-        }),
-      };
+        processing: part.videoUrl.processing,
+      });
     }
     default: {
       return part satisfies never;

--- a/src/providers/messages-to-responses.ts
+++ b/src/providers/messages-to-responses.ts
@@ -83,7 +83,13 @@ function contentPartToResponses(part: ContentPart): ResponsesInputItem {
       };
     }
     case "video_url": {
-      return { type: "input_video", video_url: part.videoUrl.url };
+      return {
+        type: "input_video",
+        video_url: part.videoUrl.url,
+        ...(part.videoUrl.processing !== undefined && {
+          processing: part.videoUrl.processing,
+        }),
+      };
     }
     default: {
       return part satisfies never;

--- a/src/providers/responses-wire.test.ts
+++ b/src/providers/responses-wire.test.ts
@@ -60,6 +60,21 @@ describe("Responses wire contract", () => {
     ]);
   });
 
+  it("validates video content with a processing mode", () => {
+    expectValidResponsesRequest([
+      {
+        role: MessageRole.User,
+        content: "",
+        contentParts: [
+          {
+            type: "video_url",
+            videoUrl: { url: "video.mp4", processing: "agentic" },
+          },
+        ],
+      },
+    ]);
+  });
+
   it("validates an assistant function call and its output", () => {
     expectValidResponsesRequest(
       [

--- a/src/results/parquet.test.ts
+++ b/src/results/parquet.test.ts
@@ -465,6 +465,17 @@ describe("runResultToParquet", () => {
             type: "image_url",
             imageUrl: { url: "https://example.com/img.png", detail: "high" },
           },
+          {
+            type: "video_url",
+            videoUrl: { url: "https://example.com/clip.mp4" },
+          },
+          {
+            type: "video_url",
+            videoUrl: {
+              url: "https://example.com/clip2.mp4",
+              processing: "agentic",
+            },
+          },
         ],
       },
     ];
@@ -494,6 +505,14 @@ describe("runResultToParquet", () => {
       {
         type: "image_url",
         image_url: { url: "https://example.com/img.png", detail: "high" },
+      },
+      { type: "video_url", video_url: { url: "https://example.com/clip.mp4" } },
+      {
+        type: "video_url",
+        video_url: {
+          url: "https://example.com/clip2.mp4",
+          processing: "agentic",
+        },
       },
     ]);
   });

--- a/src/results/parquet.ts
+++ b/src/results/parquet.ts
@@ -327,7 +327,12 @@ function contentPartToPojo(part: ContentPart): Record<string, unknown> {
     case "video_url": {
       return {
         type: "video_url",
-        video_url: { url: part.videoUrl.url },
+        video_url: {
+          url: part.videoUrl.url,
+          ...(part.videoUrl.processing !== undefined && {
+            processing: part.videoUrl.processing,
+          }),
+        },
       };
     }
     default: {

--- a/src/results/parquet.ts
+++ b/src/results/parquet.ts
@@ -16,6 +16,7 @@ import type { AggregateMetrics, SampleScore } from "../harness/metric";
 import { aggregateScores } from "../harness/metric";
 import type { RunResult } from "../harness/run";
 import { Either } from "../internal/either";
+import { definedValues } from "../internal/guards";
 import { firstZodIssueMessage, parseSchema, z } from "../internal/zod";
 import type { BenchmarkResultRow } from "./parquet-schema";
 import {
@@ -327,12 +328,10 @@ function contentPartToPojo(part: ContentPart): Record<string, unknown> {
     case "video_url": {
       return {
         type: "video_url",
-        video_url: {
+        video_url: definedValues({
           url: part.videoUrl.url,
-          ...(part.videoUrl.processing !== undefined && {
-            processing: part.videoUrl.processing,
-          }),
-        },
+          processing: part.videoUrl.processing,
+        }),
       };
     }
     default: {


### PR DESCRIPTION
## TL;DR

`vgi_bench` gains an optional `videoProcessing: "agentic" | "static"` config that sets `video_url.processing` on every sample's video part and is forwarded as `input_video.processing` to OpenRouter.

## What changed?

- `VideoContentPart` / `VideoContentPartSchema` accept an optional `processing: VideoProcessingMode` (`VIDEO_PROCESSING_MODES` added to `harness/constants.ts`).
- `messagesToResponses` forwards it: `{ type: "input_video", video_url, processing? }`. The SDK `ResponsesRequest` outbound schema already accepts the field (covered by `responses-wire.test.ts`).
- Parquet `content_parts` serialization preserves `processing`.
- `VgiBenchOptionsSchema.videoProcessing` (optional, no default) threads through `makeVgiBenchDatasetLayer` -> `vgiBenchRecordToSample`, which adds it to the video part and records `video_processing` in sample metadata.
- README config table documents the option.

## Why?

Gemini 3.7/3.8 Flash support agentic video processing via `video_url.processing`. We want to run VGIBench with it. The OpenRouter API side is responsible for dropping the field for models that do not support it (see OpenRouterTeam/openrouter-web PR on Gemini `mediaProcessing` gating).

## How to test

```sh
OPENROUTER_API_KEY=... bun run bench -- --benchmark vgi_bench --model google/gemini-3.8-flash --limit 1
```
Config-driven runs: pass `videoProcessing: "agentic"` in the `vgi_bench` run config. Expect the request body to contain `{"type":"input_video","video_url":"https://vgi-bench-mirror.openrouter.ai/<id>.mp4","processing":"agentic"}` and sample metadata to contain `"video_processing":"agentic"`. Without the option the request and metadata are byte-identical to before.

## Benchmark impact

No change unless `videoProcessing` is set. When set, Gemini models that support media processing will answer with agentic video understanding, so those runs are only comparable with runs using the same value. Metadata records the mode per sample so runs can be told apart.

## Reviewer focus

- Option is unset by default (backward compatible).
- `processing` is omitted (not `undefined`) from the part, the Responses item, and the parquet POJO when not set.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [x] Benchmark changes document dataset provenance and licensing (unchanged dataset)
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/a5eda261847148dfa1418e8df089c88c
Open in Devin Desktop: https://openrouter.devinenterprise.com/desktop/session/a5eda261847148dfa1418e8df089c88c?variant=devin
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->