### PR TITLE
fix(providers): bump @openrouter/sdk so input_video.processing reaches the wire

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@effect/platform": "0.95.0",
         "@google-cloud/storage": "7.19.0",
-        "@openrouter/sdk": "1.2.14",
+        "@openrouter/sdk": "1.2.94",
         "change-case": "5.4.4",
         "chrono-node": "2.9.0",
         "cli-progress": "3.12.0",
@@ -96,7 +96,7 @@
 
     "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
 
-    "@openrouter/sdk": ["@openrouter/sdk@1.2.14", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-eL8PH3vBbqTaCNpYLHF7sfuyDYYBH0lqKVz7wQWx/sHYGlfkOdIIgLwoxSPZiNNE15kfef9BX3WXCjyvHydq4Q=="],
+    "@openrouter/sdk": ["@openrouter/sdk@1.2.94", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Mb6io95GOaXt1g97wpswUr+BSywIx0t2kG1je2X4+noAxrzR4Pb6PVv8nQ8Hppv/H2enzZ0W6TgEETW/NRCJfA=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.62.0", "", { "os": "android", "cpu": "arm" }, "sha512-pdsv0C4gPjJ8H1+sd8u0BDx+yLACTL+rgeMIOL1ln4ihSnhw8CWXtYWgvcSkyTfgGBIzFKab+d8rx9Xl4en/Kw=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@effect/platform": "0.95.0",
     "@google-cloud/storage": "7.19.0",
-    "@openrouter/sdk": "1.2.14",
+    "@openrouter/sdk": "1.2.94",
     "change-case": "5.4.4",
     "chrono-node": "2.9.0",
     "cli-progress": "3.12.0",

--- a/src/providers/responses-client.test.ts
+++ b/src/providers/responses-client.test.ts
@@ -433,6 +433,74 @@ describe("makeResponsesLayer", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it.each(["agentic", "static"] as const)(
+    "serializes input_video.processing=%s onto the wire",
+    async (processing) => {
+      const originalFetch = globalThis.fetch;
+      const stream = await readStreamFixture();
+      const capturedBodies: unknown[] = [];
+      globalThis.fetch = async (input, init) => {
+        const request =
+          input instanceof Request ? input : new Request(input, init);
+        capturedBodies.push(await request.clone().json());
+        return new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      };
+      try {
+        await runPromise(
+          gen(function* run() {
+            const responses = yield* Responses;
+            yield* responses.send(
+              {
+                model: "m",
+                input: [
+                  {
+                    type: "message",
+                    role: "user",
+                    content: [
+                      {
+                        type: "input_video",
+                        videoUrl: "https://example.test/clip.mp4",
+                        processing,
+                      },
+                    ],
+                  },
+                ],
+              },
+              { timeoutMs: 1000 }
+            );
+          }).pipe(
+            provide(
+              makeResponsesLayer({
+                apiKey: "sk-test",
+                baseUrl: "https://example.test",
+              })
+            )
+          )
+        );
+        expect(capturedBodies[0]).toMatchObject({
+          input: [
+            {
+              type: "message",
+              role: "user",
+              content: [
+                {
+                  type: "input_video",
+                  video_url: "https://example.test/clip.mp4",
+                  processing,
+                },
+              ],
+            },
+          ],
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    }
+  );
   it("records the cache source id from the response header on cache hits", async () => {
     const originalFetch = globalThis.fetch;
     const stream = await readStreamFixture();


### PR DESCRIPTION
## TL;DR

`@openrouter/sdk` 1.2.14 → 1.2.94 so the `processing` field added in #68 is actually serialized onto the Responses request instead of being stripped by the SDK's outbound Zod schema.

## What changed?

- `package.json` / `bun.lock`: `@openrouter/sdk` `1.2.14` → `1.2.94` (first release whose `InputVideo$outboundSchema` includes `processing`).
- `responses-client.test.ts`: request-level test that captures the actual `fetch` body through `makeResponsesLayer` and asserts `input[0].content[0].processing` is `agentic` / `static`.

## Why?

#68 threaded `videoUrl.processing` through `messages-to-responses` and the Parquet writer, but `client.send()` runs the request through the SDK's `ResponsesRequest$outboundSchema`. On 1.2.14 `InputVideo$outboundSchema` is `z.object({ type, videoUrl })` — Zod strips unknown keys, so agentic and static runs sent identical requests. Flagged by Devin Review on OpenRouterTeam/openrouter-web#39712.

## How to test

The new test fails on 1.2.14 and passes on 1.2.94:

```
bun test src/providers/responses-client.test.ts -t processing
```

## Benchmark impact

No score change for existing configs. `vgi_bench` runs with `videoProcessing` set now actually request Gemini `mediaProcessing`; runs without it are unchanged.

## Reviewer focus

- The SDK jump is 80 patch releases; full suite (1406 tests), typecheck, lint, build all pass locally. `bun pm untrusted` shows the SDK's new `postinstall` (`node scripts/check-types.js || true`) is blocked by default — no `trustedDependencies` change made.

## Checklist

- [x] Tests cover changed behavior
- [x] Public API or configuration changes are backward compatible, or the break is documented
- [ ] Benchmark changes document dataset provenance and licensing
- [x] No credentials, private results, or restricted dataset contents are included
- [x] Documentation is updated where needed


Link to Devin session: https://openrouter.devinenterprise.com/sessions/a5eda261847148dfa1418e8df089c88c
Open in Devin Desktop: https://openrouter.devinenterprise.com/desktop/session/a5eda261847148dfa1418e8df089c88c?variant=devin
Requested by: @abhinav-pola
<!-- devin-review-badge-begin -->

---

<a href="https://openrouter.devinenterprise.com/review/openrouterteam/benchmark-harness/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->